### PR TITLE
Update default persistent subscription settings to match TCP client

### DIFF
--- a/src/EventStore.Client.PersistentSubscriptions/PersistentSubscriptionSettings.cs
+++ b/src/EventStore.Client.PersistentSubscriptions/PersistentSubscriptionSettings.cs
@@ -89,8 +89,8 @@ namespace EventStore.Client {
 		/// <param name="namedConsumerStrategy"></param>
 		/// <exception cref="ArgumentOutOfRangeException"></exception>
 		public PersistentSubscriptionSettings(bool resolveLinkTos = false, IPosition? startFrom = null,
-			bool extraStatistics = false, TimeSpan? messageTimeout = null, int maxRetryCount = 500,
-			int liveBufferSize = 500, int readBatchSize = 10, int historyBufferSize = 20,
+			bool extraStatistics = false, TimeSpan? messageTimeout = null, int maxRetryCount = 10,
+			int liveBufferSize = 500, int readBatchSize = 20, int historyBufferSize = 500,
 			TimeSpan? checkPointAfter = null, int minCheckPointCount = 10, int maxCheckPointCount = 1000,
 			int maxSubscriberCount = 0, string namedConsumerStrategy = SystemConsumerStrategies.RoundRobin) {
 			messageTimeout ??= TimeSpan.FromSeconds(30);


### PR DESCRIPTION
I noticed that the defaults don't match the TCP client's while updating persistent subscription docs.

Change the defaults for the following settings when creating a Persistent Subscription:

- maxRetryCount: 10
- readBatchSize: 20
- historyBufferSize: 500

The Issue 1125 test fails with these new defaults. I've created an issue to investigate this here: https://github.com/EventStore/EventStore-Client-Dotnet/issues/139
