### PR TITLE
Set Minver to use tag prefix

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -22,6 +22,7 @@
 		<PackageTags>eventstore client grpc</PackageTags>
 		<Authors>Event Store Ltd</Authors>
 		<Copyright>Copyright 2012-2020 Event Store Ltd</Copyright>
+		<MinVerTagPrefix>v</MinVerTagPrefix>
 	</PropertyGroup>
 	<ItemGroup>
 		<None Include="..\..\LICENSE.md" Pack="true" PackagePath="\"/>


### PR DESCRIPTION
We require minver to use the tag prefix to correctly identify the version we want it to use.