### PR TITLE
Restore Dotnet Tooling Before Running Tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,4 +113,5 @@ jobs:
       shell: bash
       if: github.event_name == 'push'
       run: |
+        dotnet tool restore
         find . -name "*.nupkg" | xargs -n1 dotnet tool run gpr -- push --api-key=${{ secrets.github_token }}


### PR DESCRIPTION
Fixed: nuget package push via `dotnet gpr`