### PR TITLE
Add restarting persistent subscriptions

### DIFF
--- a/src/EventStore.Client.Common/protos/operations.proto
+++ b/src/EventStore.Client.Common/protos/operations.proto
@@ -11,6 +11,7 @@ service Operations {
 	rpc MergeIndexes (Empty) returns (Empty);
 	rpc ResignNode (Empty) returns (Empty);
 	rpc SetNodePriority (SetNodePriorityReq) returns (Empty);
+	rpc RestartPersistentSubscriptions (Empty) returns (Empty);
 }
 
 message StartScavengeReq {

--- a/src/EventStore.Client.Operations/EventStoreOperationsClient.Admin.cs
+++ b/src/EventStore.Client.Operations/EventStoreOperationsClient.Admin.cs
@@ -59,5 +59,17 @@ namespace EventStore.Client {
 			await _client.SetNodePriorityAsync(new SetNodePriorityReq {Priority = nodePriority},
 				EventStoreCallOptions.Create(Settings, Settings.OperationOptions, userCredentials, cancellationToken));
 		}
+
+		/// <summary>
+		/// Restart persistent subscriptions
+		/// </summary>
+		/// <param name="userCredentials"></param>
+		/// <param name="cancellationToken"></param>
+		/// <returns></returns>
+		public async Task RestartPersistentSubscriptions(UserCredentials? userCredentials = null,
+			CancellationToken cancellationToken = default) {
+			await _client.RestartPersistentSubscriptionsAsync(EmptyResult,
+				EventStoreCallOptions.Create(Settings, Settings.OperationOptions, userCredentials, cancellationToken));
+		}
 	}
 }

--- a/test/EventStore.Client.Operations.Tests/admin.cs
+++ b/test/EventStore.Client.Operations.Tests/admin.cs
@@ -10,36 +10,6 @@ namespace EventStore.Client {
 		}
 
 		[Fact]
-		public async Task shutdown_does_not_throw() {
-			await _fixture.Client.ShutdownAsync(userCredentials: TestCredentials.Root);
-		}
-
-		[Fact]
-		public async Task shutdown_without_credentials_throws() {
-			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.Client.ShutdownAsync());
-		}
-
-		[Fact]
-		public async Task set_node_priority_does_not_throw() {
-			await _fixture.Client.SetNodePriorityAsync(1000, TestCredentials.Root);
-		}
-
-		[Fact]
-		public async Task set_node_priority_without_credentials_throws() {
-			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.Client.SetNodePriorityAsync(1000));
-		}
-
-		[Fact]
-		public async Task resign_node_does_not_throw() {
-			await _fixture.Client.ResignNodeAsync(TestCredentials.Root);
-		}
-
-		[Fact]
-		public async Task resign_node_without_credentials_throws() {
-			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.Client.ResignNodeAsync());
-		}
-
-		[Fact]
 		public async Task merge_indexes_does_not_throw() {
 			await _fixture.Client.MergeIndexesAsync(TestCredentials.Root);
 		}

--- a/test/EventStore.Client.Operations.Tests/admin.cs
+++ b/test/EventStore.Client.Operations.Tests/admin.cs
@@ -49,6 +49,16 @@ namespace EventStore.Client {
 			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.Client.MergeIndexesAsync());
 		}
 		
+		[Fact]
+		public async Task restart_persistent_subscriptions_does_not_throw() {
+			await _fixture.Client.RestartPersistentSubscriptions(TestCredentials.Root);
+		}
+
+		[Fact]
+		public async Task restart_persistent_subscriptions_without_credentials_throws() {
+			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.Client.RestartPersistentSubscriptions());
+		}
+		
 		public class Fixture : EventStoreClientFixture {
 			protected override Task Given() => Task.CompletedTask;
 			protected override Task When() => Task.CompletedTask;

--- a/test/EventStore.Client.Operations.Tests/admin_resign_node.cs
+++ b/test/EventStore.Client.Operations.Tests/admin_resign_node.cs
@@ -1,0 +1,27 @@
+using System.Threading.Tasks;
+using Xunit;
+
+namespace EventStore.Client {
+	public class admin_resign_node : IClassFixture<admin_resign_node.Fixture> {
+		private readonly Fixture _fixture;
+
+		public admin_resign_node(Fixture fixture) {
+			_fixture = fixture;
+		}
+
+		[Fact]
+		public async Task resign_node_does_not_throw() {
+			await _fixture.Client.ResignNodeAsync(TestCredentials.Root);
+		}
+
+		[Fact]
+		public async Task resign_node_without_credentials_throws() {
+			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.Client.ResignNodeAsync());
+		}
+		
+		public class Fixture : EventStoreClientFixture {
+			protected override Task Given() => Task.CompletedTask;
+			protected override Task When() => Task.CompletedTask;
+		}
+	}
+}

--- a/test/EventStore.Client.Operations.Tests/admin_shutdown_node.cs
+++ b/test/EventStore.Client.Operations.Tests/admin_shutdown_node.cs
@@ -1,0 +1,27 @@
+using System.Threading.Tasks;
+using Xunit;
+
+namespace EventStore.Client {
+	public class admin_shutdown_node : IClassFixture<admin_shutdown_node.Fixture> {
+		private readonly Fixture _fixture;
+
+		public admin_shutdown_node(Fixture fixture) {
+			_fixture = fixture;
+		}
+
+		[Fact]
+		public async Task shutdown_does_not_throw() {
+			await _fixture.Client.ShutdownAsync(userCredentials: TestCredentials.Root);
+		}
+
+		[Fact]
+		public async Task shutdown_without_credentials_throws() {
+			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.Client.ShutdownAsync());
+		}
+
+		public class Fixture : EventStoreClientFixture {
+			protected override Task Given() => Task.CompletedTask;
+			protected override Task When() => Task.CompletedTask;
+		}
+	}
+}


### PR DESCRIPTION
I moved the disruptive client operations (shutdown, resign) into separate test fixtures as they were causing the other tests alongside them to fail.