### PR TITLE
Implement parameterless IComparable for StreamPosition and StreamRevision

### DIFF
--- a/src/EventStore.Client/StreamPosition.cs
+++ b/src/EventStore.Client/StreamPosition.cs
@@ -5,7 +5,7 @@ namespace EventStore.Client {
 	/// <summary>
 	/// A structure referring to an <see cref="EventRecord"/>'s position within a stream.
 	/// </summary>
-	public readonly struct StreamPosition : IEquatable<StreamPosition>, IComparable<StreamPosition> {
+	public readonly struct StreamPosition : IEquatable<StreamPosition>, IComparable<StreamPosition>, IComparable {
 		private readonly ulong _value;
 
 		/// <summary>
@@ -57,6 +57,13 @@ namespace EventStore.Client {
 
 		/// <inheritdoc />
 		public int CompareTo(StreamPosition other) => _value.CompareTo(other._value);
+
+		/// <inheritdoc />
+		public int CompareTo(object? obj) => obj switch {
+			null => 1,
+			StreamPosition other => CompareTo(other),
+			_ => throw new ArgumentException("Object is not a StreamPosition"),
+		};
 
 		/// <inheritdoc />
 		public bool Equals(StreamPosition other) => _value == other._value;

--- a/src/EventStore.Client/StreamRevision.cs
+++ b/src/EventStore.Client/StreamRevision.cs
@@ -5,7 +5,7 @@ namespace EventStore.Client {
 	/// <summary>
 	/// A structure referring to the expected stream revision when writing to a stream.
 	/// </summary>
-	public readonly struct StreamRevision : IEquatable<StreamRevision>, IComparable<StreamRevision> {
+	public readonly struct StreamRevision : IEquatable<StreamRevision>, IComparable<StreamRevision>, IComparable {
 		private readonly ulong _value;
 
 		/// <summary>
@@ -52,6 +52,13 @@ namespace EventStore.Client {
 
 		/// <inheritdoc />
 		public int CompareTo(StreamRevision other) => _value.CompareTo(other._value);
+
+		/// <inheritdoc />
+		public int CompareTo(object? obj) => obj switch {
+			null => 1,
+			StreamRevision other => CompareTo(other),
+			_ => throw new ArgumentException("Object is not a StreamRevision"),
+		};
 
 		/// <inheritdoc />
 		public bool Equals(StreamRevision other) => _value == other._value;


### PR DESCRIPTION
This is required to satisfy the F# `comparison` constraint, and use comparison operators. Without this, `pos1 < pos2` doesn't compile in F#.