### PR TITLE
Additionally target netstandard2.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<TargetFramework>netcoreapp3.1</TargetFramework>
 		<Platform>x64</Platform>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Nullable>disable</Nullable>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,5 +1,8 @@
 <Project>
 	<Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>
+	<PropertyGroup>
+		<TargetFrameworks>netcoreapp3.1;netstandard2.1</TargetFrameworks>
+	</PropertyGroup>
 	<PropertyGroup Condition="$(MSBuildProjectName) != 'EventStore.Client'">
 		<ESPackageIdSuffix>$(MSBuildProjectName.Remove(0,18))</ESPackageIdSuffix>
 		<ESProto>$(ESPackageIdSuffix.ToLower()).proto</ESProto>

--- a/src/EventStore.Client/DefaultRequestVersionHandler.cs
+++ b/src/EventStore.Client/DefaultRequestVersionHandler.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EventStore.Client {
+	internal class DefaultRequestVersionHandler : DelegatingHandler {
+		public DefaultRequestVersionHandler(HttpMessageHandler innerHandler) : base(innerHandler) { }
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+			request.Version = new Version(2, 0);
+			return base.SendAsync(request, cancellationToken);
+		}
+	}
+}

--- a/src/EventStore.Client/EventStoreClientBase.cs
+++ b/src/EventStore.Client/EventStoreClientBase.cs
@@ -30,7 +30,11 @@ namespace EventStore.Client {
 				AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
 			}
 
+#if NETCOREAPP3_1
 			_innerHttpHandler = Settings.CreateHttpMessageHandler?.Invoke() ?? new SocketsHttpHandler();
+#elif NETSTANDARD2_1
+			_innerHttpHandler = Settings.CreateHttpMessageHandler?.Invoke() ?? new HttpClientHandler();
+#endif
 
 			_httpHandler = Settings.ConnectivitySettings.IsSingleNode
 				? (HttpMessageHandler)new SingleNodeHttpHandler(Settings) {

--- a/src/EventStore.Client/EventStoreClientBase.cs
+++ b/src/EventStore.Client/EventStoreClientBase.cs
@@ -42,13 +42,18 @@ namespace EventStore.Client {
 				}
 				: ClusterAwareHttpHandler.Create(Settings, _innerHttpHandler);
 
+#if NETSTANDARD2_1
+			_httpHandler = new DefaultRequestVersionHandler(_httpHandler);
+#endif
 
 			_channel = GrpcChannel.ForAddress(new UriBuilder(Settings.ConnectivitySettings.Address) {
 				Scheme = Uri.UriSchemeHttps
 			}.Uri, new GrpcChannelOptions {
 				HttpClient = new HttpClient(_httpHandler) {
 					Timeout = Timeout.InfiniteTimeSpan,
+#if NETCOREAPP3_1
 					DefaultRequestVersion = new Version(2, 0),
+#endif
 				},
 				LoggerFactory = Settings.LoggerFactory,
 				Credentials = Settings.ChannelCredentials

--- a/src/EventStore.Client/EventStoreClientSettings.ConnectionString.cs
+++ b/src/EventStore.Client/EventStoreClientSettings.ConnectionString.cs
@@ -150,11 +150,17 @@ namespace EventStore.Client {
 
 				if (typedOptions.TryGetValue("TlsVerifyCert", out object tlsVerifyCert)) {
 					if (!(bool)tlsVerifyCert) {
+#if NETCOREAPP3_1
 						settings.CreateHttpMessageHandler = () => new SocketsHttpHandler {
 							SslOptions = {
 								RemoteCertificateValidationCallback = delegate { return true; }
 							}
 						};
+#elif NETSTANDARD2_1
+						settings.CreateHttpMessageHandler = () => new HttpClientHandler {
+							ServerCertificateCustomValidationCallback = delegate { return true; }
+						};
+#endif
 					}
 				}
 

--- a/src/EventStore.Client/GossipBasedEndpointDiscoverer.cs
+++ b/src/EventStore.Client/GossipBasedEndpointDiscoverer.cs
@@ -35,10 +35,17 @@ namespace EventStore.Client {
 			_gossipClients = new Dictionary<EndPoint,  GossipClient>();
 			_gossipClientFactory = (gossipSeedEndPoint) => {
 				string url = gossipSeedEndPoint.ToHttpUrl(gossipOverHttps?EndPointExtensions.HTTPS_SCHEMA:EndPointExtensions.HTTP_SCHEMA);
+				var httpHandler = httpMessageHandler ?? new HttpClientHandler();
+#if NETSTANDARD2_1
+				httpHandler = new DefaultRequestVersionHandler(httpHandler);
+#endif
+
 				var channel = GrpcChannel.ForAddress(url, new GrpcChannelOptions {
-					HttpClient = new HttpClient(httpMessageHandler ?? new HttpClientHandler()) {
+					HttpClient = new HttpClient(httpHandler) {
 						Timeout = gossipTimeout,
+#if NETCOREAPP3_1
 						DefaultRequestVersion = new Version(2, 0),
+#endif
 					}
 				});
 				var callInvoker = channel.CreateCallInvoker();

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,5 +1,8 @@
 <Project>
 	<Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+	<PropertyGroup>
+		<TargetFrameworks>netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Ductus.FluentDocker" Version="2.7.3" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0"/>

--- a/test/EventStore.Client.Tests.Common/EventStoreClientFixtureBase.cs
+++ b/test/EventStore.Client.Tests.Common/EventStoreClientFixtureBase.cs
@@ -158,7 +158,7 @@ namespace EventStore.Client {
 					await Policy.Handle<Exception>()
 						.WaitAndRetryAsync(5, retryCount => TimeSpan.FromSeconds(retryCount * retryCount))
 						.ExecuteAsync(async () => {
-							using var response = await _httpClient.GetAsync("/web/index.html", cancellationToken);
+							using var response = await _httpClient.GetAsync("/health/live", cancellationToken);
 							if (response.StatusCode >= HttpStatusCode.BadRequest) {
 								throw new Exception($"Health check failed with status code {response.StatusCode}");
 							}


### PR DESCRIPTION
Changed: Additionally target netstandard2.1


This PR is similar to the one opened by @dealproc here: https://github.com/EventStore/EventStore-Client-Dotnet/pull/19.
- However it multi-targets both netstandard2.1 and netcoreapp3.1.
- Tests also multi-target both netcoreapp3.0 and netcoreapp3.1 so that they run with both the netstandard2.1 and netcoreapp3.1 version of the client.

I've also added @dealproc as co-author on this commit:  0c4e976

This commit: d806bae6ee58a6db379036f84dd2618cba14e31a fixes the `EventStore.Client.listing_users` flaky test (admin user wasn't yet created)

Co-Authored-By: Richard Bennett <inbox@richardbennett.dev>