### PR TITLE
Align Subscription APIs

### DIFF
--- a/src/EventStore.Client.PersistentSubscriptions/PersistentSubscription.cs
+++ b/src/EventStore.Client.PersistentSubscriptions/PersistentSubscription.cs
@@ -143,9 +143,8 @@ namespace EventStore.Client {
 					ConvertToEventRecord(response.Event.Event)!,
 					ConvertToEventRecord(response.Event.Link),
 					response.Event.PositionCase switch {
-						ReadResp.Types.ReadEvent.PositionOneofCase.CommitPosition => new Position(
-							response.Event.CommitPosition, 0).ToInt64().commitPosition,
-						ReadResp.Types.ReadEvent.PositionOneofCase.NoPosition => default(long?),
+						ReadResp.Types.ReadEvent.PositionOneofCase.CommitPosition => response.Event.CommitPosition,
+						ReadResp.Types.ReadEvent.PositionOneofCase.NoPosition => null,
 						_ => throw new InvalidOperationException()
 					});
 

--- a/src/EventStore.Client.PersistentSubscriptions/PersistentSubscription.cs
+++ b/src/EventStore.Client.PersistentSubscriptions/PersistentSubscription.cs
@@ -16,6 +16,7 @@ namespace EventStore.Client {
 		private readonly AsyncDuplexStreamingCall<ReadReq, ReadResp> _call;
 		private int _subscriptionDroppedInvoked;
 
+		public string SubscriptionId { get; }
 
 		internal static async Task<PersistentSubscription> Confirm(AsyncDuplexStreamingCall<ReadReq, ReadResp> call,
 			ReadReq.Types.Options options, bool autoAck,
@@ -44,6 +45,7 @@ namespace EventStore.Client {
 			_eventAppeared = eventAppeared;
 			_subscriptionDropped = subscriptionDropped;
 			_disposed = new CancellationTokenSource();
+			SubscriptionId = call.ResponseStream.Current.SubscriptionConfirmation.SubscriptionId;
 			Task.Run(Subscribe);
 		}
 

--- a/src/EventStore.Client.PersistentSubscriptions/PersistentSubscription.cs
+++ b/src/EventStore.Client.PersistentSubscriptions/PersistentSubscription.cs
@@ -9,36 +9,42 @@ using Grpc.Core;
 #nullable enable
 namespace EventStore.Client {
 	public class PersistentSubscription : IDisposable {
-		private readonly PersistentSubscriptions.PersistentSubscriptions.PersistentSubscriptionsClient _client;
-		private readonly UserCredentials? _userCredentials;
-		private readonly ReadReq.Types.Options _options;
 		private readonly bool _autoAck;
 		private readonly Func<PersistentSubscription, ResolvedEvent, int?, CancellationToken, Task> _eventAppeared;
 		private readonly Action<PersistentSubscription, SubscriptionDroppedReason, Exception?> _subscriptionDropped;
 		private readonly CancellationTokenSource _disposed;
-		private readonly TaskCompletionSource<bool> _started;
 		private readonly AsyncDuplexStreamingCall<ReadReq, ReadResp> _call;
 		private int _subscriptionDroppedInvoked;
 
-		public Task Started => _started.Task;
 
-		internal PersistentSubscription(
-			PersistentSubscriptions.PersistentSubscriptions.PersistentSubscriptionsClient client,
-			ReadReq.Types.Options options,
-			bool autoAck,
+		internal static async Task<PersistentSubscription> Confirm(AsyncDuplexStreamingCall<ReadReq, ReadResp> call,
+			ReadReq.Types.Options options, bool autoAck,
 			Func<PersistentSubscription, ResolvedEvent, int?, CancellationToken, Task> eventAppeared,
 			Action<PersistentSubscription, SubscriptionDroppedReason, Exception?> subscriptionDropped,
-			UserCredentials? userCredentials) {
-			_client = client;
-			_userCredentials = userCredentials;
-			_options = options;
+			CancellationToken cancellationToken = default) {
+			await call.RequestStream.WriteAsync(new ReadReq {
+				Options = options
+			}).ConfigureAwait(false);
+
+			if (!await call.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false) ||
+			    call.ResponseStream.Current.ContentCase != ReadResp.ContentOneofCase.SubscriptionConfirmation) {
+				throw new InvalidOperationException();
+			}
+
+			return new PersistentSubscription(call, autoAck, eventAppeared, subscriptionDropped);
+		}
+
+		private PersistentSubscription(
+			AsyncDuplexStreamingCall<ReadReq, ReadResp> call,
+			bool autoAck,
+			Func<PersistentSubscription, ResolvedEvent, int?, CancellationToken, Task> eventAppeared,
+			Action<PersistentSubscription, SubscriptionDroppedReason, Exception?> subscriptionDropped) {
+			_call = call;
 			_autoAck = autoAck;
 			_eventAppeared = eventAppeared;
 			_subscriptionDropped = subscriptionDropped;
 			_disposed = new CancellationTokenSource();
-			_started = new TaskCompletionSource<bool>();
-			_call = _client.Read(RequestMetadata.Create(_userCredentials), cancellationToken: _disposed.Token);
-			_ = Subscribe();
+			Task.Run(Subscribe);
 		}
 
 		public Task Ack(params Uuid[] eventIds) {
@@ -81,22 +87,6 @@ namespace EventStore.Client {
 		}
 
 		private async Task Subscribe() {
-			try {
-				await _call.RequestStream.WriteAsync(new ReadReq {
-					Options = _options
-				}).ConfigureAwait(false);
-
-				if (!await _call.ResponseStream.MoveNext(_disposed.Token).ConfigureAwait(false) ||
-				    _call.ResponseStream.Current.ContentCase != ReadResp.ContentOneofCase.SubscriptionConfirmation) {
-					throw new InvalidOperationException();
-				}
-			} catch (Exception ex) {
-				SubscriptionDropped(SubscriptionDroppedReason.ServerError, ex);
-				return;
-			} finally {
-				_started.SetResult(true);
-			}
-
 			try {
 				while (await _call!.ResponseStream.MoveNext().ConfigureAwait(false) &&
 				       !_disposed.IsCancellationRequested) {

--- a/src/EventStore.Client.Streams/EventStoreClient.Read.cs
+++ b/src/EventStore.Client.Streams/EventStoreClient.Read.cs
@@ -151,7 +151,7 @@ namespace EventStore.Client {
 				yield return e;
 			}
 
-			(SubscriptionConfirmation, Position?, ResolvedEvent) ConvertToItem(ReadResp response) => response.ContentCase switch {
+			static (SubscriptionConfirmation, Position?, ResolvedEvent) ConvertToItem(ReadResp response) => response.ContentCase switch {
 				ReadResp.ContentOneofCase.Confirmation => (
 					new SubscriptionConfirmation(response.Confirmation.SubscriptionId), null, default),
 				ReadResp.ContentOneofCase.Event => (SubscriptionConfirmation.None,
@@ -163,18 +163,17 @@ namespace EventStore.Client {
 				_ => throw new InvalidOperationException()
 			};
 
-			ResolvedEvent ConvertToResolvedEvent(ReadResp.Types.ReadEvent readEvent) =>
+			static ResolvedEvent ConvertToResolvedEvent(ReadResp.Types.ReadEvent readEvent) =>
 				new ResolvedEvent(
 					ConvertToEventRecord(readEvent.Event)!,
 					ConvertToEventRecord(readEvent.Link),
 					readEvent.PositionCase switch {
-						ReadResp.Types.ReadEvent.PositionOneofCase.CommitPosition => new Position(
-							readEvent.CommitPosition, 0).ToInt64().commitPosition,
+						ReadResp.Types.ReadEvent.PositionOneofCase.CommitPosition => readEvent.CommitPosition,
 						ReadResp.Types.ReadEvent.PositionOneofCase.NoPosition => null,
 						_ => throw new InvalidOperationException()
 					});
 
-			EventRecord? ConvertToEventRecord(ReadResp.Types.ReadEvent.Types.RecordedEvent e) =>
+			static EventRecord? ConvertToEventRecord(ReadResp.Types.ReadEvent.Types.RecordedEvent e) =>
 				e == null
 					? null
 					: new EventRecord(

--- a/src/EventStore.Client.Streams/StreamSubscription.cs
+++ b/src/EventStore.Client.Streams/StreamSubscription.cs
@@ -16,6 +16,7 @@ namespace EventStore.Client {
 		private readonly CancellationTokenSource _disposed;
 		private int _subscriptionDroppedInvoked;
 
+		public string SubscriptionId { get; }
 
 		internal static async Task<StreamSubscription> Confirm(
 			IAsyncEnumerable<(SubscriptionConfirmation confirmation, Position?, ResolvedEvent)> read,
@@ -48,6 +49,7 @@ namespace EventStore.Client {
 			_log = log;
 			_cancellationToken = cancellationToken;
 			_subscriptionDroppedInvoked = 0;
+			SubscriptionId = events.Current.confirmation.SubscriptionId;
 
 			Task.Run(Subscribe);
 		}

--- a/src/EventStore.Client.Streams/StreamSubscription.cs
+++ b/src/EventStore.Client.Streams/StreamSubscription.cs
@@ -17,7 +17,7 @@ namespace EventStore.Client {
 		private int _subscriptionDroppedInvoked;
 
 		internal static async Task<StreamSubscription> Confirm(
-			IAsyncEnumerable<(SubscriptionConfirmation, Position?, ResolvedEvent)> read,
+			IAsyncEnumerable<(SubscriptionConfirmation confirmation, Position?, ResolvedEvent)> read,
 			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
 			Action<StreamSubscription, SubscriptionDroppedReason, Exception?>? subscriptionDropped,
 			ILogger log,
@@ -25,7 +25,7 @@ namespace EventStore.Client {
 			CancellationToken cancellationToken = default) {
 			var enumerator = read.GetAsyncEnumerator(cancellationToken);
 			if (!await enumerator.MoveNextAsync(cancellationToken).ConfigureAwait(false) ||
-			    enumerator.Current.Item1 == SubscriptionConfirmation.None) {
+			    enumerator.Current.confirmation == SubscriptionConfirmation.None) {
 				throw new InvalidOperationException();
 			}
 

--- a/src/EventStore.Client.Streams/StreamSubscription.cs
+++ b/src/EventStore.Client.Streams/StreamSubscription.cs
@@ -16,6 +16,7 @@ namespace EventStore.Client {
 		private readonly CancellationTokenSource _disposed;
 		private int _subscriptionDroppedInvoked;
 
+
 		internal static async Task<StreamSubscription> Confirm(
 			IAsyncEnumerable<(SubscriptionConfirmation confirmation, Position?, ResolvedEvent)> read,
 			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
@@ -33,7 +34,7 @@ namespace EventStore.Client {
 				checkpointReached, cancellationToken);
 		}
 
-		private StreamSubscription(IAsyncEnumerator<(SubscriptionConfirmation, Position?, ResolvedEvent)> events,
+		private StreamSubscription(IAsyncEnumerator<(SubscriptionConfirmation confirmation, Position?, ResolvedEvent)> events,
 			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
 			Action<StreamSubscription, SubscriptionDroppedReason, Exception?>? subscriptionDropped,
 			ILogger log,

--- a/src/EventStore.Client/Interceptors/TypedExceptionInterceptor.cs
+++ b/src/EventStore.Client/Interceptors/TypedExceptionInterceptor.cs
@@ -107,32 +107,7 @@ namespace EventStore.Client.Interceptors {
 			};
 		}
 
-
-		/*		private static Exception ConvertRpcException(RpcException ex) {
-			return ex.Trailers.TryGetValue(Constants.Exceptions.ExceptionKey, out var value) switch {
-				true => value switch {
-					Constants.Exceptions.PersistentSubscriptionDoesNotExist => new
-						PersistentSubscriptionNotFoundException(
-							ex.Trailers.FirstOrDefault(x => x.Key == Constants.Exceptions.StreamName)?.Value,
-							ex.Trailers.FirstOrDefault(x => x.Key == Constants.Exceptions.GroupName)?.Value, ex),
-					Constants.Exceptions.MaximumSubscribersReached => new
-						MaximumSubscribersReachedException(
-							ex.Trailers.FirstOrDefault(x => x.Key == Constants.Exceptions.StreamName)?.Value,
-							ex.Trailers.FirstOrDefault(x => x.Key == Constants.Exceptions.GroupName)?.Value, ex),
-					Constants.Exceptions.PersistentSubscriptionDropped => new
-						PersistentSubscriptionDroppedByServerException(
-							ex.Trailers.FirstOrDefault(x => x.Key == Constants.Exceptions.StreamName)?.Value,
-							ex.Trailers.FirstOrDefault(x => x.Key == Constants.Exceptions.GroupName)?.Value, ex),
-				},
-				false => ex.StatusCode switch {
-					StatusCode.DeadlineExceeded => ex,
-					StatusCode.Unauthenticated => new NotAuthenticatedException(ex.Message, ex),
-					_ => new InvalidOperationException(ex.Message, ex)
-				}
-			};
-		}
-*/
-		class AsyncStreamReader<TResponse> : IAsyncStreamReader<TResponse> {
+		private class AsyncStreamReader<TResponse> : IAsyncStreamReader<TResponse> {
 			private readonly Action<Exception>? _exceptionOccurred;
 			private readonly IDictionary<string, Func<RpcException, Exception>> _exceptionMap;
 			private readonly IAsyncStreamReader<TResponse> _inner;

--- a/src/EventStore.Client/Position.cs
+++ b/src/EventStore.Client/Position.cs
@@ -147,9 +147,5 @@ namespace EventStore.Client {
 		/// </returns>
 		/// <filterpriority>2</filterpriority>
 		public override string ToString() => $"C:{CommitPosition}/P:{PreparePosition}";
-
-		public (long commitPosition, long preparePosition) ToInt64() => Equals(End)
-			? (-1, -1)
-			: ((long)CommitPosition, (long)PreparePosition);
 	}
 }

--- a/src/EventStore.Client/ResolvedEvent.cs
+++ b/src/EventStore.Client/ResolvedEvent.cs
@@ -4,9 +4,7 @@ namespace EventStore.Client {
 		public readonly EventRecord Event;
 		public readonly EventRecord? Link;
 
-		public EventRecord OriginalEvent {
-			get { return Link ?? Event; }
-		}
+		public EventRecord OriginalEvent => Link ?? Event;
 
 		/// <summary>
 		/// Position of the OriginalEvent (unresolved link or event) if available
@@ -19,12 +17,12 @@ namespace EventStore.Client {
 
 		public bool IsResolved => Link != null && Event != null;
 
-		public ResolvedEvent(EventRecord @event, EventRecord? link, long? commitPosition) {
+		public ResolvedEvent(EventRecord @event, EventRecord? link, ulong? commitPosition) {
 			Event = @event;
 			Link = link;
 			OriginalPosition = commitPosition.HasValue
-				? new Position((ulong)commitPosition.Value, (link ?? @event).Position.PreparePosition)
-				: default;
+				? new Position(commitPosition.Value, (link ?? @event).Position.PreparePosition)
+				: new Position?();
 		}
 	}
 }

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/Bugs/Issue_1125.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/Bugs/Issue_1125.cs
@@ -39,7 +39,7 @@ namespace EventStore.Client.Bugs {
 					resolveLinkTos: true, startFrom: StreamRevision.Start),
 				userCredentials: userCredentials);
 
-			using (_fixture.Client.Subscribe(streamName, subscriptionName,
+			using (await _fixture.Client.SubscribeAsync(streamName, subscriptionName,
 				async (subscription, @event, arg3, arg4) => {
 					var result = Interlocked.Increment(ref hitCount);
 					await subscription.Ack(@event);

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/a_nak_in_autoack_mode_drops_the_subscription.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/a_nak_in_autoack_mode_drops_the_subscription.cs
@@ -39,7 +39,7 @@ namespace EventStore.Client {
 			protected override async Task Given() {
 				await Client.CreateAsync(Stream, Group,
 					new PersistentSubscriptionSettings(startFrom: StreamRevision.Start), TestCredentials.Root);
-				_subscription = Client.Subscribe(Stream, Group,
+				_subscription = await Client.SubscribeAsync(Stream, Group,
 					delegate {
 						throw new Exception("test");
 					}, (subscription, reason, ex) => _subscriptionDroppedSource.SetResult((reason, ex)), TestCredentials.Root);

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/connect_to_existing_with_max_one_client.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/connect_to_existing_with_max_one_client.cs
@@ -15,35 +15,27 @@ namespace EventStore.Client {
 
 		[Fact]
 		public async Task the_second_subscription_fails_to_connect() {
-			var dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
+			using var first = await _fixture.Client.SubscribeAsync(Stream, Group,
+				delegate { return Task.CompletedTask; },
+				userCredentials: TestCredentials.Root).WithTimeout();
 
-			using var first = _fixture.Client
-				.Subscribe(Stream, Group, delegate { return Task.CompletedTask; }, userCredentials: TestCredentials.Root);
-			await first.Started.WithTimeout();
-			using var second = _fixture.Client
-				.Subscribe(Stream, Group, delegate { return Task.CompletedTask; },
-					(s, r, e) => dropped.SetResult((r, e)), userCredentials: TestCredentials.Root);
-			await second.Started.WithTimeout();
+			var ex = await Assert.ThrowsAsync<MaximumSubscribersReachedException>(async () => {
+				using var _ = await _fixture.Client.SubscribeAsync(Stream, Group,
+					delegate { return Task.CompletedTask; },
+					userCredentials: TestCredentials.Root);
+			}).WithTimeout();
 
-			var (reason, exception) = await dropped.Task.WithTimeout();
-
-			Assert.Equal(SubscriptionDroppedReason.ServerError, reason);
-			var ex = Assert.IsType<MaximumSubscribersReachedException>(exception);
 			Assert.Equal(Stream, ex.StreamName);
 			Assert.Equal(Group, ex.GroupName);
 		}
 
 		public class Fixture : EventStoreClientFixture {
-			public Fixture() {
-			}
-
-			protected override Task Given() {
-				return Client.CreateAsync(
+			protected override Task Given() =>
+				Client.CreateAsync(
 					Stream,
 					Group,
 					new PersistentSubscriptionSettings(maxSubscriberCount: 1),
 					TestCredentials.Root);
-			}
 
 			protected override Task When() => Task.CompletedTask;
 		}

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/connect_to_existing_with_permissions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/connect_to_existing_with_permissions.cs
@@ -16,18 +16,15 @@ namespace EventStore.Client {
 		[Fact]
 		public async Task the_subscription_succeeds() {
 			var dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
-			using var subscription = _fixture.Client.Subscribe(Stream, "agroupname17",
+			using var subscription = await _fixture.Client.SubscribeAsync(Stream, "agroupname17",
 				delegate { return Task.CompletedTask; }, (s, reason, ex) => dropped.TrySetResult((reason, ex)),
-				TestCredentials.Root);
+				TestCredentials.Root).WithTimeout();
 			Assert.NotNull(subscription);
 
 			await Assert.ThrowsAsync<TimeoutException>(() => dropped.Task.WithTimeout());
 		}
 
 		public class Fixture : EventStoreClientFixture {
-			public Fixture() {
-			}
-
 			protected override Task Given() =>
 				Client.CreateAsync(
 					Stream,

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/connect_to_existing_with_start_from_beginning_and_events_in_it.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/connect_to_existing_with_start_from_beginning_and_events_in_it.cs
@@ -42,8 +42,8 @@ namespace EventStore.Client {
 					new PersistentSubscriptionSettings(startFrom: StreamRevision.Start), TestCredentials.Root);
 			}
 
-			protected override Task When() {
-				_subscription = Client.Subscribe(Stream, Group,
+			protected override async Task When() {
+				_subscription = await Client.SubscribeAsync(Stream, Group,
 					(subscription, e, r, ct) => {
 						_firstEventSource.TrySetResult(e);
 						return Task.CompletedTask;
@@ -52,7 +52,6 @@ namespace EventStore.Client {
 							_firstEventSource.TrySetException(ex!);
 						}
 					}, TestCredentials.TestUser1);
-				return _subscription.Started;
 			}
 
 			public override Task DisposeAsync() {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/connect_to_existing_with_start_from_beginning_and_no_stream.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/connect_to_existing_with_start_from_beginning_and_no_stream.cs
@@ -39,7 +39,7 @@ namespace EventStore.Client {
 			protected override async Task Given() {
 				await Client.CreateAsync(Stream, Group,
 					new PersistentSubscriptionSettings(), TestCredentials.Root);
-				_subscription = Client.Subscribe(Stream, Group,
+				_subscription = await Client.SubscribeAsync(Stream, Group,
 					(subscription, e, r, ct) => {
 						_firstEventSource.TrySetResult(e);
 						return Task.CompletedTask;

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/connect_to_existing_with_start_from_beginning_not_set_and_events_in_it.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/connect_to_existing_with_start_from_beginning_not_set_and_events_in_it.cs
@@ -40,8 +40,8 @@ namespace EventStore.Client {
 					new PersistentSubscriptionSettings(startFrom: StreamRevision.End), TestCredentials.Root);
 			}
 
-			protected override  Task When() {
-				_subscription = Client.Subscribe(Stream, Group,
+			protected override async Task When() {
+				_subscription = await Client.SubscribeAsync(Stream, Group,
 					(subscription, e, r, ct) => {
 						_firstEventSource.TrySetResult(e);
 						return Task.CompletedTask;
@@ -50,7 +50,6 @@ namespace EventStore.Client {
 							_firstEventSource.TrySetException(ex!);
 						}
 					}, TestCredentials.TestUser1);
-				return Task.CompletedTask;
 			}
 
 			public override Task DisposeAsync() {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/connect_to_existing_with_start_from_beginning_not_set_and_events_in_it_then_event_written.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/connect_to_existing_with_start_from_beginning_not_set_and_events_in_it_then_event_written.cs
@@ -44,7 +44,7 @@ namespace EventStore.Client {
 				await StreamsClient.AppendToStreamAsync(Stream, AnyStreamRevision.NoStream, Events.Take(10));
 				await Client.CreateAsync(Stream, Group,
 					new PersistentSubscriptionSettings(startFrom: StreamRevision.End), TestCredentials.Root);
-				_subscription = Client.Subscribe(Stream, Group,
+				_subscription = await Client.SubscribeAsync(Stream, Group,
 					(subscription, e, r, ct) => {
 						_firstEventSource.TrySetResult(e);
 						return Task.CompletedTask;

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/connect_to_existing_with_start_from_two_and_no_stream.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/connect_to_existing_with_start_from_two_and_no_stream.cs
@@ -38,7 +38,7 @@ namespace EventStore.Client {
 			protected override async Task Given() {
 				await Client.CreateAsync(Stream, Group,
 					new PersistentSubscriptionSettings(startFrom: new StreamRevision(2)), TestCredentials.Root);
-				_subscription = Client.Subscribe(Stream, Group,
+				_subscription = await Client.SubscribeAsync(Stream, Group,
 					(subscription, e, r, ct) => {
 						_firstEventSource.TrySetResult(e);
 						return Task.CompletedTask;

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/connect_to_existing_with_start_from_x_set_and_events_in_it.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/connect_to_existing_with_start_from_x_set_and_events_in_it.cs
@@ -37,7 +37,7 @@ namespace EventStore.Client {
 				await StreamsClient.AppendToStreamAsync(Stream, AnyStreamRevision.NoStream, Events.Take(10));
 				await Client.CreateAsync(Stream, Group,
 					new PersistentSubscriptionSettings(startFrom: new StreamRevision(4)), TestCredentials.Root);
-				_subscription = Client.Subscribe(Stream, Group,
+				_subscription = await Client.SubscribeAsync(Stream, Group,
 					(subscription, e, r, ct) => {
 						_firstEventSource.TrySetResult(e);
 						return Task.CompletedTask;

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/connect_to_existing_with_start_from_x_set_and_events_in_it_then_event_written.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/connect_to_existing_with_start_from_x_set_and_events_in_it_then_event_written.cs
@@ -42,7 +42,7 @@ namespace EventStore.Client {
 				await StreamsClient.AppendToStreamAsync(Stream, AnyStreamRevision.NoStream, Events.Take(10));
 				await Client.CreateAsync(Stream, Group,
 					new PersistentSubscriptionSettings(startFrom: new StreamRevision(10)), TestCredentials.Root);
-				_subscription = Client.Subscribe(Stream, Group,
+				_subscription = await Client.SubscribeAsync(Stream, Group,
 					(subscription, e, r, ct) => {
 						_firstEventSource.TrySetResult(e);
 						return Task.CompletedTask;

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/connect_to_existing_with_start_from_x_set_higher_than_x_and_events_in_it_then_event_written.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/connect_to_existing_with_start_from_x_set_higher_than_x_and_events_in_it_then_event_written.cs
@@ -45,7 +45,7 @@ namespace EventStore.Client {
 				await StreamsClient.AppendToStreamAsync(Stream, AnyStreamRevision.NoStream, Events.Take(11));
 				await Client.CreateAsync(Stream, Group,
 					new PersistentSubscriptionSettings(startFrom: new StreamRevision(11)), TestCredentials.Root);
-				_subscription = Client.Subscribe(Stream, Group,
+				_subscription = await Client.SubscribeAsync(Stream, Group,
 					(subscription, e, r, ct) => {
 						_firstEventSource.TrySetResult(e);
 						return Task.CompletedTask;

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/connect_to_existing_without_permissions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/connect_to_existing_without_permissions.cs
@@ -10,21 +10,13 @@ namespace EventStore.Client {
 		public connect_to_existing_without_permissions(Fixture fixture) { _fixture = fixture; }
 
 		[Fact]
-		public async Task throws_access_denied() {
-			var dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
-			_fixture.Client.Subscribe(Stream, "agroupname55",
-				delegate { return Task.CompletedTask; },
-				(s, r, e) => dropped.TrySetResult((r,e)));
-
-			var (reason, exception) = await dropped.Task.WithTimeout();
-			Assert.Equal(SubscriptionDroppedReason.ServerError, reason);
-			Assert.IsType<AccessDeniedException>(exception);
-		}
+		public Task throws_access_denied() =>
+			Assert.ThrowsAsync<AccessDeniedException>(async () => {
+				using var _ = await _fixture.Client.SubscribeAsync(Stream, "agroupname55",
+					delegate { return Task.CompletedTask; });
+			}).WithTimeout();
 
 		public class Fixture : EventStoreClientFixture {
-			public Fixture() {
-			}
-
 			protected override Task Given() =>
 				Client.CreateAsync(
 					Stream,

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/connect_with_retries.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/connect_with_retries.cs
@@ -34,7 +34,7 @@ namespace EventStore.Client {
 				await StreamsClient.AppendToStreamAsync(Stream, AnyStreamRevision.NoStream, Events);
 				await Client.CreateAsync(Stream, Group,
 					new PersistentSubscriptionSettings(startFrom: StreamRevision.Start), TestCredentials.Root);
-				_subscription = Client.Subscribe(Stream, Group,
+				_subscription = await Client.SubscribeAsync(Stream, Group,
 					async (subscription, e, r, ct) => {
 						if (r > 4) {
 							_retryCountSource.TrySetResult(r.Value);

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/connecting_to_a_persistent_subscription.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/connecting_to_a_persistent_subscription.cs
@@ -45,7 +45,7 @@ namespace EventStore.Client {
 				await StreamsClient.AppendToStreamAsync(Stream, AnyStreamRevision.NoStream, Events.Take(11));
 				await Client.CreateAsync(Stream, Group,
 					new PersistentSubscriptionSettings(startFrom: new StreamRevision(11)), TestCredentials.Root);
-				_subscription = Client.Subscribe(Stream, Group,
+				_subscription = await Client.SubscribeAsync(Stream, Group,
 					(subscription, e, r, ct) => {
 						_firstEventSource.TrySetResult(e);
 						return Task.CompletedTask;

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/deleting_existing_with_subscriber.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/deleting_existing_with_subscriber.cs
@@ -25,10 +25,9 @@ namespace EventStore.Client {
 				await Client.CreateAsync(Stream, "groupname123",
 					new PersistentSubscriptionSettings(),
 					TestCredentials.Root);
-				_subscription = Client.Subscribe(Stream, "groupname123",
+				_subscription = await Client.SubscribeAsync(Stream, "groupname123",
 					(s, e, i, ct) => Task.CompletedTask,
-					(s, r, e) => _dropped.TrySetResult((r, e)), userCredentials:TestCredentials.Root);
-				await _subscription.Started;
+					(s, r, e) => _dropped.TrySetResult((r, e)), TestCredentials.Root);
 			}
 
 			protected override Task When() =>

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/happy_case_catching_up_to_link_to_events_auto_ack.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/happy_case_catching_up_to_link_to_events_auto_ack.cs
@@ -48,7 +48,7 @@ namespace EventStore.Client {
 				await Client.CreateAsync(Stream, Group,
 					new PersistentSubscriptionSettings(startFrom: StreamRevision.Start, resolveLinkTos: true),
 					TestCredentials.Root);
-				_subscription = Client.Subscribe(Stream, Group,
+				_subscription = await Client.SubscribeAsync(Stream, Group,
 					(subscription, e, retryCount, ct) => {
 						if (Interlocked.Increment(ref _eventReceivedCount) == _events.Length) {
 							_eventsReceived.TrySetResult(true);

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/happy_case_catching_up_to_link_to_events_manual_ack.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/happy_case_catching_up_to_link_to_events_manual_ack.cs
@@ -48,7 +48,7 @@ namespace EventStore.Client {
 				await Client.CreateAsync(Stream, Group,
 					new PersistentSubscriptionSettings(startFrom: StreamRevision.Start, resolveLinkTos: true),
 					TestCredentials.Root);
-				_subscription = Client.Subscribe(Stream, Group,
+				_subscription = await Client.SubscribeAsync(Stream, Group,
 					(subscription, e, retryCount, ct) => {
 						subscription.Ack(e);
 

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/happy_case_catching_up_to_normal_events_auto_ack.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/happy_case_catching_up_to_normal_events_auto_ack.cs
@@ -43,7 +43,7 @@ namespace EventStore.Client {
 				await Client.CreateAsync(Stream, Group,
 					new PersistentSubscriptionSettings(startFrom: StreamRevision.Start, resolveLinkTos: true),
 					TestCredentials.Root);
-				_subscription = Client.Subscribe(Stream, Group,
+				_subscription = await Client.SubscribeAsync(Stream, Group,
 					(subscription, e, retryCount, ct) => {
 						if (Interlocked.Increment(ref _eventReceivedCount) == _events.Length) {
 							_eventsReceived.TrySetResult(true);

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/happy_case_catching_up_to_normal_events_manual_ack.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/happy_case_catching_up_to_normal_events_manual_ack.cs
@@ -43,7 +43,7 @@ namespace EventStore.Client {
 				await Client.CreateAsync(Stream, Group,
 					new PersistentSubscriptionSettings(startFrom: StreamRevision.Start, resolveLinkTos: true),
 					TestCredentials.Root);
-				_subscription = Client.Subscribe(Stream, Group,
+				_subscription = await Client.SubscribeAsync(Stream, Group,
 					(subscription, e, retryCount, ct) => {
 						subscription.Ack(e);
 

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/happy_case_writing_and_subscribing_to_normal_events_auto_ack.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/happy_case_writing_and_subscribing_to_normal_events_auto_ack.cs
@@ -39,7 +39,7 @@ namespace EventStore.Client {
 				await Client.CreateAsync(Stream, Group,
 					new PersistentSubscriptionSettings(startFrom: StreamRevision.End, resolveLinkTos: true),
 					TestCredentials.Root);
-				_subscription = Client.Subscribe(Stream, Group,
+				_subscription = await Client.SubscribeAsync(Stream, Group,
 					(subscription, e, retryCount, ct) => {
 						if (Interlocked.Increment(ref _eventReceivedCount) == _events.Length) {
 							_eventsReceived.TrySetResult(true);

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/happy_case_writing_and_subscribing_to_normal_events_manual_ack.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/happy_case_writing_and_subscribing_to_normal_events_manual_ack.cs
@@ -39,7 +39,7 @@ namespace EventStore.Client {
 				await Client.CreateAsync(Stream, Group,
 					new PersistentSubscriptionSettings(startFrom: StreamRevision.End, resolveLinkTos: true),
 					TestCredentials.Root);
-				_subscription = Client.Subscribe(Stream, Group,
+				_subscription = await Client.SubscribeAsync(Stream, Group,
 					(subscription, e, retryCount, ct) => {
 						subscription.Ack(e);
 						if (Interlocked.Increment(ref _eventReceivedCount) == _events.Length) {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/when_writing_and_subscribing_to_normal_events_manual_nack.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/when_writing_and_subscribing_to_normal_events_manual_nack.cs
@@ -40,7 +40,7 @@ namespace EventStore.Client {
 				await Client.CreateAsync(Stream, Group,
 					new PersistentSubscriptionSettings(startFrom: StreamRevision.Start, resolveLinkTos: true),
 					TestCredentials.Root);
-				_subscription = Client.Subscribe(Stream, Group,
+				_subscription = await Client.SubscribeAsync(Stream, Group,
 					(subscription, e, retryCount, ct) => {
 						subscription.Nack(PersistentSubscriptionNakEventAction.Park, "fail", e);
 

--- a/test/EventStore.Client.Tests.Common/EventStoreClientFixtureBase`1.cs
+++ b/test/EventStore.Client.Tests.Common/EventStoreClientFixtureBase`1.cs
@@ -100,7 +100,7 @@ namespace EventStore.Client {
 				Value = new Tuple<string, Guid>(captureCorrelationId, captureId)
 			};
 
-			bool Filter(LogEvent logEvent) => callContextData.Value!.Item2.Equals(captureId);
+			bool Filter(LogEvent logEvent) => callContextData!.Value!.Item2.Equals(captureId);
 
 			MessageTemplateTextFormatter formatter = new MessageTemplateTextFormatter(
 				"{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level:u3}] [{SourceContext}] {Message}");


### PR DESCRIPTION
Persistent Subscriptions (`Subscribe`) and Stream Subscriptions (`SubscribeAsync`) have a slightly different api. This PR changes makes them both `SubscribeAsync`.