### PR TITLE
Provide a read status which will allow the client to avoid exceptions

### DIFF
--- a/src/EventStore.Client.Common/protos/streams.proto
+++ b/src/EventStore.Client.Common/protos/streams.proto
@@ -86,6 +86,7 @@ message ReadResp {
 		ReadEvent event = 1;
 		SubscriptionConfirmation confirmation = 2;
 		Checkpoint checkpoint = 3;
+		StreamNotFound stream_not_found = 4;
 	}
 
 	message ReadEvent {
@@ -113,6 +114,9 @@ message ReadResp {
 	message Checkpoint {
 		uint64 commit_position = 1;
 		uint64 prepare_position = 2;
+	}
+	message StreamNotFound {
+
 	}
 }
 

--- a/src/EventStore.Client.Streams/ReadState.cs
+++ b/src/EventStore.Client.Streams/ReadState.cs
@@ -1,0 +1,6 @@
+namespace EventStore.Client {
+	public enum ReadState {
+		StreamNotFound,
+		Ok
+	}
+}

--- a/test/EventStore.Client.Streams.Tests/read_stream_backward.cs
+++ b/test/EventStore.Client.Streams.Tests/read_stream_backward.cs
@@ -33,6 +33,16 @@ namespace EventStore.Client {
 
 			Assert.Equal(stream, ex.Stream);
 		}
+		
+		[Fact]
+		public async Task stream_does_not_exist_can_be_checked() {
+			var stream = _fixture.GetStreamName();
+
+			var result = _fixture.Client.ReadStreamAsync(Direction.Backwards, stream, StreamPosition.End, 1);
+
+			var state = await result.ReadState;
+			Assert.Equal(ReadState.StreamNotFound, state);
+		}
 
 		[Fact]
 		public async Task stream_deleted_throws() {

--- a/test/EventStore.Client.Streams.Tests/read_stream_forward.cs
+++ b/test/EventStore.Client.Streams.Tests/read_stream_forward.cs
@@ -33,7 +33,17 @@ namespace EventStore.Client {
 
 			Assert.Equal(stream, ex.Stream);
 		}
+		
+		[Fact]
+		public async Task stream_does_not_exist_can_be_checked() {
+			var stream = _fixture.GetStreamName();
 
+			var result = _fixture.Client.ReadStreamAsync(Direction.Forwards, stream, StreamPosition.Start, 1);
+			
+			var state = await result.ReadState;
+			Assert.Equal(ReadState.StreamNotFound, state);
+		}
+		
 		[Fact]
 		public async Task stream_deleted_throws() {
 			var stream = _fixture.GetStreamName();


### PR DESCRIPTION
When performing a read for a stream, the consumer can decide whether they want the enumeration to throw or to check the read result before continuing.

The ReadState in the example below would currently either be `Ok` or `StreamNotFound`.

i.e.
```
var result = client.ReadStreamAsync(Direction.Forwards, "foo", StreamPosition.Start, 1);
var state = await result.ReadState;
```