### PR TITLE
Remove duplicate not allowed node states from endpoint discoverer

### DIFF
--- a/src/EventStore.Client/GossipBasedEndpointDiscoverer.cs
+++ b/src/EventStore.Client/GossipBasedEndpointDiscoverer.cs
@@ -151,8 +151,6 @@ namespace EventStore.Client {
 			NodePreference nodePreference) {
 			var notAllowedStates = new[] {
 				ClusterMessages.VNodeState.Manager,
-				ClusterMessages.VNodeState.ShuttingDown,
-				ClusterMessages.VNodeState.Manager,
 				ClusterMessages.VNodeState.Shutdown,
 				ClusterMessages.VNodeState.Unknown,
 				ClusterMessages.VNodeState.Initializing,


### PR DESCRIPTION
The `Manager` and `ShuttingDown` states are duplicates and can safely be removed.