### PR TITLE
Refactor to netstandard2.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<TargetFramework>netcoreapp3.1</TargetFramework>
+		<TargetFramework>netstandard2.1</TargetFramework>
 		<Platform>x64</Platform>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Nullable>disable</Nullable>

--- a/src/EventStore.Client/EventStoreClientBase.cs
+++ b/src/EventStore.Client/EventStoreClientBase.cs
@@ -29,11 +29,6 @@ namespace EventStore.Client {
 				_httpHandler = ClusterAwareHttpHandler.Create(Settings, _httpHandler);
 			}
 
-			HttpRequestMessage msg = new HttpRequestMessage()
-			{
-				Version = new Version(2, 0)
-			};
-
 			_channel = GrpcChannel.ForAddress(Settings.ConnectivitySettings.Address, new GrpcChannelOptions {
 				HttpClient = new HttpClient(_httpHandler) {
 					Timeout = Timeout.InfiniteTimeSpan

--- a/src/EventStore.Client/Infrastructure/DefaultRequestVersionHandler.cs
+++ b/src/EventStore.Client/Infrastructure/DefaultRequestVersionHandler.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EventStore.Client
+{
+    internal class DefaultRequestVersionHandler : DelegatingHandler
+    {
+        public DefaultRequestVersionHandler(HttpMessageHandler innerHandler) : base(innerHandler)
+        {
+            InnerHandler = innerHandler;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            request.Version = new Version(2, 0);
+            return base.SendAsync(request, cancellationToken);
+        }
+    }
+}

--- a/src/EventStore.Client/Infrastructure/IPEndpointParser.cs
+++ b/src/EventStore.Client/Infrastructure/IPEndpointParser.cs
@@ -1,0 +1,76 @@
+using System.Globalization;
+using System.Net;
+
+namespace EventStore.Client
+{
+    internal static class IPEndPointParser	
+    {	
+        public static bool TryParse(string addressWithPort, out IPEndPoint endpoint)	
+        {	
+            string addressPart = null;	
+            string portPart = null;	
+            IPAddress address;	
+            endpoint = null;	
+
+            if (string.IsNullOrEmpty(addressWithPort))	
+            {	
+                return false;	
+            }	
+
+            var lastColonIndex = addressWithPort.LastIndexOf(':');	
+            if (lastColonIndex > 0)	
+            {	
+                // IPv4 with port or IPv6	
+                var closingIndex = addressWithPort.LastIndexOf(']');	
+                if (closingIndex > 0)	
+                {	
+                    // IPv6 with brackets	
+                    addressPart = addressWithPort.Substring(1, closingIndex - 1);	
+                    if (closingIndex < lastColonIndex)	
+                    {	
+                        // IPv6 with port [::1]:80	
+                        portPart = addressWithPort.Substring(lastColonIndex + 1);	
+                    }	
+                }	
+                else	
+                {	
+                    // IPv6 without port or IPv4	
+                    var firstColonIndex = addressWithPort.IndexOf(':');	
+                    if (firstColonIndex != lastColonIndex)	
+                    {	
+                        // IPv6 ::1	
+                        addressPart = addressWithPort;	
+                    }	
+                    else	
+                    {	
+                        // IPv4 with port 127.0.0.1:123	
+                        addressPart = addressWithPort.Substring(0, firstColonIndex);	
+                        portPart = addressWithPort.Substring(firstColonIndex + 1);	
+                    }	
+                }	
+            }	
+            else	
+            {	
+                // IPv4 without port	
+                addressPart = addressWithPort;	
+            }	
+
+            if (IPAddress.TryParse(addressPart, out address))	
+            {	
+                if (portPart != null)	
+                {	
+                    int port;	
+                    if (int.TryParse(portPart, NumberStyles.None, CultureInfo.InvariantCulture, out port))	
+                    {	
+                        endpoint = new IPEndPoint(address, port);	
+                        return true;	
+                    }	
+                    return false;	
+                }	
+                endpoint = new IPEndPoint(address, 0);	
+                return true;	
+            }	
+            return false;	
+        }	
+    }
+}

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,5 +1,8 @@
 <Project>
 	<Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+	<PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Docker.DotNet" Version="3.125.2" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0"/>


### PR DESCRIPTION
This is a quick refactor to allow the library to compile as netstandard2.1

The utilization of this change within the lib is to allow usage within Blazor, as netcoreapp3.1 libraries cannot be pulled into the Blazor project.