### PR TITLE
Fix EventStore.Client.update_non_existent.the_completion_fails_with_not_found test

### DIFF
--- a/test/EventStore.Client.PersistentSubscriptions.Tests/update_non_existient.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/update_non_existient.cs
@@ -15,7 +15,7 @@ namespace EventStore.Client {
 
 		[Fact]
 		public async Task the_completion_fails_with_not_found() {
-			await Assert.ThrowsAsync<InvalidOperationException>(
+			await Assert.ThrowsAsync<PersistentSubscriptionNotFoundException>(
 				() => _fixture.Client.UpdateAsync(Stream, Group,
 					new PersistentSubscriptionSettings(), TestCredentials.Root));
 		}


### PR DESCRIPTION
This is a breaking change introduced by https://github.com/EventStore/EventStore/pull/2933

It needs to be merged to master only if https://github.com/EventStore/EventStore/pull/2933 has been merged so that regression tests pass on this repository.