### PR TITLE
Add projection reset to client

### DIFF
--- a/src/EventStore.Client.ProjectionManagement/EventStoreProjectionManagementClient.Control.cs
+++ b/src/EventStore.Client.ProjectionManagement/EventStoreProjectionManagementClient.Control.cs
@@ -23,6 +23,24 @@ namespace EventStore.Client {
 		}
 
 		/// <summary>
+		/// Resets a projection. This will re-emit events. Streams that are written to from the projection will also be soft deleted.
+		/// </summary>
+		/// <param name="name"></param>
+		/// <param name="userCredentials"></param>
+		/// <param name="cancellationToken"></param>
+		/// <returns></returns>
+		public async Task ResetAsync(string name, UserCredentials? userCredentials = null,
+			CancellationToken cancellationToken = default) {
+			using var call = _client.ResetAsync(new ResetReq {
+				Options = new ResetReq.Types.Options {
+					Name = name,
+					WriteCheckpoint = true
+				}
+			}, EventStoreCallOptions.Create(Settings, Settings.OperationOptions, userCredentials, cancellationToken));
+			await call.ResponseAsync.ConfigureAwait(false);
+		}
+
+		/// <summary>
 		/// Aborts a projection. Saves the projection's checkpoint.
 		/// </summary>
 		/// <param name="name"></param>

--- a/test/EventStore.Client.ProjectionManagement.Tests/reset.cs
+++ b/test/EventStore.Client.ProjectionManagement.Tests/reset.cs
@@ -1,0 +1,26 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace EventStore.Client {
+	public class reset : IClassFixture<reset.Fixture> {
+		private readonly Fixture _fixture;
+
+		public reset(Fixture fixture) {
+			_fixture = fixture;
+		}
+
+		[Fact]
+		public async Task status_is_running() {
+			var name = StandardProjections.Names.First();
+			await _fixture.Client.ResetAsync(name, TestCredentials.Root);
+			var result = await _fixture.Client.GetStatusAsync(name, TestCredentials.Root);
+			Assert.Equal("Running", result.Status);
+		}
+
+		public class Fixture : EventStoreClientFixture {
+			protected override Task Given() => Task.CompletedTask;
+			protected override Task When() => Task.CompletedTask;
+		}
+	}
+}


### PR DESCRIPTION
This adds a remote call `ResetAsync` to `EventStoreProjectionManagementClient`. Without it the client is not able to reset a projection.

The RPC call was already specified in the protobuf definition.

I am not sure if it is correct to always write a checkpoint.