### PR TITLE
Add operations proto contract and implementation

### DIFF
--- a/src/EventStore.Client.Common/protos/operations.proto
+++ b/src/EventStore.Client.Common/protos/operations.proto
@@ -2,9 +2,15 @@ syntax = "proto3";
 package event_store.client.operations;
 option java_package = "com.eventstore.client.operations";
 
+import "shared.proto";
+
 service Operations {
 	rpc StartScavenge (StartScavengeReq) returns (ScavengeResp);
 	rpc StopScavenge (StopScavengeReq) returns (ScavengeResp);
+	rpc Shutdown (Empty) returns (Empty);
+	rpc MergeIndexes (Empty) returns (Empty);
+	rpc ResignNode (Empty) returns (Empty);
+	rpc SetNodePriority (SetNodePriorityReq) returns (Empty);
 }
 
 message StartScavengeReq {
@@ -31,4 +37,8 @@ message ScavengeResp {
 		InProgress = 1;
 		Stopped = 2;
 	}
+}
+
+message SetNodePriorityReq {
+	int32 priority = 1;
 }

--- a/src/EventStore.Client.Common/protos/projectionmanagement.proto
+++ b/src/EventStore.Client.Common/protos/projectionmanagement.proto
@@ -15,6 +15,7 @@ service Projections {
 	rpc Reset (ResetReq) returns (ResetResp);
 	rpc State (StateReq) returns (StateResp);
 	rpc Result (ResultReq) returns (ResultResp);
+	rpc RestartSubsystem (Empty) returns (Empty);
 }
 
 message CreateReq {

--- a/src/EventStore.Client.Operations/EventStoreOperationsClient.Admin.cs
+++ b/src/EventStore.Client.Operations/EventStoreOperationsClient.Admin.cs
@@ -1,0 +1,39 @@
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Client.Operations;
+
+#nullable enable
+namespace EventStore.Client {
+	public partial class EventStoreOperationsClient {
+		private static readonly Empty EmptyResult = new Empty();
+
+		public async Task ShutdownAsync(
+			UserCredentials? userCredentials = null,
+			CancellationToken cancellationToken = default) {
+			await _client.ShutdownAsync(EmptyResult, RequestMetadata.Create(userCredentials),
+				cancellationToken: cancellationToken);
+		}
+
+		public async Task MergeIndexesAsync(
+			UserCredentials? userCredentials = null,
+			CancellationToken cancellationToken = default) {
+			await _client.MergeIndexesAsync(EmptyResult, RequestMetadata.Create(userCredentials),
+				cancellationToken: cancellationToken);
+		}
+
+		public async Task ResignNodeAsync(
+			UserCredentials? userCredentials = null,
+			CancellationToken cancellationToken = default) {
+			await _client.ResignNodeAsync(EmptyResult, RequestMetadata.Create(userCredentials),
+				cancellationToken: cancellationToken);
+		}
+
+		public async Task SetNodePriorityAsync(int nodePriority,
+			UserCredentials? userCredentials = null,
+			CancellationToken cancellationToken = default) {
+			await _client.SetNodePriorityAsync(new SetNodePriorityReq {Priority = nodePriority},
+				RequestMetadata.Create(userCredentials),
+				cancellationToken: cancellationToken);
+		}
+	}
+}

--- a/src/EventStore.Client.ProjectionManagement/EventStoreProjectionManagementClient.Control.cs
+++ b/src/EventStore.Client.ProjectionManagement/EventStoreProjectionManagementClient.Control.cs
@@ -33,5 +33,11 @@ namespace EventStore.Client {
 			}, RequestMetadata.Create(userCredentials), cancellationToken: cancellationToken);
 			await call.ResponseAsync.ConfigureAwait(false);
 		}
+
+		public async Task RestartSubsystemAsync(UserCredentials? userCredentials = null,
+			CancellationToken cancellationToken = default) {
+			await _client.RestartSubsystemAsync(new Empty(), RequestMetadata.Create(userCredentials),
+				cancellationToken: cancellationToken);
+		}
 	}
 }

--- a/test/EventStore.Client.Operations.Tests/admin.cs
+++ b/test/EventStore.Client.Operations.Tests/admin.cs
@@ -1,0 +1,57 @@
+using System.Threading.Tasks;
+using Xunit;
+
+namespace EventStore.Client {
+	public class admin : IClassFixture<admin.Fixture> {
+		private readonly Fixture _fixture;
+
+		public admin(Fixture fixture) {
+			_fixture = fixture;
+		}
+
+		[Fact]
+		public async Task shutdown_does_not_throw() {
+			await _fixture.Client.ShutdownAsync(userCredentials: TestCredentials.Root);
+		}
+
+		[Fact]
+		public async Task shutdown_without_credentials_throws() {
+			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.Client.ShutdownAsync());
+		}
+
+		[Fact]
+		public async Task set_node_priority_does_not_throw() {
+			await _fixture.Client.SetNodePriorityAsync(1000, TestCredentials.Root);
+		}
+
+		[Fact]
+		public async Task set_node_priority_without_credentials_throws() {
+			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.Client.SetNodePriorityAsync(1000));
+		}
+
+		[Fact]
+		public async Task resign_node_does_not_throw() {
+			await _fixture.Client.ResignNodeAsync(TestCredentials.Root);
+		}
+
+		[Fact]
+		public async Task resign_node_without_credentials_throws() {
+			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.Client.ResignNodeAsync());
+		}
+
+		[Fact]
+		public async Task merge_indexes_does_not_throw() {
+			await _fixture.Client.MergeIndexesAsync(TestCredentials.Root);
+		}
+
+		[Fact]
+		public async Task merge_indexes_without_credentials_throws() {
+			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.Client.MergeIndexesAsync());
+		}
+		
+		public class Fixture : EventStoreClientFixture {
+			protected override Task Given() => Task.CompletedTask;
+			protected override Task When() => Task.CompletedTask;
+		}
+	}
+}

--- a/test/EventStore.Client.ProjectionManagement.Tests/restart_subsystem.cs
+++ b/test/EventStore.Client.ProjectionManagement.Tests/restart_subsystem.cs
@@ -1,0 +1,29 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Xunit;
+
+namespace EventStore.Client {
+	public class restart_subsystem : IClassFixture<restart_subsystem.Fixture> {
+		private readonly Fixture _fixture;
+
+		public restart_subsystem(Fixture fixture) {
+			_fixture = fixture;
+		}
+
+		[Fact]
+		public async Task does_not_throw() {
+			await _fixture.Client.RestartSubsystemAsync(TestCredentials.Root);
+		}
+
+		[Fact]
+		public async Task throws_when_given_no_credentials() {
+			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.Client.RestartSubsystemAsync());
+		}
+
+		public class Fixture : EventStoreClientFixture {
+			protected override Task Given() => Task.CompletedTask;
+			protected override Task When() => Task.CompletedTask;
+		}
+	}
+}

--- a/test/EventStore.Client.Streams.Tests/sending_and_receiving_large_messages.cs
+++ b/test/EventStore.Client.Streams.Tests/sending_and_receiving_large_messages.cs
@@ -19,7 +19,7 @@ namespace EventStore.Client {
 		public async Task over_the_hard_limit() {
 			var streamName = _fixture.GetStreamName();
 			var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _fixture.Client.AppendToStreamAsync(
-				streamName, AnyStreamRevision.NoStream,
+				streamName, StreamState.NoStream,
 				_fixture.LargeEvent));
 			var rpcEx = Assert.IsType<RpcException>(ex.InnerException);
 			Assert.Equal(StatusCode.ResourceExhausted, rpcEx.StatusCode);


### PR DESCRIPTION
Added: Operations proto contract and implementation

Fixes: https://github.com/EventStore/EventStore/issues/2151
Requires https://github.com/EventStore/EventStore/pull/2446 to be merged.

Add the following to client.Operations:
- MergeIndexes
- Shutdown
- ResignNode
- SetNodePriority

Add RestartSubsystem to client.ProjectionManagement