### PR TITLE
Improve cluster tests in preparation for batch appends

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -25,7 +25,7 @@
 		<Copyright>Copyright 2012-2020 Event Store Ltd</Copyright>
 		<MinVerTagPrefix>v</MinVerTagPrefix>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<GrpcPackageVersion>2.33.1</GrpcPackageVersion>
+		<GrpcPackageVersion>2.38.0</GrpcPackageVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<None Include="..\..\LICENSE.md" Pack="true" PackagePath="\"/>

--- a/test/EventStore.Client.Operations.Tests/EventStore.Client.Operations.Tests.csproj
+++ b/test/EventStore.Client.Operations.Tests/EventStore.Client.Operations.Tests.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\EventStore.Client.Operations\EventStore.Client.Operations.csproj" />
+		<ProjectReference Include="..\..\src\EventStore.Client.Streams\EventStore.Client.Streams.csproj" />
 		<ProjectReference Include="..\..\src\EventStore.Client.UserManagement\EventStore.Client.UserManagement.csproj" />
 	</ItemGroup>
 </Project>

--- a/test/EventStore.Client.Operations.Tests/EventStoreClientFixture.cs
+++ b/test/EventStore.Client.Operations.Tests/EventStoreClientFixture.cs
@@ -4,12 +4,19 @@ using System.Threading.Tasks;
 namespace EventStore.Client {
 	public abstract class EventStoreClientFixture : EventStoreClientFixtureBase {
 		public EventStoreOperationsClient Client { get; }
+		public EventStoreClient StreamsClient { get; }
 
 		protected EventStoreClientFixture(EventStoreClientSettings? settings = null) : base(settings) {
 			Client = new EventStoreOperationsClient(Settings);
+			StreamsClient = new EventStoreClient(Settings);
+		}
+
+		protected override async Task OnServerUpAsync() {
+			await StreamsClient.WarmUpAsync();
 		}
 
 		public override async Task DisposeAsync() {
+			await StreamsClient.DisposeAsync();
 			await Client.DisposeAsync();
 			await base.DisposeAsync();
 		}

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/EventStoreClientFixture.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/EventStoreClientFixture.cs
@@ -14,13 +14,11 @@ namespace EventStore.Client {
 			UserManagementClient = new EventStoreUserManagementClient(Settings);
 		}
 
-		public override async Task InitializeAsync() {
-			await TestServer.StartAsync().WithTimeout(TimeSpan.FromMinutes(5));
+		protected override async Task OnServerUpAsync() {
+			await StreamsClient.WarmUpAsync();
 			await UserManagementClient.CreateUserWithRetry(TestCredentials.TestUser1.Username!,
 				TestCredentials.TestUser1.Username!, Array.Empty<string>(), TestCredentials.TestUser1.Password!,
 				TestCredentials.Root);
-			await Given().WithTimeout(TimeSpan.FromMinutes(5));
-			await When().WithTimeout(TimeSpan.FromMinutes(5));
 		}
 
 		public override async Task DisposeAsync() {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/create_on_existing_stream.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/create_on_existing_stream.cs
@@ -14,8 +14,8 @@ namespace EventStore.Client.SubscriptionToStream {
 		public class Fixture : EventStoreClientFixture {
 			protected override Task Given() => Task.CompletedTask;
 
-			protected override Task When() =>
-				StreamsClient.AppendToStreamAsync(Stream, StreamState.Any, CreateTestEvents());
+			protected override async Task When() =>
+				await StreamsClient.AppendToStreamAsync(Stream, StreamState.Any, CreateTestEvents());
 		}
 
 		[Fact]

--- a/test/EventStore.Client.ProjectionManagement.Tests/EventStoreClientFixture.cs
+++ b/test/EventStore.Client.ProjectionManagement.Tests/EventStoreClientFixture.cs
@@ -22,8 +22,8 @@ namespace EventStore.Client {
 
 		protected virtual bool RunStandardProjections => true;
 
-		public override async Task InitializeAsync() {
-			await TestServer.StartAsync();
+		protected override async Task OnServerUpAsync() {
+			await StreamsClient.WarmUpAsync();
 			await UserManagementClient.CreateUserWithRetry(TestCredentials.TestUser1.Username!,
 				TestCredentials.TestUser1.Username!, Array.Empty<string>(), TestCredentials.TestUser1.Password!,
 				TestCredentials.Root).WithTimeout();
@@ -33,9 +33,6 @@ namespace EventStore.Client {
 				await Task.WhenAll(StandardProjections.Names.Select(name =>
 					Client.EnableAsync(name, TestCredentials.Root)));
 			}
-
-			await Given().WithTimeout(TimeSpan.FromMinutes(5));
-			await When().WithTimeout(TimeSpan.FromMinutes(5));
 		}
 
 		public override async Task DisposeAsync() {

--- a/test/EventStore.Client.Streams.Tests/EventStoreClientFixture.cs
+++ b/test/EventStore.Client.Streams.Tests/EventStoreClientFixture.cs
@@ -10,6 +10,10 @@ namespace EventStore.Client {
 			Client = new EventStoreClient(Settings);
 		}
 
+		protected override async Task OnServerUpAsync() {
+			await Client.WarmUpAsync();
+		}
+
 		public override async Task DisposeAsync() {
 			await Client.DisposeAsync();
 			await base.DisposeAsync();

--- a/test/EventStore.Client.Streams.Tests/Security/SecurityFixture.cs
+++ b/test/EventStore.Client.Streams.Tests/Security/SecurityFixture.cs
@@ -23,8 +23,8 @@ namespace EventStore.Client.Security {
 			UserManagementClient = new EventStoreUserManagementClient(Settings);
 		}
 
-		public override async Task InitializeAsync() {
-			await TestServer.StartAsync().WithTimeout(TimeSpan.FromMinutes(5));
+		protected override async Task OnServerUpAsync() {
+			await base.OnServerUpAsync();
 
 			await UserManagementClient.CreateUserWithRetry(TestCredentials.TestUser1.Username,
 				nameof(TestCredentials.TestUser1), Array.Empty<string>(), TestCredentials.TestUser1.Password,
@@ -37,9 +37,6 @@ namespace EventStore.Client.Security {
 			await UserManagementClient.CreateUserWithRetry(TestCredentials.TestAdmin.Username,
 				nameof(TestCredentials.TestAdmin), new[] {SystemRoles.Admins}, TestCredentials.TestAdmin.Password,
 				TestCredentials.Root).WithTimeout();
-
-			await Given().WithTimeout(TimeSpan.FromMinutes(10));
-			await When().WithTimeout(TimeSpan.FromMinutes(10));
 		}
 
 		protected override async Task Given() {

--- a/test/EventStore.Client.Tests.Common/EventStoreClientExtensions.cs
+++ b/test/EventStore.Client.Tests.Common/EventStoreClientExtensions.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Polly;
+
+#nullable enable
+namespace EventStore.Client {
+	public static class EventStoreClientExtensions {
+		public static async Task WarmUpAsync(this EventStoreClient self) {
+			// if we can read from $users then we know that 1. the users exist
+			// and 2. we are connected to leader if we require it
+			await Policy.Handle<Exception>()
+				.WaitAndRetryAsync(10, retryCount => TimeSpan.FromSeconds(2))
+				.ExecuteAsync(async () => {
+					var users = await self
+						.ReadStreamAsync(
+							Direction.Forwards,
+							"$users",
+							StreamPosition.Start,
+							userCredentials: TestCredentials.Root)
+						.ToArrayAsync();
+
+					if (users.Length == 0)
+						throw new Exception("no users yet");
+
+					// the read from leader above is not enough to garantee the next write goes to leader
+					await self.AppendToStreamAsync($"warmup", StreamState.Any, Enumerable.Empty<EventData>());
+				});
+		}
+	}
+}

--- a/test/EventStore.Client.Tests.Common/EventStoreClientFixtureBase.cs
+++ b/test/EventStore.Client.Tests.Common/EventStoreClientFixtureBase.cs
@@ -75,11 +75,19 @@ namespace EventStore.Client {
 
 			Settings.LoggerFactory ??= new SerilogLoggerFactory();
 
-			TestServer = GlobalEnvironment.UseCluster
-				? (IEventStoreTestServer)new EventStoreTestServerCluster(hostCertificatePath, Settings.ConnectivitySettings.Address, env)
-				: new EventStoreTestServer(hostCertificatePath, Settings.ConnectivitySettings.Address, env);
+			Settings.ConnectivitySettings.MaxDiscoverAttempts = 20;
+			Settings.ConnectivitySettings.DiscoveryInterval = TimeSpan.FromSeconds(1);
+
+			if (GlobalEnvironment.UseExternalServer) {
+				TestServer = new EventStoreTestServerExternal();
+			} else {
+				TestServer = GlobalEnvironment.UseCluster
+					? (IEventStoreTestServer)new EventStoreTestServerCluster(hostCertificatePath, Settings.ConnectivitySettings.Address, env)
+					: new EventStoreTestServer(hostCertificatePath, Settings.ConnectivitySettings.Address, env);
+			}
 		}
 
+		protected abstract Task OnServerUpAsync();
 		protected abstract Task Given();
 		protected abstract Task When();
 
@@ -97,6 +105,7 @@ namespace EventStore.Client {
 
 		public virtual async Task InitializeAsync() {
 			await TestServer.StartAsync().WithTimeout(TimeSpan.FromMinutes(5));
+			await OnServerUpAsync();
 			await Given().WithTimeout(TimeSpan.FromMinutes(5));
 			await When().WithTimeout(TimeSpan.FromMinutes(5));
 		}

--- a/test/EventStore.Client.Tests.Common/EventStoreTestServer.cs
+++ b/test/EventStore.Client.Tests.Common/EventStoreTestServer.cs
@@ -64,6 +64,8 @@ namespace EventStore.Client {
 				.WithName(ContainerName)
 				.MountVolume(_hostCertificatePath, "/etc/eventstore/certs", MountType.ReadOnly)
 				.ExposePort(2113, 2113)
+				//.KeepContainer()
+				//.KeepRunning()
 				.Build();
 		}
 
@@ -88,7 +90,7 @@ namespace EventStore.Client {
 			_eventStore.Start();
 			try {
 				await Policy.Handle<Exception>()
-					.WaitAndRetryAsync(5, retryCount => TimeSpan.FromSeconds(retryCount * retryCount))
+					.WaitAndRetryAsync(10, retryCount => TimeSpan.FromSeconds(2))
 					.ExecuteAsync(async () => {
 						using var response = await _httpClient.GetAsync("/health/live", cancellationToken);
 						if (response.StatusCode >= HttpStatusCode.BadRequest) {

--- a/test/EventStore.Client.Tests.Common/EventStoreTestServerExternal.cs
+++ b/test/EventStore.Client.Tests.Common/EventStoreTestServerExternal.cs
@@ -1,0 +1,21 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable
+namespace EventStore.Client {
+	public class EventStoreTestServerExternal : IEventStoreTestServer {
+		public EventStoreTestServerExternal() {
+		}
+
+		public ValueTask DisposeAsync() {
+			return new ValueTask(Task.CompletedTask);
+		}
+
+		public Task StartAsync(CancellationToken cancellationToken = default) {
+			return Task.CompletedTask;
+		}
+
+		public void Stop() {
+		}
+	}
+}

--- a/test/EventStore.Client.Tests.Common/GlobalEnvironment.cs
+++ b/test/EventStore.Client.Tests.Common/GlobalEnvironment.cs
@@ -10,9 +10,15 @@ namespace EventStore.Client {
 			if (bool.TryParse(useClusterEnvVar, out var useCluster)) {
 				UseCluster = useCluster;
 			}
+
+			var useExternalServerEnvVar = Environment.GetEnvironmentVariable(UseExternalServerName);
+			if (bool.TryParse(useExternalServerEnvVar, out var useExternalServer)) {
+				UseExternalServer = useExternalServer;
+			}
 		}
 
 		public static bool UseCluster { get; } = false;
+		public static bool UseExternalServer { get; } = false;
 		public static string ImageTag => GetEnvironmentVariable(ImageTagName, ImageTagDefault);
 		public static string DbLogFormat => GetEnvironmentVariable(DbLogFormatName, DbLogFormatDefault);
 
@@ -41,6 +47,7 @@ namespace EventStore.Client {
 		};
 
 		static string UseClusterName => "ES_USE_CLUSTER";
+		static string UseExternalServerName => "ES_USE_EXTERNAL_SERVER";
 		static string ImageTagName => "ES_DOCKER_TAG";
 		static string ImageTagDefault => "ci"; // e.g. "21.6.0-focal"
 		static string DbLogFormatName => "EVENTSTORE_DB_LOG_FORMAT";

--- a/test/EventStore.Client.Tests.Common/docker-compose.yml
+++ b/test/EventStore.Client.Tests.Common/docker-compose.yml
@@ -103,7 +103,7 @@ services:
       - EVENTSTORE_CERTIFICATE_FILE=/etc/eventstore/certs/node4/node.crt
       - EVENTSTORE_CERTIFICATE_PRIVATE_KEY_FILE=/etc/eventstore/certs/node4/node.key
       - EVENTSTORE_ADVERTISE_HOST_TO_CLIENT_AS=127.0.0.1
-      - EVENTSTORE_ADVERTISE_HTTP_PORT_TO_CLIENT_AS=2113
+      - EVENTSTORE_ADVERTISE_HTTP_PORT_TO_CLIENT_AS=2114
     ports:
       - 2114:2113
     networks:

--- a/test/EventStore.Client.UserManagement.Tests/EventStore.Client.UserManagement.Tests.csproj
+++ b/test/EventStore.Client.UserManagement.Tests/EventStore.Client.UserManagement.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<ItemGroup>
+		<ProjectReference Include="..\..\src\EventStore.Client.Streams\EventStore.Client.Streams.csproj" />
 		<ProjectReference Include="..\..\src\EventStore.Client.UserManagement\EventStore.Client.UserManagement.csproj" />
 	</ItemGroup>
 </Project>

--- a/test/EventStore.Client.UserManagement.Tests/EventStoreClientFixture.cs
+++ b/test/EventStore.Client.UserManagement.Tests/EventStoreClientFixture.cs
@@ -4,11 +4,18 @@ using System.Threading.Tasks;
 namespace EventStore.Client {
 	public abstract class EventStoreClientFixture : EventStoreClientFixtureBase {
 		public EventStoreUserManagementClient Client { get; }
+		public EventStoreClient StreamsClient { get; }
 		protected EventStoreClientFixture(EventStoreClientSettings? settings = null) : base(settings) {
 			Client = new EventStoreUserManagementClient(Settings);
+			StreamsClient = new EventStoreClient(Settings);
+		}
+
+		protected override async Task OnServerUpAsync() {
+			await StreamsClient.WarmUpAsync();
 		}
 
 		public override async Task DisposeAsync() {
+			await StreamsClient.DisposeAsync();
 			await Client.DisposeAsync();
 			await base.DisposeAsync();
 		}


### PR DESCRIPTION
- Environment variable to prevent spinning up a test server at all (for when you're running one already)
- Wait for $users stream before running tests
- Warm up the streams client to make sure it is connected to leader for both reads and writes
    (so that the tests themselves dont have to retry)
- Upgrade grpc