### PR TITLE
Properly cancel the subscription when disposing a subscription

### DIFF
--- a/src/EventStore.Client.Streams/StreamSubscription.cs
+++ b/src/EventStore.Client.Streams/StreamSubscription.cs
@@ -108,6 +108,7 @@ namespace EventStore.Client {
 
 			SubscriptionDropped(SubscriptionDroppedReason.Disposed);
 
+			_disposed.Cancel();
 			_disposed.Dispose();
 		}
 
@@ -172,6 +173,9 @@ namespace EventStore.Client {
 						return false;
 					}
 					if (!await _inner.MoveNextAsync().ConfigureAwait(false)) {
+						return false;
+					}
+					if (_cancellationToken.IsCancellationRequested) {
 						return false;
 					}
 


### PR DESCRIPTION
I noticed that when a `Subscription` is disposed, the cancellation token isn't cancelled, but only disposed. This causes any calls to the `.Token` property on it to throw `ObjectDisposedException`

Furthermore, when a subscription is disposed, the actual async reader connection to EventStore is still connected and waiting for the next message. Once one comes in, the code will end up throwing an exception (as it's trying to read the token), and logging that as an error, This can happen much later after the connection is disposed, if your server is not busy.

To patch this, I'm also checking if the token was cancelled After a new message is received. Without this call, this new event/checkpoint would raise an event from a disposed subscription, which is not something that should happen either.

With both of these patches, you can dispose a subscription and not get any exceptions (the subscription dropped event is still raised), and no more events/checkpoints will be raised from this subscription.

Ideally the connection to ES should be closed at this point, but when I called Dispose on the base stream, this ends up logging errors from the base Grpc code, which I'm trying to avoid too :) 