### PR TITLE
Add GossipOverHttps option to EventStoreClientConnectivitySettings

### DIFF
--- a/src/EventStore.Client/ClusterAwareHttpHandler.cs
+++ b/src/EventStore.Client/ClusterAwareHttpHandler.cs
@@ -14,13 +14,13 @@ namespace EventStore.Client {
 
 		public static ClusterAwareHttpHandler Create(EventStoreClientSettings settings,
 			HttpMessageHandler? httpMessageHandler = null) => new ClusterAwareHttpHandler(
-			settings.ConnectivitySettings.UseHttps,
+			settings.ConnectivitySettings.GossipOverHttps,
 			settings.ConnectivitySettings.NodePreference == NodePreference.Leader,
 			new ClusterEndpointDiscoverer(
 				settings.ConnectivitySettings.MaxDiscoverAttempts,
 				settings.ConnectivitySettings.GossipSeeds,
 				settings.ConnectivitySettings.GossipTimeout,
-				settings.ConnectivitySettings.UseHttps,
+				settings.ConnectivitySettings.GossipOverHttps,
 				settings.ConnectivitySettings.DiscoveryInterval,
 				settings.ConnectivitySettings.NodePreference,
 				httpMessageHandler)) {

--- a/src/EventStore.Client/EventStoreClientBase.cs
+++ b/src/EventStore.Client/EventStoreClientBase.cs
@@ -20,6 +20,11 @@ namespace EventStore.Client {
 		protected EventStoreClientBase(EventStoreClientSettings? settings,
 			IDictionary<string, Func<RpcException, Exception>> exceptionMap) {
 			Settings = settings ?? new EventStoreClientSettings();
+			if(Settings.ConnectivitySettings.Address.Scheme == Uri.UriSchemeHttp || !Settings.ConnectivitySettings.UseHttps){
+				//this must be switched on before creation of the HttpMessageHandler
+				AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
+			}
+
 			_httpHandler = Settings.CreateHttpMessageHandler?.Invoke() ?? new HttpClientHandler();
 
 			var connectionName = Settings.ConnectionName ?? $"ES-{Guid.NewGuid()}";

--- a/src/EventStore.Client/EventStoreClientBase.cs
+++ b/src/EventStore.Client/EventStoreClientBase.cs
@@ -20,7 +20,7 @@ namespace EventStore.Client {
 		protected EventStoreClientBase(EventStoreClientSettings? settings,
 			IDictionary<string, Func<RpcException, Exception>> exceptionMap) {
 			Settings = settings ?? new EventStoreClientSettings();
-			if(Settings.ConnectivitySettings.Address.Scheme == Uri.UriSchemeHttp || !Settings.ConnectivitySettings.UseHttps){
+			if(Settings.ConnectivitySettings.Address.Scheme == Uri.UriSchemeHttp || !Settings.ConnectivitySettings.GossipOverHttps){
 				//this must be switched on before creation of the HttpMessageHandler
 				AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
 			}

--- a/src/EventStore.Client/EventStoreClientConnectivitySettings.cs
+++ b/src/EventStore.Client/EventStoreClientConnectivitySettings.cs
@@ -20,14 +20,14 @@ namespace EventStore.Client {
 		public DnsEndPoint[]? DnsGossipSeeds { get; set; }
 		public IPEndPoint[]? IpGossipSeeds { get; set; }
 		public TimeSpan GossipTimeout { get; set; }
-		public bool UseHttps { get; set; } = true;
+		public bool GossipOverHttps { get; set; } = true;
 		public TimeSpan DiscoveryInterval { get; set; }
 		public NodePreference NodePreference { get; set; }
 
 		public static EventStoreClientConnectivitySettings Default => new EventStoreClientConnectivitySettings {
 			MaxDiscoverAttempts = 10,
 			GossipTimeout = TimeSpan.FromSeconds(5),
-			UseHttps = true,
+			GossipOverHttps = true,
 			DiscoveryInterval = TimeSpan.FromMilliseconds(100),
 			NodePreference = NodePreference.Leader,
 		};

--- a/src/EventStore.Client/EventStoreClientConnectivitySettings.cs
+++ b/src/EventStore.Client/EventStoreClientConnectivitySettings.cs
@@ -20,12 +20,14 @@ namespace EventStore.Client {
 		public DnsEndPoint[]? DnsGossipSeeds { get; set; }
 		public IPEndPoint[]? IpGossipSeeds { get; set; }
 		public TimeSpan GossipTimeout { get; set; }
+		public bool UseHttps { get; set; } = true;
 		public TimeSpan DiscoveryInterval { get; set; }
 		public NodePreference NodePreference { get; set; }
 
 		public static EventStoreClientConnectivitySettings Default => new EventStoreClientConnectivitySettings {
 			MaxDiscoverAttempts = 10,
 			GossipTimeout = TimeSpan.FromSeconds(5),
+			UseHttps = true,
 			DiscoveryInterval = TimeSpan.FromMilliseconds(100),
 			NodePreference = NodePreference.Leader,
 		};

--- a/src/EventStore.Client/GossipBasedEndpointDiscoverer.cs
+++ b/src/EventStore.Client/GossipBasedEndpointDiscoverer.cs
@@ -24,6 +24,7 @@ namespace EventStore.Client {
 			int maxDiscoverAttempts,
 			EndPoint[] gossipSeeds,
 			TimeSpan gossipTimeout,
+			bool gossipOverHttps,
 			TimeSpan discoveryInterval,
 			NodePreference nodePreference,
 			HttpMessageHandler? httpMessageHandler = null) {
@@ -33,7 +34,7 @@ namespace EventStore.Client {
 			_nodePreference = nodePreference;
 			_gossipClients = new Dictionary<EndPoint,  GossipClient>();
 			_gossipClientFactory = (gossipSeedEndPoint) => {
-				string url = gossipSeedEndPoint.ToHttpUrl(EndPointExtensions.HTTPS_SCHEMA);
+				string url = gossipSeedEndPoint.ToHttpUrl(gossipOverHttps?EndPointExtensions.HTTPS_SCHEMA:EndPointExtensions.HTTP_SCHEMA);
 				var channel = GrpcChannel.ForAddress(url, new GrpcChannelOptions {
 					HttpClient = new HttpClient(httpMessageHandler ?? new HttpClientHandler()) {
 						Timeout = gossipTimeout,


### PR DESCRIPTION
Fixes #50

This PR allows the dotnet gRPC client to connect to a cluster running with --insecure (related PR: https://github.com/EventStore/EventStore/pull/2556)