### PR TITLE
Align test structure and set timeout to 10 seconds

### DIFF
--- a/test/EventStore.Client.PersistentSubscriptions.Tests/deleting_existing_with_subscriber.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/deleting_existing_with_subscriber.cs
@@ -5,48 +5,21 @@ using Xunit;
 namespace EventStore.Client {
 	public class deleting_existing_with_subscriber
 		: IClassFixture<deleting_existing_with_subscriber.Fixture> {
-		private readonly Fixture _fixture;
 		private const string Stream = nameof(deleting_existing_with_subscriber);
+		private const string Group = "existing";
+		private readonly Fixture _fixture;
 
 		public deleting_existing_with_subscriber(Fixture fixture) {
 			_fixture = fixture;
 		}
 
-		public class Fixture : EventStoreClientFixture {
-			public Task<(SubscriptionDroppedReason reason, Exception exception)> Dropped => _dropped.Task;
-			private readonly TaskCompletionSource<(SubscriptionDroppedReason, Exception)> _dropped;
-			private PersistentSubscription _subscription;
-
-			public Fixture() {
-				_dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
-			}
-
-			protected override async Task Given() {
-				await Client.CreateAsync(Stream, "groupname123",
-					new PersistentSubscriptionSettings(),
-					TestCredentials.Root);
-				_subscription = await Client.SubscribeAsync(Stream, "groupname123",
-					(s, e, i, ct) => Task.CompletedTask,
-					(s, r, e) => _dropped.TrySetResult((r, e)), TestCredentials.Root);
-			}
-
-			protected override Task When() =>
-				Client.DeleteAsync(Stream, "groupname123",
-					TestCredentials.Root);
-
-			public override Task DisposeAsync() {
-				_subscription?.Dispose();
-				return base.DisposeAsync();
-			}
-		}
-
 		[Fact]
 		public async Task the_subscription_is_dropped() {
-			var (reason, exception) = await _fixture.Dropped.WithTimeout();
+			var (reason, exception) = await _fixture.Dropped.WithTimeout(TimeSpan.FromSeconds(10));
 			Assert.Equal(SubscriptionDroppedReason.ServerError, reason);
 			var ex = Assert.IsType<PersistentSubscriptionDroppedByServerException>(exception);
 			Assert.Equal(Stream, ex.StreamName);
-			Assert.Equal("groupname123", ex.GroupName);
+			Assert.Equal(Group, ex.GroupName);
 		}
 
 		[Fact (Skip = "Isn't this how it should work?")]
@@ -55,7 +28,35 @@ namespace EventStore.Client {
 			Assert.Equal(SubscriptionDroppedReason.ServerError, reason);
 			var ex = Assert.IsType<PersistentSubscriptionNotFoundException>(exception);
 			Assert.Equal(Stream, ex.StreamName);
-			Assert.Equal("groupname123", ex.GroupName);
+			Assert.Equal(Group, ex.GroupName);
+		}
+
+		public class Fixture : EventStoreClientFixture {
+			public Task<(SubscriptionDroppedReason reason, Exception exception)> Dropped => _droppedSource.Task;
+			private readonly TaskCompletionSource<(SubscriptionDroppedReason, Exception)> _droppedSource;
+			private PersistentSubscription _subscription;
+
+			public Fixture() {
+				_droppedSource = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
+			}
+
+			protected override async Task Given() {
+				await Client.CreateAsync(Stream, Group,
+					new PersistentSubscriptionSettings(),
+					TestCredentials.Root);
+				_subscription = await Client.SubscribeAsync(Stream, Group,
+					delegate { return Task.CompletedTask; },
+					(subscription, reason, ex) => _droppedSource.TrySetResult((reason, ex)), TestCredentials.Root);
+			}
+
+			protected override Task When() =>
+				Client.DeleteAsync(Stream, Group,
+					TestCredentials.Root);
+
+			public override Task DisposeAsync() {
+				_subscription?.Dispose();
+				return base.DisposeAsync();
+			}
 		}
 	}
 }


### PR DESCRIPTION
Attempt to align the test structure and fix the current failing tests due to timeouts.