### PR TITLE
Support infinite timeouts

### DIFF
--- a/src/EventStore.Client.Streams/DeadLine.cs
+++ b/src/EventStore.Client.Streams/DeadLine.cs
@@ -1,10 +1,14 @@
 ﻿using System;
+using System.Threading;
 
 #nullable enable
 namespace EventStore.Client {
 	internal static class DeadLine {
-		public static DateTime? After(TimeSpan? timeoutAfter) =>
-			timeoutAfter.HasValue ? DateTime.UtcNow.Add(timeoutAfter.Value) : (DateTime?)null;
+		public static DateTime? After(TimeSpan? timeoutAfter){
+			if(!timeoutAfter.HasValue) return null;
+			if(timeoutAfter.Value == TimeSpan.MaxValue || timeoutAfter.Value == Timeout.InfiniteTimeSpan) return DateTime.MaxValue;
+			return DateTime.UtcNow.Add(timeoutAfter.Value);
+		}
 
 		public static TimeSpan? None = null;
 	}


### PR DESCRIPTION
Partially Fixes: #29

This PR allows infinite operation timeouts by specifying TimeSpan.MaxValue or Timeout.InfiniteTimeSpan in EventStoreClientOperationOptions.TimeoutAfter.

The second part of the issue (default timeout) has not been dealt with yet. The issue is that just changing the default timeout from 5 seconds to infinity would affect the default timeouts of all operations, not only stream read operations: https://github.com/EventStore/EventStore-Client-Dotnet/blob/master/src/EventStore.Client/EventStoreClientOperationOptions.cs#L10

We could override them in these specific stream read operations but i'm not sure if there's a better approach.