### PR TITLE
Update cluster discovery to remove internal http

### DIFF
--- a/src/EventStore.Client/ClusterMessage.cs
+++ b/src/EventStore.Client/ClusterMessage.cs
@@ -12,8 +12,8 @@ namespace EventStore.Client {
 
 			public VNodeState State { get; set; }
 			public bool IsAlive { get; set; }
-			public string? ExternalHttpIp { get; set; }
-			public int ExternalHttpPort { get; set; }
+			public string? HttpEndPointIp { get; set; }
+			public int HttpEndPointPort { get; set; }
 		}
 
 		public enum VNodeState {

--- a/src/EventStore.Client/EndPointExtensions.cs
+++ b/src/EventStore.Client/EndPointExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Net;
+
+namespace EventStore.Client {
+	static class EndPointExtensions {
+		public static string GetHost(this EndPoint endpoint) =>
+			endpoint switch {
+				IPEndPoint ip => ip.Address.ToString(),
+				DnsEndPoint dns => dns.Host,
+				_ => throw new ArgumentOutOfRangeException(nameof(endpoint), endpoint?.GetType(),
+					"An invalid endpoint has been provided")
+			};
+
+		public static int GetPort(this EndPoint endpoint) =>
+			endpoint switch {
+				IPEndPoint ip => ip.Port,
+				DnsEndPoint dns => dns.Port,
+				_ => throw new ArgumentOutOfRangeException(nameof(endpoint), endpoint?.GetType(),
+					"An invalid endpoint has been provided")
+			};
+	}
+}

--- a/src/EventStore.Client/IEndpointDiscoverer.cs
+++ b/src/EventStore.Client/IEndpointDiscoverer.cs
@@ -3,6 +3,6 @@ using System.Threading.Tasks;
 
 namespace EventStore.Client {
 	public interface IEndpointDiscoverer {
-		Task<IPEndPoint> DiscoverAsync();
+		Task<EndPoint> DiscoverAsync();
 	}
 }

--- a/src/EventStore.Client/NotLeaderException.cs
+++ b/src/EventStore.Client/NotLeaderException.cs
@@ -4,9 +4,9 @@ using System.Net;
 #nullable enable
 namespace EventStore.Client {
 	public class NotLeaderException : Exception {
-		public IPEndPoint LeaderEndpoint { get; }
+		public EndPoint LeaderEndpoint { get; }
 
-		public NotLeaderException(IPEndPoint newLeaderEndpoint, Exception? exception = null) : base(
+		public NotLeaderException(EndPoint newLeaderEndpoint, Exception? exception = null) : base(
 			$"Not leader. New leader at {newLeaderEndpoint}.", exception) {
 			LeaderEndpoint = newLeaderEndpoint;
 		}

--- a/test/EventStore.Client.Tests/ClusterAwareHttpHandlerTests.cs
+++ b/test/EventStore.Client.Tests/ClusterAwareHttpHandlerTests.cs
@@ -88,13 +88,13 @@ namespace EventStore.Client {
 	}
 
 	internal class FakeEndpointDiscoverer : IEndpointDiscoverer {
-		private readonly Func<IPEndPoint> _function;
+		private readonly Func<EndPoint> _function;
 
-		public FakeEndpointDiscoverer(Func<IPEndPoint> function) {
+		public FakeEndpointDiscoverer(Func<EndPoint> function) {
 			_function = function;
 		}
 
-		public Task<IPEndPoint> DiscoverAsync() {
+		public Task<EndPoint> DiscoverAsync() {
 			return Task.FromResult(_function());
 		}
 	}

--- a/test/EventStore.Client.Tests/GossipBasedEndpointDiscovererTests.cs
+++ b/test/EventStore.Client.Tests/GossipBasedEndpointDiscovererTests.cs
@@ -19,8 +19,8 @@ namespace EventStore.Client {
 					new ClusterMessages.MemberInfo {
 						State = ClusterMessages.VNodeState.Leader,
 						InstanceId = Guid.NewGuid(),
-						ExternalHttpIp = IPAddress.Any.ToString(),
-						ExternalHttpPort = 4444,
+						HttpEndPointIp = IPAddress.Any.ToString(),
+						HttpEndPointPort = 4444,
 						IsAlive = true,
 					},
 				}
@@ -52,15 +52,15 @@ namespace EventStore.Client {
 					new ClusterMessages.MemberInfo {
 						State = ClusterMessages.VNodeState.Leader,
 						InstanceId = Guid.NewGuid(),
-						ExternalHttpIp = IPAddress.Any.ToString(),
-						ExternalHttpPort = 1111,
+						HttpEndPointIp = IPAddress.Any.ToString(),
+						HttpEndPointPort = 1111,
 						IsAlive = true,
 					},
 					new ClusterMessages.MemberInfo {
 						State = ClusterMessages.VNodeState.Follower,
 						InstanceId = Guid.NewGuid(),
-						ExternalHttpIp = IPAddress.Any.ToString(),
-						ExternalHttpPort = 2222,
+						HttpEndPointIp = IPAddress.Any.ToString(),
+						HttpEndPointPort = 2222,
 						IsAlive = true,
 					},
 				}
@@ -70,15 +70,15 @@ namespace EventStore.Client {
 					new ClusterMessages.MemberInfo {
 						State = ClusterMessages.VNodeState.Leader,
 						InstanceId = Guid.NewGuid(),
-						ExternalHttpIp = IPAddress.Any.ToString(),
-						ExternalHttpPort = 1111,
+						HttpEndPointIp = IPAddress.Any.ToString(),
+						HttpEndPointPort = 1111,
 						IsAlive = false,
 					},
 					new ClusterMessages.MemberInfo {
 						State = ClusterMessages.VNodeState.Leader,
 						InstanceId = Guid.NewGuid(),
-						ExternalHttpIp = IPAddress.Any.ToString(),
-						ExternalHttpPort = 2222,
+						HttpEndPointIp = IPAddress.Any.ToString(),
+						HttpEndPointPort = 2222,
 						IsAlive = true,
 					},
 				}
@@ -101,17 +101,17 @@ namespace EventStore.Client {
 
 			var result = await sut.DiscoverAsync();
 
-			var expected = firstGossip.Members.First(x => x.ExternalHttpPort == 1111);
-			
-			Assert.Equal(expected.ExternalHttpIp, result.Address.ToString());
-			Assert.Equal(expected.ExternalHttpPort, result.Port);
+			var expected = firstGossip.Members.First(x => x.HttpEndPointPort == 1111);
+
+			Assert.Equal(expected.HttpEndPointIp, result.GetHost());
+			Assert.Equal(expected.HttpEndPointPort, result.GetPort());
 			
 			result = await sut.DiscoverAsync();
 
-			expected = secondGossip.Members.First(x => x.ExternalHttpPort == 2222);
-			
-			Assert.Equal(expected.ExternalHttpIp, result.Address.ToString());
-			Assert.Equal(expected.ExternalHttpPort, result.Port);
+			expected = secondGossip.Members.First(x => x.HttpEndPointPort == 2222);
+
+			Assert.Equal(expected.HttpEndPointIp, result.GetHost());
+			Assert.Equal(expected.HttpEndPointPort, result.GetPort());
 		}
 
 		[Fact]
@@ -150,8 +150,8 @@ namespace EventStore.Client {
 					new ClusterMessages.MemberInfo {
 						State = invalidState,
 						InstanceId = Guid.NewGuid(),
-						ExternalHttpIp = IPAddress.Any.ToString(),
-						ExternalHttpPort = 4444,
+						HttpEndPointIp = IPAddress.Any.ToString(),
+						HttpEndPointPort = 4444,
 						IsAlive = true,
 					},
 				}
@@ -177,15 +177,15 @@ namespace EventStore.Client {
 					new ClusterMessages.MemberInfo {
 						State = ClusterMessages.VNodeState.Leader,
 						InstanceId = Guid.NewGuid(),
-						ExternalHttpIp = IPAddress.Any.ToString(),
-						ExternalHttpPort = 1111,
+						HttpEndPointIp = IPAddress.Any.ToString(),
+						HttpEndPointPort = 1111,
 						IsAlive = true,
 					},
 					new ClusterMessages.MemberInfo {
 						State = ClusterMessages.VNodeState.Follower,
 						InstanceId = Guid.NewGuid(),
-						ExternalHttpIp = IPAddress.Any.ToString(),
-						ExternalHttpPort = 2222,
+						HttpEndPointIp = IPAddress.Any.ToString(),
+						HttpEndPointPort = 2222,
 						IsAlive = true,
 					},
 					new ClusterMessages.MemberInfo {
@@ -193,15 +193,15 @@ namespace EventStore.Client {
 							? expectedState
 							: ClusterMessages.VNodeState.ReadOnlyReplica,
 						InstanceId = Guid.NewGuid(),
-						ExternalHttpIp = IPAddress.Any.ToString(),
-						ExternalHttpPort = 3333,
+						HttpEndPointIp = IPAddress.Any.ToString(),
+						HttpEndPointPort = 3333,
 						IsAlive = true,
 					},
 					new ClusterMessages.MemberInfo {
 						State = ClusterMessages.VNodeState.Manager,
 						InstanceId = Guid.NewGuid(),
-						ExternalHttpIp = IPAddress.Any.ToString(),
-						ExternalHttpPort = 4444,
+						HttpEndPointIp = IPAddress.Any.ToString(),
+						HttpEndPointPort = 4444,
 						IsAlive = true,
 					},
 				}
@@ -213,8 +213,8 @@ namespace EventStore.Client {
 			}, Timeout.InfiniteTimeSpan, TimeSpan.Zero, preference, handler);
 
 			var result = await sut.DiscoverAsync();
-			Assert.Equal(result.Port,
-				gossip.Members.Last(x => x.State == expectedState).ExternalHttpPort);
+			Assert.Equal(result.GetPort(),
+				gossip.Members.Last(x => x.State == expectedState).HttpEndPointPort);
 		}
 
 		[Fact]
@@ -224,15 +224,15 @@ namespace EventStore.Client {
 					new ClusterMessages.MemberInfo {
 						State = ClusterMessages.VNodeState.Leader,
 						InstanceId = Guid.NewGuid(),
-						ExternalHttpIp = IPAddress.Any.ToString(),
-						ExternalHttpPort = 1111,
+						HttpEndPointIp = IPAddress.Any.ToString(),
+						HttpEndPointPort = 1111,
 						IsAlive = false,
 					},
 					new ClusterMessages.MemberInfo {
 						State = ClusterMessages.VNodeState.Follower,
 						InstanceId = Guid.NewGuid(),
-						ExternalHttpIp = IPAddress.Any.ToString(),
-						ExternalHttpPort = 2222,
+						HttpEndPointIp = IPAddress.Any.ToString(),
+						HttpEndPointPort = 2222,
 						IsAlive = true,
 					},
 				}
@@ -244,8 +244,8 @@ namespace EventStore.Client {
 			}, Timeout.InfiniteTimeSpan, TimeSpan.Zero, NodePreference.Leader, handler);
 
 			var result = await sut.DiscoverAsync();
-			Assert.Equal(result.Port,
-				gossip.Members.Last(x => x.State == ClusterMessages.VNodeState.Follower).ExternalHttpPort);
+			Assert.Equal(result.GetPort(),
+				gossip.Members.Last(x => x.State == ClusterMessages.VNodeState.Follower).HttpEndPointPort);
 		}
 
 		private HttpResponseMessage ResponseFromGossip(ClusterMessages.ClusterInfo gossip) =>


### PR DESCRIPTION
Changed: Update cluster discovery to match the new cluster member info from Event Store server

Fixes https://github.com/EventStore/EventStore/issues/2330
Relies on https://github.com/EventStore/EventStore/pull/2479

- Use httpEndPoint from the cluster member info for cluster discovery
- Change IPEndPoint used in cluster discovery to EndPoint for compatibily with the dns endpoint change (https://github.com/EventStore/EventStore/issues/2478)