### PR TITLE
Improve Test Output for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       run: |
         ./gencert.sh
         dotnet test --configuration ${{ matrix.configuration }} --blame \
-          --logger:html --logger:trx --logger:"console;verbosity=normal" \
+          --logger:"GitHubActions;report-warnings=false" --logger:html --logger:trx --logger:"console;verbosity=normal" \
           --results-directory=$(pwd)/test-results/test/EventStore.Client${{ matrix.test }}.Tests \
           --framework ${{ matrix.framework }} \
           test/EventStore.Client${{ matrix.test }}.Tests

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -3,7 +3,9 @@
 	<ItemGroup>
 		<PackageReference Include="AutoFixture.Xunit2" Version="4.15.0" />
 		<PackageReference Include="Ductus.FluentDocker" Version="2.10.7" />
+		<PackageReference Include="GitHubActionsTestLogger" Version="1.2.0"/>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3"/>
+		<PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.8.3"/>
 		<PackageReference Include="Polly" Version="7.2.1" />
 		<PackageReference Include="Serilog" Version="2.10.0"/>
 		<PackageReference Include="Serilog.AspNetCore" Version="3.4.0"/>


### PR DESCRIPTION
Currently to see which tests failed in CI, you either need to search the build log or open the test results artifacts. This PR improves that situation by reporting test failures as annotations.