### PR TITLE
Update persistent subscriptions to minimum viable tier

### DIFF
--- a/samples/persistent-subscriptions/Program.cs
+++ b/samples/persistent-subscriptions/Program.cs
@@ -11,11 +11,19 @@ namespace persistent_subscriptions
 			    EventStoreClientSettings.Create("esdb://localhost:2113?tls=false")
 		    );
 		    await CreatePersistentSubscription(client);
+		    await UpdatePersistentSubscription(client);
 		    await ConnectToPersistentSubscriptionToStream(client);
 		    await CreatePersistentSubscriptionToAll(client);
 		    await ConnectToPersistentSubscriptionToAll(client);
 		    await ConnectToPersistentSubscriptionWithManualAcks(client);
-		    await UpdatePersistentSubscription(client);
+		    await GetPersistentSubscriptionToStreamInfo(client);
+		    await GetPersistentSubscriptionToAllInfo(client);
+		    await ReplayParkedToStream(client);
+		    await ReplayParkedToAll(client);
+		    await ListPersistentSubscriptionsToStream(client);
+		    await ListPersistentSubscriptionsToAll(client);
+		    await ListAllPersistentSubscriptions(client);
+		    await RestartPersistentSubscriptionSubsystem(client);
 		    await DeletePersistentSubscription(client);
 	    }
 
@@ -24,7 +32,7 @@ namespace persistent_subscriptions
 		    var userCredentials = new UserCredentials("admin", "changeit");
 
 		    var settings = new PersistentSubscriptionSettings();
-		    await client.CreateAsync(
+		    await client.CreateToStreamAsync(
 			    "test-stream",
 			    "subscription-group",
 			    settings,
@@ -97,7 +105,7 @@ namespace persistent_subscriptions
 			    resolveLinkTos: true,
 			    checkPointLowerBound: 20);
 
-		    await client.UpdateAsync(
+		    await client.UpdateToStreamAsync(
 			    "test-stream",
 			    "subscription-group",
 			    settings,
@@ -108,13 +116,115 @@ namespace persistent_subscriptions
 	    static async Task DeletePersistentSubscription(EventStorePersistentSubscriptionsClient client) {
 		    #region delete-persistent-subscription
 		    var userCredentials = new UserCredentials("admin", "changeit");
-		    await client.DeleteAsync(
+		    await client.DeleteToStreamAsync(
 			    "test-stream",
 			    "subscription-group",
 			    userCredentials: userCredentials);
 		    #endregion delete-persistent-subscription
 	    }
 
+	    static async Task GetPersistentSubscriptionToStreamInfo(EventStorePersistentSubscriptionsClient client) {
+		    #region get-persistent-subscription-to-stream-info
+
+		    var userCredentials = new UserCredentials("admin", "changeit");
+		    var info = await client.GetInfoToStreamAsync(
+			    "test-stream",
+			    "subscription-group",
+			    userCredentials: userCredentials);
+		    
+		    Console.WriteLine($"GroupName: {info.GroupName}, EventSource: {info.EventSource}, Status: {info.Status}");
+
+		    #endregion get-persistent-subscription-to-stream-info
+	    }
+	    
+	    static async Task GetPersistentSubscriptionToAllInfo(EventStorePersistentSubscriptionsClient client) {
+		    #region get-persistent-subscription-to-all-info
+
+		    var userCredentials = new UserCredentials("admin", "changeit");
+		    var info = await client.GetInfoToAllAsync(
+			    "subscription-group",
+			    userCredentials: userCredentials);
+		    
+		    Console.WriteLine($"GroupName: {info.GroupName}, EventSource: {info.EventSource}, Status: {info.Status}");
+
+		    #endregion get-persistent-subscription-to-all-info
+	    }
+	    
+	    static async Task ReplayParkedToStream(EventStorePersistentSubscriptionsClient client) {
+		    #region replay-parked-of-persistent-subscription-to-stream
+
+		    var userCredentials = new UserCredentials("admin", "changeit");
+		    await client.ReplayParkedMessagesToStreamAsync(
+			    "test-stream",
+			    "subscription-group",
+			    stopAt: 10,
+			    userCredentials: userCredentials);
+		    
+		    #endregion persistent-subscription-replay-parked-to-stream
+	    }
+	    
+	    static async Task ReplayParkedToAll(EventStorePersistentSubscriptionsClient client) {
+		    #region replay-parked-of-persistent-subscription-to-all
+
+		    var userCredentials = new UserCredentials("admin", "changeit");
+		    await client.ReplayParkedMessagesToAllAsync(
+			    "subscription-group",
+			    stopAt: 10,
+			    userCredentials: userCredentials);
+		    
+		    #endregion replay-parked-of-persistent-subscription-to-all
+	    }
+	    
+	    static async Task ListPersistentSubscriptionsToStream(EventStorePersistentSubscriptionsClient client) {
+		    #region list-persistent-subscriptions-to-stream
+
+		    var userCredentials = new UserCredentials("admin", "changeit");
+		    var subscriptions = await client.ListToStreamAsync(
+			    "test-stream",
+			    userCredentials: userCredentials);
+
+		    foreach (var s in subscriptions) {
+			    Console.WriteLine($"GroupName: {s.GroupName}, EventSource: {s.EventSource}, Status: {s.Status}");
+		    }
+		    
+		    #endregion list-persistent-subscriptions-to-stream
+	    }
+	    
+	    static async Task ListPersistentSubscriptionsToAll(EventStorePersistentSubscriptionsClient client) {
+		    #region list-persistent-subscriptions-to-all
+
+		    var userCredentials = new UserCredentials("admin", "changeit");
+		    var subscriptions = await client.ListToAllAsync(userCredentials: userCredentials);
+
+		    foreach (var s in subscriptions) {
+			    Console.WriteLine($"GroupName: {s.GroupName}, EventSource: {s.EventSource}, Status: {s.Status}");
+		    }
+		    
+		    #endregion list-persistent-subscriptions-to-all
+	    }
+	    
+	    static async Task ListAllPersistentSubscriptions(EventStorePersistentSubscriptionsClient client) {
+		    #region list-persistent-subscriptions
+
+		    var userCredentials = new UserCredentials("admin", "changeit");
+		    var subscriptions = await client.ListAllAsync(userCredentials: userCredentials);
+
+		    foreach (var s in subscriptions) {
+			    Console.WriteLine($"GroupName: {s.GroupName}, EventSource: {s.EventSource}, Status: {s.Status}");
+		    }
+		    
+		    #endregion list-persistent-subscriptions
+	    }
+	    
+	    static async Task RestartPersistentSubscriptionSubsystem(EventStorePersistentSubscriptionsClient client) {
+		    #region restart-persistent-subscription-subsystem
+
+		    var userCredentials = new UserCredentials("admin", "changeit");
+		    await client.RestartSubsystemAsync(userCredentials: userCredentials);
+
+		    #endregion restart-persistent-subscription-subsystem
+	    }
+	    
 	    static Task HandleEvent(ResolvedEvent evnt) {
 		    return Task.CompletedTask;
 	    }

--- a/src/EventStore.Client.Common/protos/persistentsubscriptions.proto
+++ b/src/EventStore.Client.Common/protos/persistentsubscriptions.proto
@@ -9,6 +9,10 @@ service PersistentSubscriptions {
 	rpc Update (UpdateReq) returns (UpdateResp);
 	rpc Delete (DeleteReq) returns (DeleteResp);
 	rpc Read (stream ReadReq) returns (stream ReadResp);
+	rpc GetInfo (GetInfoReq) returns (GetInfoResp);
+	rpc ReplayParked (ReplayParkedReq) returns (ReplayParkedResp);
+	rpc List (ListReq) returns (ListResp);
+	rpc RestartSubsystem (event_store.client.Empty) returns (event_store.client.Empty);
 }
 
 message ReadReq {
@@ -155,7 +159,7 @@ message CreateReq {
 		int32 live_buffer_size = 10;
 		int32 read_batch_size = 11;
 		int32 history_buffer_size = 12;
-		ConsumerStrategy named_consumer_strategy = 13;
+		ConsumerStrategy named_consumer_strategy = 13 [deprecated = true];
 		oneof message_timeout {
 			int64 message_timeout_ticks = 4;
 			int32 message_timeout_ms = 14;
@@ -164,6 +168,7 @@ message CreateReq {
 			int64 checkpoint_after_ticks = 6;
 			int32 checkpoint_after_ms = 15;
 		}
+		string consumer_strategy = 16;
 	}
 
 	enum ConsumerStrategy {
@@ -257,4 +262,109 @@ message DeleteReq {
 }
 
 message DeleteResp {
+}
+
+message GetInfoReq {
+	Options options = 1;
+
+	message Options {
+		oneof stream_option {
+			event_store.client.StreamIdentifier stream_identifier = 1;
+			event_store.client.Empty all = 2;
+		}
+
+		string group_name = 3;
+	}
+}
+
+message GetInfoResp {
+	SubscriptionInfo subscription_info = 1;
+}
+
+message SubscriptionInfo {
+	string event_source = 1;
+	string group_name = 2;
+	string status = 3;
+	repeated ConnectionInfo connections = 4;
+	int32 average_per_second = 5;
+	int64 total_items = 6;
+	int64 count_since_last_measurement = 7;
+	string last_checkpointed_event_position = 8;
+	string last_known_event_position = 9;
+	bool resolve_link_tos = 10;
+	string start_from = 11;
+	int32 message_timeout_milliseconds = 12;
+	bool extra_statistics = 13;
+	int32 max_retry_count = 14;
+	int32 live_buffer_size = 15;
+	int32 buffer_size = 16;
+	int32 read_batch_size = 17;
+	int32 check_point_after_milliseconds = 18;
+	int32 min_check_point_count = 19;
+	int32 max_check_point_count = 20;
+	int32 read_buffer_count = 21;
+	int64 live_buffer_count = 22;
+	int32 retry_buffer_count = 23;
+	int32 total_in_flight_messages = 24;
+	int32 outstanding_messages_count = 25;
+	string named_consumer_strategy = 26;
+	int32 max_subscriber_count = 27;
+	int64 parked_message_count = 28;
+
+	message ConnectionInfo {
+		string from = 1;
+		string username = 2;
+		int32 average_items_per_second = 3;
+		int64 total_items = 4;
+		int64 count_since_last_measurement = 5;
+		repeated Measurement observed_measurements = 6;
+		int32 available_slots = 7;
+		int32 in_flight_messages = 8;
+		string connection_name = 9;
+	}
+
+	message Measurement {
+		string key = 1;
+		int64 value = 2;
+	}
+}
+
+message ReplayParkedReq {
+	Options options = 1;
+
+	message Options {
+		string group_name = 1;
+		oneof stream_option {
+			event_store.client.StreamIdentifier stream_identifier = 2;
+			event_store.client.Empty all = 3;
+		}
+		oneof stop_at_option {
+			int64 stop_at = 4;
+			event_store.client.Empty no_limit = 5;
+		}
+	}
+}
+
+message ReplayParkedResp {
+}
+
+message ListReq {
+	Options options = 1;
+
+	message Options {
+		oneof list_option {
+			event_store.client.Empty list_all_subscriptions = 1;
+			StreamOption list_for_stream = 2;
+		}
+	}
+	message StreamOption {
+		oneof stream_option {
+			event_store.client.StreamIdentifier stream = 1;
+			event_store.client.Empty all = 2;
+		}
+	}
+}
+
+message ListResp {
+	repeated SubscriptionInfo subscriptions = 1;
 }

--- a/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClient.Delete.cs
+++ b/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClient.Delete.cs
@@ -8,13 +8,15 @@ namespace EventStore.Client {
 		/// <summary>
 		/// Deletes a persistent subscription.
 		/// </summary>
-		/// <param name="streamName"></param>
-		/// <param name="groupName"></param>
-		/// <param name="deadline"></param>
-		/// <param name="userCredentials"></param>
-		/// <param name="cancellationToken"></param>
-		/// <returns></returns>
-		public async Task DeleteAsync(string streamName, string groupName, TimeSpan? deadline = null,
+		[Obsolete("DeleteAsync is no longer supported. Use DeleteToStreamAsync instead.", false)]
+		public Task DeleteAsync(string streamName, string groupName, TimeSpan? deadline = null,
+			UserCredentials? userCredentials = null, CancellationToken cancellationToken = default) =>
+			DeleteToStreamAsync(streamName, groupName, deadline, userCredentials, cancellationToken);
+
+		/// <summary>
+		/// Deletes a persistent subscription.
+		/// </summary>
+		public async Task DeleteToStreamAsync(string streamName, string groupName, TimeSpan? deadline = null,
 			UserCredentials? userCredentials = null, CancellationToken cancellationToken = default) {
 			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
 
@@ -45,14 +47,9 @@ namespace EventStore.Client {
 		/// <summary>
 		/// Deletes a persistent subscription to $all.
 		/// </summary>
-		/// <param name="groupName"></param>
-		/// <param name="deadline"></param>
-		/// <param name="userCredentials"></param>
-		/// <param name="cancellationToken"></param>
-		/// <returns></returns>
 		public async Task DeleteToAllAsync(string groupName, TimeSpan? deadline = null,
 			UserCredentials? userCredentials = null, CancellationToken cancellationToken = default) =>
-			await DeleteAsync(SystemStreams.AllStream, groupName, deadline, userCredentials, cancellationToken)
+			await DeleteToStreamAsync(SystemStreams.AllStream, groupName, deadline, userCredentials, cancellationToken)
 				.ConfigureAwait(false);
 	}
 }

--- a/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClient.Info.cs
+++ b/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClient.Info.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Client.PersistentSubscriptions;
+using Grpc.Core;
+
+#nullable enable
+namespace EventStore.Client {
+	partial class EventStorePersistentSubscriptionsClient {
+		/// <summary>
+		/// Gets the status of a persistent subscription to $all
+		/// </summary>
+		public async Task<PersistentSubscriptionInfo> GetInfoToAllAsync(string groupName, TimeSpan? deadline = null,
+			UserCredentials? userCredentials = null, CancellationToken cancellationToken = default) {
+
+			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
+			if (channelInfo.ServerCapabilities.SupportsPersistentSubscriptionsGetInfo) {
+				var req = new GetInfoReq() {
+					Options = new GetInfoReq.Types.Options{
+						GroupName = groupName,
+						All = new Empty()
+					}
+				};
+
+				return await GetInfoGrpcAsync(req, deadline, userCredentials, channelInfo.CallInvoker, cancellationToken)
+					.ConfigureAwait(false);
+			}
+
+			throw new NotSupportedException("The server does not support getting persistent subscription details for $all");
+		}
+
+		/// <summary>
+		/// Gets the status of a persistent subscription to a stream
+		/// </summary>
+		public async Task<PersistentSubscriptionInfo> GetInfoToStreamAsync(string streamName, string groupName,
+			TimeSpan? deadline = null, UserCredentials? userCredentials = null, CancellationToken cancellationToken = default) {
+
+			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
+			if (channelInfo.ServerCapabilities.SupportsPersistentSubscriptionsGetInfo) {
+				var req = new GetInfoReq() {
+					Options = new GetInfoReq.Types.Options {
+						GroupName = groupName,
+						StreamIdentifier = streamName
+					}
+				};
+			
+				return await GetInfoGrpcAsync(req, deadline, userCredentials, channelInfo.CallInvoker, cancellationToken)
+					.ConfigureAwait(false);
+			}
+
+			return await GetInfoHttpAsync(streamName, groupName, channelInfo, deadline, userCredentials, cancellationToken)
+				.ConfigureAwait(false);
+		}
+		
+		private async Task<PersistentSubscriptionInfo> GetInfoGrpcAsync(GetInfoReq req, TimeSpan? deadline,
+			UserCredentials? userCredentials, CallInvoker callInvoker, CancellationToken cancellationToken) {
+			
+			var result = await new PersistentSubscriptions.PersistentSubscriptions.PersistentSubscriptionsClient(callInvoker)
+				.GetInfoAsync(req, EventStoreCallOptions.CreateNonStreaming(Settings, deadline, userCredentials, cancellationToken))
+				.ConfigureAwait(false);
+			
+			return PersistentSubscriptionInfo.From(result.SubscriptionInfo);
+		}
+
+		private async Task<PersistentSubscriptionInfo> GetInfoHttpAsync(string streamName, string groupName,
+			ChannelInfo channelInfo, TimeSpan? deadline, UserCredentials? userCredentials, CancellationToken cancellationToken) {
+			
+			var path = $"/subscriptions/{UrlEncode(streamName)}/{UrlEncode(groupName)}/info";
+			var result = await HttpGet<PersistentSubscriptionDto>(path,
+					onNotFound: () => throw new PersistentSubscriptionNotFoundException(streamName, groupName),
+					channelInfo, deadline, userCredentials, cancellationToken)
+				.ConfigureAwait(false);
+			
+			return PersistentSubscriptionInfo.From(result);
+		}
+	}
+}

--- a/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClient.List.cs
+++ b/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClient.List.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Client.PersistentSubscriptions;
+using Grpc.Core;
+
+#nullable enable
+namespace EventStore.Client {
+	partial class EventStorePersistentSubscriptionsClient {
+		/// <summary>
+		/// Lists persistent subscriptions to $all.
+		/// </summary>
+		public async Task<IEnumerable<PersistentSubscriptionInfo>> ListToAllAsync(TimeSpan? deadline = null,
+			UserCredentials? userCredentials = null, CancellationToken cancellationToken = default) {
+			
+			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
+			if (channelInfo.ServerCapabilities.SupportsPersistentSubscriptionsList) {
+				var req = new ListReq() {
+					Options = new ListReq.Types.Options{
+						ListForStream = new ListReq.Types.StreamOption() {
+							All = new Empty()
+						}
+					}
+				};
+
+				return await ListGrpcAsync(req, deadline, userCredentials, channelInfo.CallInvoker, cancellationToken)
+					.ConfigureAwait(false);
+			}
+			
+			throw new NotSupportedException("The server does not support listing the persistent subscriptions.");
+		}
+
+		/// <summary>
+		/// Lists persistent subscriptions to the specified stream.
+		/// </summary>
+		public async Task<IEnumerable<PersistentSubscriptionInfo>> ListToStreamAsync(string streamName, TimeSpan? deadline = null,
+			UserCredentials? userCredentials = null, CancellationToken cancellationToken = default) {
+
+			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
+			if (channelInfo.ServerCapabilities.SupportsPersistentSubscriptionsList) {
+				var req = new ListReq() {
+					Options = new ListReq.Types.Options {
+						ListForStream = new ListReq.Types.StreamOption() {
+							Stream = streamName
+						}
+					}
+				};
+				
+				return await ListGrpcAsync(req, deadline, userCredentials, channelInfo.CallInvoker, cancellationToken)
+					.ConfigureAwait(false);
+			}
+			
+			return await ListHttpAsync(streamName, channelInfo, deadline, userCredentials, cancellationToken)
+				.ConfigureAwait(false);
+		}
+
+		/// <summary>
+		/// Lists all persistent subscriptions.
+		/// </summary>
+		public async Task<IEnumerable<PersistentSubscriptionInfo>> ListAllAsync(TimeSpan? deadline = null,
+			UserCredentials? userCredentials = null, CancellationToken cancellationToken = default) {
+
+			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
+			if (channelInfo.ServerCapabilities.SupportsPersistentSubscriptionsList) {
+				var req = new ListReq() {
+					Options = new ListReq.Types.Options {
+						ListAllSubscriptions = new Empty()
+					}
+				};
+				
+				return await ListGrpcAsync(req, deadline, userCredentials, channelInfo.CallInvoker, cancellationToken)
+					.ConfigureAwait(false);
+			}
+
+			try {
+				var result = await HttpGet<IList<PersistentSubscriptionDto>>("/subscriptions",
+						onNotFound: () => throw new PersistentSubscriptionNotFoundException(string.Empty, string.Empty),
+						channelInfo, deadline, userCredentials, cancellationToken)
+					.ConfigureAwait(false);
+
+				return result.Select(PersistentSubscriptionInfo.From);
+			} catch (AccessDeniedException ex) when (userCredentials != null) { // Required to get same gRPC behavior.
+				throw new NotAuthenticatedException(ex.Message, ex);
+			}
+		}
+		
+		private async Task<IEnumerable<PersistentSubscriptionInfo>> ListGrpcAsync(ListReq req, TimeSpan? deadline,
+			UserCredentials? userCredentials, CallInvoker callInvoker, CancellationToken cancellationToken) {
+			
+			using var call = new PersistentSubscriptions.PersistentSubscriptions.PersistentSubscriptionsClient(callInvoker)
+				.ListAsync(req, EventStoreCallOptions.CreateNonStreaming(Settings, deadline, userCredentials, cancellationToken));
+
+			ListResp? response = await call.ResponseAsync.ConfigureAwait(false);
+
+			return response.Subscriptions.Select(PersistentSubscriptionInfo.From);
+		}
+		
+		private async Task<IEnumerable<PersistentSubscriptionInfo>> ListHttpAsync(string streamName,
+			ChannelInfo channelInfo, TimeSpan? deadline, UserCredentials? userCredentials, CancellationToken cancellationToken) {
+
+			var path = $"/subscriptions/{UrlEncode(streamName)}";
+			var result = await HttpGet<IList<PersistentSubscriptionDto>>(path,
+					onNotFound: () => throw new PersistentSubscriptionNotFoundException(streamName, string.Empty),
+					channelInfo, deadline, userCredentials, cancellationToken)
+				.ConfigureAwait(false);
+			return result.Select(PersistentSubscriptionInfo.From);
+		}
+	}
+}

--- a/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClient.Read.cs
+++ b/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClient.Read.cs
@@ -8,15 +8,6 @@ namespace EventStore.Client {
 		/// <summary>
 		/// Subscribes to a persistent subscription.
 		/// </summary>
-		/// <param name="streamName"></param>
-		/// <param name="groupName"></param>
-		/// <param name="eventAppeared"></param>
-		/// <param name="subscriptionDropped"></param>
-		/// <param name="userCredentials"></param>
-		/// <param name="bufferSize"></param>
-		/// <param name="autoAck"></param>
-		/// <param name="cancellationToken"></param>
-		/// <returns></returns>
 		/// <exception cref="ArgumentNullException"></exception>
 		/// <exception cref="ArgumentException"></exception>
 		/// <exception cref="ArgumentOutOfRangeException"></exception>
@@ -38,14 +29,6 @@ namespace EventStore.Client {
 		/// <summary>
 		/// Subscribes to a persistent subscription. Messages must be manually acknowledged
 		/// </summary>
-		/// <param name="streamName"></param>
-		/// <param name="groupName"></param>
-		/// <param name="eventAppeared"></param>
-		/// <param name="subscriptionDropped"></param>
-		/// <param name="userCredentials"></param>
-		/// <param name="bufferSize"></param>
-		/// <param name="cancellationToken"></param>
-		/// <returns></returns>
 		/// <exception cref="ArgumentNullException"></exception>
 		/// <exception cref="ArgumentException"></exception>
 		/// <exception cref="ArgumentOutOfRangeException"></exception>
@@ -104,13 +87,6 @@ namespace EventStore.Client {
 		/// <summary>
 		/// Subscribes to a persistent subscription to $all. Messages must be manually acknowledged
 		/// </summary>
-		/// <param name="groupName"></param>
-		/// <param name="eventAppeared"></param>
-		/// <param name="subscriptionDropped"></param>
-		/// <param name="userCredentials"></param>
-		/// <param name="bufferSize"></param>
-		/// <param name="cancellationToken"></param>
-		/// <returns></returns>
 		public async Task<PersistentSubscription> SubscribeToAllAsync(string groupName,
 			Func<PersistentSubscription, ResolvedEvent, int?, CancellationToken, Task> eventAppeared,
 			Action<PersistentSubscription, SubscriptionDroppedReason, Exception?>? subscriptionDropped = null,

--- a/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClient.ReplayParked.cs
+++ b/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClient.ReplayParked.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Client.PersistentSubscriptions;
+using Grpc.Core;
+using NotSupportedException = System.NotSupportedException;
+
+#nullable enable
+namespace EventStore.Client {
+	partial class EventStorePersistentSubscriptionsClient {
+		/// <summary>
+		/// Retry the parked messages of the persistent subscription
+		/// </summary>
+		public async Task ReplayParkedMessagesToAllAsync(string groupName, long? stopAt = null, TimeSpan? deadline = null,
+			UserCredentials? userCredentials = null, CancellationToken cancellationToken = default) {
+
+			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
+			if (channelInfo.ServerCapabilities.SupportsPersistentSubscriptionsReplayParked) {
+				var req = new ReplayParkedReq() {
+					Options = new ReplayParkedReq.Types.Options{
+						GroupName = groupName,
+						All = new Empty()
+					},
+				};
+
+				await ReplayParkedGrpcAsync(req, stopAt, deadline, userCredentials, channelInfo.CallInvoker, cancellationToken)
+					.ConfigureAwait(false);
+				
+				return;
+			}
+
+			if (channelInfo.ServerCapabilities.SupportsPersistentSubscriptionsToAll) {
+				await ReplayParkedHttpAsync(SystemStreams.AllStream, groupName, stopAt, channelInfo,
+						deadline, userCredentials, cancellationToken)
+					.ConfigureAwait(false);
+				
+				return;
+			}
+			
+			throw new NotSupportedException("The server does not support persistent subscriptions to $all.");
+		}
+
+		/// <summary>
+		/// Retry the parked messages of the persistent subscription
+		/// </summary>
+		public async Task ReplayParkedMessagesToStreamAsync(string streamName, string groupName, long? stopAt=null,
+			TimeSpan? deadline=null, UserCredentials? userCredentials=null, CancellationToken cancellationToken=default) {
+
+			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
+			if (channelInfo.ServerCapabilities.SupportsPersistentSubscriptionsReplayParked) {
+				var req = new ReplayParkedReq() {
+					Options = new ReplayParkedReq.Types.Options {
+						GroupName = groupName,
+						StreamIdentifier = streamName
+					},
+				};
+			
+				await ReplayParkedGrpcAsync(req, stopAt, deadline, userCredentials, channelInfo.CallInvoker, cancellationToken)
+					.ConfigureAwait(false);
+				
+				return;
+			}
+			
+			await ReplayParkedHttpAsync(streamName, groupName, stopAt, channelInfo, deadline, userCredentials, cancellationToken)
+				.ConfigureAwait(false);
+		}
+		
+		private async Task ReplayParkedGrpcAsync(ReplayParkedReq req, long? numberOfEvents, TimeSpan? deadline,
+			UserCredentials? userCredentials, CallInvoker callInvoker, CancellationToken cancellationToken) {
+
+			if (numberOfEvents.HasValue) {
+				req.Options.StopAt = numberOfEvents.Value;
+			} else {
+				req.Options.NoLimit = new Empty();	
+			}
+
+			await new PersistentSubscriptions.PersistentSubscriptions.PersistentSubscriptionsClient(callInvoker)
+				.ReplayParkedAsync(req, EventStoreCallOptions.CreateNonStreaming(Settings, deadline, userCredentials, cancellationToken))
+				.ConfigureAwait(false);
+		}
+		
+		private async Task ReplayParkedHttpAsync(string streamName, string groupName, long? numberOfEvents,
+			ChannelInfo channelInfo, TimeSpan? deadline, UserCredentials? userCredentials, CancellationToken cancellationToken) {
+
+			var path = $"/subscriptions/{UrlEncode(streamName)}/{UrlEncode(groupName)}/replayParked";
+			var query = numberOfEvents.HasValue ? $"stopAt={numberOfEvents.Value}":"";
+
+			await HttpPost(path, query,
+					onNotFound: () => throw new PersistentSubscriptionNotFoundException(streamName, groupName),
+					channelInfo, deadline, userCredentials, cancellationToken)
+				.ConfigureAwait(false);
+		}
+	}
+}

--- a/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClient.RestartSubsystem.cs
+++ b/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClient.RestartSubsystem.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable
+namespace EventStore.Client {
+	partial class EventStorePersistentSubscriptionsClient {
+		/// <summary>
+		/// Restarts the persistent subscriptions subsystem.
+		/// </summary>
+		public async Task RestartSubsystemAsync(TimeSpan? deadline = null, UserCredentials? userCredentials = null,
+			CancellationToken cancellationToken = default) {
+			
+			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
+			if (channelInfo.ServerCapabilities.SupportsPersistentSubscriptionsRestartSubsystem) {
+				await new PersistentSubscriptions.PersistentSubscriptions.PersistentSubscriptionsClient(channelInfo.CallInvoker)
+					.RestartSubsystemAsync(new Empty(), EventStoreCallOptions
+						.CreateNonStreaming(Settings, deadline, userCredentials, cancellationToken))
+					.ConfigureAwait(false);
+				return;
+			}
+
+			await HttpPost(
+				path: "/subscriptions/restart",
+				query: "",
+				onNotFound: () =>
+					throw new Exception("Unexpected exception while restarting the persistent subscription subsystem."),
+				channelInfo, deadline, userCredentials, cancellationToken)
+			.ConfigureAwait(false);
+		}
+	}
+}

--- a/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClient.Update.cs
+++ b/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClient.Update.cs
@@ -60,15 +60,18 @@ namespace EventStore.Client {
 		/// <summary>
 		/// Updates a persistent subscription.
 		/// </summary>
-		/// <param name="streamName"></param>
-		/// <param name="groupName"></param>
-		/// <param name="settings"></param>
-		/// <param name="deadline"></param>
-		/// <param name="userCredentials"></param>
-		/// <param name="cancellationToken"></param>
-		/// <returns></returns>
 		/// <exception cref="ArgumentNullException"></exception>
-		public async Task UpdateAsync(string streamName, string groupName, PersistentSubscriptionSettings settings,
+		[Obsolete("UpdateAsync is no longer supported. Use UpdateToStreamAsync instead.", false)]
+		public Task UpdateAsync(string streamName, string groupName, PersistentSubscriptionSettings settings,
+			TimeSpan? deadline = null, UserCredentials? userCredentials = null,
+			CancellationToken cancellationToken = default) => 
+			UpdateToStreamAsync(streamName, groupName, settings, deadline, userCredentials, cancellationToken);
+
+		/// <summary>
+		/// Updates a persistent subscription.
+		/// </summary>
+		/// <exception cref="ArgumentNullException"></exception>
+		public async Task UpdateToStreamAsync(string streamName, string groupName, PersistentSubscriptionSettings settings,
 			TimeSpan? deadline = null, UserCredentials? userCredentials = null,
 			CancellationToken cancellationToken = default) {
 			if (streamName == null) {
@@ -148,16 +151,10 @@ namespace EventStore.Client {
 		/// <summary>
 		/// Updates a persistent subscription to $all.
 		/// </summary>
-		/// <param name="groupName"></param>
-		/// <param name="settings"></param>
-		/// <param name="deadline"></param>
-		/// <param name="userCredentials"></param>
-		/// <param name="cancellationToken"></param>
-		/// <returns></returns>
 		public async Task UpdateToAllAsync(string groupName, PersistentSubscriptionSettings settings,
 			TimeSpan? deadline = null, UserCredentials? userCredentials = null,
 			CancellationToken cancellationToken = default) =>
-			await UpdateAsync(SystemStreams.AllStream, groupName, settings, deadline, userCredentials,
+			await UpdateToStreamAsync(SystemStreams.AllStream, groupName, settings, deadline, userCredentials,
 					cancellationToken)
 				.ConfigureAwait(false);
 	}

--- a/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClient.cs
+++ b/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Encodings.Web;
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -15,13 +16,12 @@ namespace EventStore.Client {
 		/// <summary>
 		/// Constructs a new <see cref="EventStorePersistentSubscriptionsClient"/>.
 		/// </summary>
-		/// <param name="settings"></param>
 		public EventStorePersistentSubscriptionsClient(EventStoreClientSettings? settings) : base(settings,
 			new Dictionary<string, Func<RpcException, Exception>> {
 				[Constants.Exceptions.PersistentSubscriptionDoesNotExist] = ex => new
 					PersistentSubscriptionNotFoundException(
 						ex.Trailers.First(x => x.Key == Constants.Exceptions.StreamName).Value,
-						ex.Trailers.First(x => x.Key == Constants.Exceptions.GroupName).Value, ex),
+						ex.Trailers.FirstOrDefault(x => x.Key == Constants.Exceptions.GroupName)?.Value ?? "", ex),
 				[Constants.Exceptions.MaximumSubscribersReached] = ex => new
 					MaximumSubscribersReachedException(
 						ex.Trailers.First(x => x.Key == Constants.Exceptions.StreamName).Value,
@@ -33,6 +33,10 @@ namespace EventStore.Client {
 			}) {
 			_log = Settings.LoggerFactory?.CreateLogger<EventStorePersistentSubscriptionsClient>()
 			       ?? new NullLogger<EventStorePersistentSubscriptionsClient>();
+		}
+		
+		private static string UrlEncode(string s) {
+			return UrlEncoder.Default.Encode(s);
 		}
 	}
 }

--- a/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClientCollectionExtensions.cs
+++ b/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClientCollectionExtensions.cs
@@ -15,10 +15,6 @@ namespace Microsoft.Extensions.DependencyInjection {
 		/// <summary>
 		/// Adds an <see cref="EventStorePersistentSubscriptionsClient"/> to the <see cref="IServiceCollection"/>.
 		/// </summary>
-		/// <param name="services"></param>
-		/// <param name="address"></param>
-		/// <param name="createHttpMessageHandler"></param>
-		/// <returns></returns>
 		/// <exception cref="ArgumentNullException"></exception>
 		public static IServiceCollection AddEventStorePersistentSubscriptionsClient(this IServiceCollection services,
 			Uri address, Func<HttpMessageHandler>? createHttpMessageHandler = null)
@@ -30,9 +26,6 @@ namespace Microsoft.Extensions.DependencyInjection {
 		/// <summary>
 		/// Adds an <see cref="EventStorePersistentSubscriptionsClient"/> to the <see cref="IServiceCollection"/>.
 		/// </summary>
-		/// <param name="services"></param>
-		/// <param name="configureSettings"></param>
-		/// <returns></returns>
 		/// <exception cref="ArgumentNullException"></exception>
 		public static IServiceCollection AddEventStorePersistentSubscriptionsClient(this IServiceCollection services,
 			Action<EventStoreClientSettings>? configureSettings = null) =>
@@ -42,10 +35,6 @@ namespace Microsoft.Extensions.DependencyInjection {
 		/// <summary>
 		/// Adds an <see cref="EventStorePersistentSubscriptionsClient"/> to the <see cref="IServiceCollection"/>.
 		/// </summary>
-		/// <param name="services"></param>
-		/// <param name="connectionString"></param>
-		/// <param name="configureSettings"></param>
-		/// <returns></returns>
 		/// <exception cref="ArgumentNullException"></exception>
 		public static IServiceCollection AddEventStorePersistentSubscriptionsClient(this IServiceCollection services,
 			string connectionString, Action<EventStoreClientSettings>? configureSettings = null) =>

--- a/src/EventStore.Client.PersistentSubscriptions/MaximumSubscribersReachedException.cs
+++ b/src/EventStore.Client.PersistentSubscriptions/MaximumSubscribersReachedException.cs
@@ -17,9 +17,6 @@ namespace EventStore.Client {
 		/// <summary>
 		/// Constructs a new <see cref="MaximumSubscribersReachedException"/>.
 		/// </summary>
-		/// <param name="streamName"></param>
-		/// <param name="groupName"></param>
-		/// <param name="exception"></param>
 		/// <exception cref="ArgumentNullException"></exception>
 		public MaximumSubscribersReachedException(string streamName, string groupName, Exception? exception = null)
 			: base($"Maximum subscriptions reached for subscription group '{groupName}' on stream '{streamName}.'",

--- a/src/EventStore.Client.PersistentSubscriptions/PersistentSubscription.cs
+++ b/src/EventStore.Client.PersistentSubscriptions/PersistentSubscription.cs
@@ -113,7 +113,6 @@ namespace EventStore.Client {
 		/// <param name="action">The <see cref="PersistentSubscriptionNakEventAction"/> to take.</param>
 		/// <param name="reason">A reason given.</param>
 		/// <param name="eventIds">The <see cref="Uuid"/> of the <see cref="ResolvedEvent" />s to nak. There should not be more than 2000 to nak at a time.</param>
-		/// <returns></returns>
 		/// <exception cref="ArgumentException">The number of eventIds exceeded the limit of 2000.</exception>
 		public Task Nack(PersistentSubscriptionNakEventAction action, string reason, params Uuid[] eventIds) {
 			if (eventIds.Length > 2000) {
@@ -129,7 +128,6 @@ namespace EventStore.Client {
 		/// <param name="action">The <see cref="PersistentSubscriptionNakEventAction"/> to take.</param>
 		/// <param name="reason">A reason given.</param>
 		/// <param name="resolvedEvents">The <see cref="ResolvedEvent" />s to nak. There should not be more than 2000 to nak at a time.</param>
-		/// <returns></returns>
 		/// <exception cref="ArgumentException">The number of resolvedEvents exceeded the limit of 2000.</exception>
 		public Task Nack(PersistentSubscriptionNakEventAction action, string reason,
 			params ResolvedEvent[] resolvedEvents) =>

--- a/src/EventStore.Client.PersistentSubscriptions/PersistentSubscriptionDroppedByServerException.cs
+++ b/src/EventStore.Client.PersistentSubscriptions/PersistentSubscriptionDroppedByServerException.cs
@@ -18,9 +18,6 @@ namespace EventStore.Client {
 		/// <summary>
 		/// Constructs a new <see cref="PersistentSubscriptionDroppedByServerException"/>.
 		/// </summary>
-		/// <param name="streamName"></param>
-		/// <param name="groupName"></param>
-		/// <param name="exception"></param>
 		/// <exception cref="ArgumentNullException"></exception>
 		public PersistentSubscriptionDroppedByServerException(string streamName, string groupName,
 			Exception? exception = null)

--- a/src/EventStore.Client.PersistentSubscriptions/PersistentSubscriptionExtraStatistic.cs
+++ b/src/EventStore.Client.PersistentSubscriptions/PersistentSubscriptionExtraStatistic.cs
@@ -1,0 +1,23 @@
+﻿namespace EventStore.Client;
+
+/// <summary>
+/// Provides the definitions of the available extra statistics.
+/// </summary>
+public static class PersistentSubscriptionExtraStatistic {
+#pragma warning disable CS1591
+	public const string Highest = "Highest";
+	public const string Mean = "Mean";
+	public const string Median = "Median";
+	public const string Fastest = "Fastest";
+	public const string Quintile1 = "Quintile 1";
+	public const string Quintile2 = "Quintile 2";
+	public const string Quintile3 = "Quintile 3";
+	public const string Quintile4 = "Quintile 4";
+	public const string Quintile5 = "Quintile 5";
+	public const string NinetyPercent = "90%";
+	public const string NinetyFivePercent = "95%";
+	public const string NinetyNinePercent = "99%";
+	public const string NinetyNinePointFivePercent = "99.5%";
+	public const string NinetyNinePointNinePercent = "99.9%";
+#pragma warning restore CS1591
+}

--- a/src/EventStore.Client.PersistentSubscriptions/PersistentSubscriptionInfo.cs
+++ b/src/EventStore.Client.PersistentSubscriptions/PersistentSubscriptionInfo.cs
@@ -1,0 +1,224 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using EventStore.Client.PersistentSubscriptions;
+using Google.Protobuf.Collections;
+
+namespace EventStore.Client {
+	/// <summary>
+	/// Provides the details for a persistent subscription.
+	/// </summary>
+	/// <param name="EventSource">The source of events for the subscription.</param>
+	/// <param name="GroupName">The group name given on creation.</param>
+	/// <param name="Status">The current status of the subscription.</param>
+	/// <param name="Connections">Active connections to the subscription.</param>
+	/// <param name="Settings">The settings used to create the persistant subscription.</param>
+	/// <param name="Stats">Live statistics for the persistent subscription.</param>
+	public record PersistentSubscriptionInfo(string EventSource, string GroupName, string Status,
+		IEnumerable<PersistentSubscriptionConnectionInfo> Connections,
+		PersistentSubscriptionSettings? Settings, PersistentSubscriptionStats Stats) {
+
+		internal static PersistentSubscriptionInfo From(SubscriptionInfo info) {
+			IPosition? startFrom = null;
+			IPosition? lastCheckpointedEventPosition = null;
+			IPosition? lastKnownEventPosition = null;
+			if (info.EventSource == SystemStreams.AllStream) {
+				if (Position.TryParse(info.StartFrom, out var position)) {
+					startFrom = position;
+				}
+				if (Position.TryParse(info.LastCheckpointedEventPosition, out position)) {
+					lastCheckpointedEventPosition = position;
+				}
+				if (Position.TryParse(info.LastKnownEventPosition, out position)) {
+					lastKnownEventPosition = position;
+				}
+			} else {
+				if (long.TryParse(info.StartFrom, out var streamPosition)) {
+					startFrom = StreamPosition.FromInt64(streamPosition);
+				}
+				if (ulong.TryParse(info.LastCheckpointedEventPosition, out var position)) {
+					lastCheckpointedEventPosition = new StreamPosition(position);
+				}
+				if (ulong.TryParse(info.LastKnownEventPosition, out position)) {
+					lastKnownEventPosition = new StreamPosition(position);
+				}
+			}
+			
+			return new PersistentSubscriptionInfo(
+				EventSource: info.EventSource,
+				GroupName: info.GroupName,
+				Status: info.Status,
+				Connections: From(info.Connections),
+				Settings: new PersistentSubscriptionSettings(
+					resolveLinkTos: info.ResolveLinkTos,
+					startFrom: startFrom,
+					extraStatistics: info.ExtraStatistics,
+					messageTimeout: TimeSpan.FromMilliseconds(info.MessageTimeoutMilliseconds),
+					maxRetryCount: info.MaxRetryCount,
+					liveBufferSize: info.LiveBufferSize,
+					readBatchSize: info.ReadBatchSize,
+					historyBufferSize: info.BufferSize,
+					checkPointAfter: TimeSpan.FromMilliseconds(info.CheckPointAfterMilliseconds),
+					checkPointLowerBound: info.MinCheckPointCount,
+					checkPointUpperBound: info.MaxCheckPointCount,
+					maxSubscriberCount: info.MaxSubscriberCount,
+					consumerStrategyName: info.NamedConsumerStrategy
+				),
+				Stats: new PersistentSubscriptionStats(
+					AveragePerSecond: info.AveragePerSecond,
+					TotalItems: info.TotalItems,
+					CountSinceLastMeasurement: info.CountSinceLastMeasurement,
+					ReadBufferCount: info.ReadBufferCount,
+					LiveBufferCount: info.LiveBufferCount,
+					RetryBufferCount: info.RetryBufferCount,
+					TotalInFlightMessages: info.TotalInFlightMessages,
+					OutstandingMessagesCount: info.OutstandingMessagesCount,
+					ParkedMessageCount: info.ParkedMessageCount,
+					LastCheckpointedEventPosition: lastCheckpointedEventPosition,
+					LastKnownEventPosition: lastKnownEventPosition
+				)
+			);
+		}
+
+		internal static PersistentSubscriptionInfo From(PersistentSubscriptionDto info) {
+			PersistentSubscriptionSettings? settings = null;
+			if (info.Config != null) {
+				settings = new PersistentSubscriptionSettings(
+					resolveLinkTos: info.Config.ResolveLinktos,
+					// we only need to support StreamPosition as $all was never implemented in http api.
+					startFrom: new StreamPosition(info.Config.StartFrom),
+					extraStatistics: info.Config.ExtraStatistics,
+					messageTimeout: TimeSpan.FromMilliseconds(info.Config.MessageTimeoutMilliseconds),
+					maxRetryCount: info.Config.MaxRetryCount,
+					liveBufferSize: info.Config.LiveBufferSize,
+					readBatchSize: info.Config.ReadBatchSize,
+					historyBufferSize: info.Config.BufferSize,
+					checkPointAfter: TimeSpan.FromMilliseconds(info.Config.CheckPointAfterMilliseconds),
+					checkPointLowerBound: info.Config.MinCheckPointCount,
+					checkPointUpperBound: info.Config.MaxCheckPointCount,
+					maxSubscriberCount: info.Config.MaxSubscriberCount,
+					consumerStrategyName: info.Config.NamedConsumerStrategy
+				);
+			}
+			
+			return new PersistentSubscriptionInfo(
+				EventSource: info.EventStreamId,
+				GroupName: info.GroupName,
+				Status: info.Status,
+				Connections: PersistentSubscriptionConnectionInfo.CreateFrom(info.Connections),
+				Settings: settings,
+				Stats: new PersistentSubscriptionStats(
+					AveragePerSecond: (int)info.AverageItemsPerSecond,
+					TotalItems: info.TotalItemsProcessed,
+					CountSinceLastMeasurement: info.CountSinceLastMeasurement,
+					ReadBufferCount: info.ReadBufferCount,
+					LiveBufferCount: info.LiveBufferCount,
+					RetryBufferCount: info.RetryBufferCount,
+					TotalInFlightMessages: info.TotalInFlightMessages,
+					OutstandingMessagesCount: info.OutstandingMessagesCount,
+					ParkedMessageCount: info.ParkedMessageCount,
+					LastCheckpointedEventPosition: StreamPosition.FromInt64(info.LastProcessedEventNumber),
+					LastKnownEventPosition: StreamPosition.FromInt64(info.LastKnownEventNumber)
+				)
+			);
+		}
+
+		private static IEnumerable<PersistentSubscriptionConnectionInfo> From(
+			RepeatedField<SubscriptionInfo.Types.ConnectionInfo> connections) {
+			foreach (var conn in connections) {
+				yield return new PersistentSubscriptionConnectionInfo(
+					From: conn.From,
+					Username: conn.Username,
+					AverageItemsPerSecond: conn.AverageItemsPerSecond,
+					TotalItems: conn.TotalItems,
+					CountSinceLastMeasurement: conn.CountSinceLastMeasurement,
+					AvailableSlots: conn.AvailableSlots,
+					InFlightMessages: conn.InFlightMessages,
+					ConnectionName: conn.ConnectionName,
+					ExtraStatistics: From(conn.ObservedMeasurements)
+				);
+			}
+		}
+
+		private static IDictionary<string, long> From(IEnumerable<SubscriptionInfo.Types.Measurement> measurements) =>
+			measurements.ToDictionary(k => k.Key, v => v.Value);
+	}
+
+	/// <summary>
+	/// Provides the statistics of a persistent subscription.
+	/// </summary>
+	/// <param name="AveragePerSecond">Average number of events per second.</param>
+	/// <param name="TotalItems">Total number of events processed by subscription.</param>
+	/// <param name="CountSinceLastMeasurement">Number of events seen since last measurement on this connection (used as the basis for <see cref="AveragePerSecond"/>).</param>
+	/// <param name="ReadBufferCount">Number of events in the read buffer.</param>
+	/// <param name="LiveBufferCount">Number of events in the live buffer.</param>
+	/// <param name="RetryBufferCount">Number of events in the retry buffer.</param>
+	/// <param name="TotalInFlightMessages">Current in flight messages across all connections.</param>
+	/// <param name="OutstandingMessagesCount">Current number of outstanding messages.</param>
+	/// <param name="ParkedMessageCount">The current number of parked messages.</param>
+	/// <param name="LastCheckpointedEventPosition">The <see cref="IPosition"/> of the last checkpoint. This will be null if there are no checkpoints.</param>
+	/// <param name="LastKnownEventPosition">The <see cref="IPosition"/> of the last known event. This will be undefined if no events have been received yet.</param>
+	public record PersistentSubscriptionStats(
+		int AveragePerSecond, long TotalItems, long CountSinceLastMeasurement, int ReadBufferCount,
+		long LiveBufferCount, int RetryBufferCount, int TotalInFlightMessages, int OutstandingMessagesCount,
+		long ParkedMessageCount, IPosition? LastCheckpointedEventPosition, IPosition? LastKnownEventPosition);
+
+	/// <summary>
+	/// Provides the details of a persistent subscription connection.
+	/// </summary>
+	/// <param name="From">Origin of this connection.</param>
+	/// <param name="Username">Connection username.</param>
+	/// <param name="ConnectionName">The name of the connection.</param>
+	/// <param name="AverageItemsPerSecond">Average events per second on this connection.</param>
+	/// <param name="TotalItems">Total items on this connection.</param>
+	/// <param name="CountSinceLastMeasurement">Number of items seen since last measurement on this connection (used as the basis for averageItemsPerSecond).</param>
+	/// <param name="AvailableSlots">Number of available slots.</param>
+	/// <param name="InFlightMessages">Number of in flight messages on this connection.</param>
+	/// <param name="ExtraStatistics">Timing measurements for the connection. Can be enabled with the ExtraStatistics setting.</param>
+	public record PersistentSubscriptionConnectionInfo(string From, string Username, string ConnectionName, int AverageItemsPerSecond,
+		long TotalItems, long CountSinceLastMeasurement, int AvailableSlots, int InFlightMessages,
+		IDictionary<string, long> ExtraStatistics) {
+
+		internal static IEnumerable<PersistentSubscriptionConnectionInfo> CreateFrom(
+			IEnumerable<PersistentSubscriptionConnectionInfoDto> connections) {
+
+			foreach (var connection in connections) {
+				yield return  CreateFrom(connection);
+			}
+		}
+
+		private static PersistentSubscriptionConnectionInfo CreateFrom(PersistentSubscriptionConnectionInfoDto connection) {
+			return  new PersistentSubscriptionConnectionInfo(
+				From: connection.From,
+				Username: connection.Username,
+				ConnectionName: connection.ConnectionName,
+				AverageItemsPerSecond: (int)connection.AverageItemsPerSecond,
+				TotalItems: connection.TotalItems,
+				CountSinceLastMeasurement: connection.CountSinceLastMeasurement,
+				AvailableSlots: connection.AvailableSlots,
+				InFlightMessages: connection.InFlightMessages,
+				ExtraStatistics: CreateFrom(connection.ExtraStatistics)
+			);
+		}
+
+		private static IDictionary<string, long> CreateFrom(IEnumerable<PersistentSubscriptionMeasurementInfoDto> extraStatistics) =>
+			extraStatistics.ToDictionary(k => k.Key, v => v.Value);
+	}
+	
+	internal record PersistentSubscriptionDto(string EventStreamId, string GroupName,
+		string Status, float AverageItemsPerSecond, long TotalItemsProcessed, long CountSinceLastMeasurement,
+		long LastProcessedEventNumber, long LastKnownEventNumber, int ReadBufferCount, long LiveBufferCount,
+		int RetryBufferCount, int TotalInFlightMessages, int OutstandingMessagesCount, int ParkedMessageCount,
+		PersistentSubscriptionConfig? Config, IEnumerable<PersistentSubscriptionConnectionInfoDto> Connections);
+
+	internal record PersistentSubscriptionConfig(bool ResolveLinktos, ulong StartFrom, string StartPosition,
+		int MessageTimeoutMilliseconds, bool ExtraStatistics, int MaxRetryCount, int LiveBufferSize, int BufferSize,
+		int ReadBatchSize, int CheckPointAfterMilliseconds, int MinCheckPointCount, int MaxCheckPointCount,
+		int MaxSubscriberCount, string NamedConsumerStrategy);
+	
+	internal record PersistentSubscriptionConnectionInfoDto(string From, string Username, float AverageItemsPerSecond,
+		long TotalItems, long CountSinceLastMeasurement, int AvailableSlots, int InFlightMessages, string ConnectionName,
+		IEnumerable<PersistentSubscriptionMeasurementInfoDto> ExtraStatistics);
+	
+	internal record PersistentSubscriptionMeasurementInfoDto(string Key, long Value);
+}

--- a/src/EventStore.Client.PersistentSubscriptions/PersistentSubscriptionNotFoundException.cs
+++ b/src/EventStore.Client.PersistentSubscriptions/PersistentSubscriptionNotFoundException.cs
@@ -17,9 +17,6 @@ namespace EventStore.Client {
 		/// <summary>
 		/// Constructs a new <see cref="PersistentSubscriptionNotFoundException"/>.
 		/// </summary>
-		/// <param name="streamName"></param>
-		/// <param name="groupName"></param>
-		/// <param name="exception"></param>
 		/// <exception cref="ArgumentNullException"></exception>
 		public PersistentSubscriptionNotFoundException(string streamName, string groupName, Exception? exception = null)
 			: base($"Subscription group '{groupName}' on stream '{streamName}' does not exist.", exception) {

--- a/src/EventStore.Client.PersistentSubscriptions/PersistentSubscriptionSettings.cs
+++ b/src/EventStore.Client.PersistentSubscriptions/PersistentSubscriptionSettings.cs
@@ -73,19 +73,6 @@ namespace EventStore.Client {
 		/// <summary>
 		/// Constructs a new <see cref="PersistentSubscriptionSettings"/>.
 		/// </summary>
-		/// <param name="resolveLinkTos"></param>
-		/// <param name="startFrom"></param>
-		/// <param name="extraStatistics"></param>
-		/// <param name="messageTimeout"></param>
-		/// <param name="maxRetryCount"></param>
-		/// <param name="liveBufferSize"></param>
-		/// <param name="readBatchSize"></param>
-		/// <param name="historyBufferSize"></param>
-		/// <param name="checkPointAfter"></param>
-		/// <param name="checkPointLowerBound"></param>
-		/// <param name="checkPointUpperBound"></param>
-		/// <param name="maxSubscriberCount"></param>
-		/// <param name="consumerStrategyName"></param>
 		/// <exception cref="ArgumentOutOfRangeException"></exception>
 		public PersistentSubscriptionSettings(bool resolveLinkTos = false, IPosition? startFrom = null,
 			bool extraStatistics = false, TimeSpan? messageTimeout = null, int maxRetryCount = 10,

--- a/src/EventStore.Client/ChannelCache.cs
+++ b/src/EventStore.Client/ChannelCache.cs
@@ -27,15 +27,14 @@ namespace EventStore.Client {
 				DnsEndPointEqualityComparer.Instance);
 		}
 
-		public TChannel GetChannelInfo(DnsEndPoint endPoint, bool? https = null) {
+		public TChannel GetChannelInfo(DnsEndPoint endPoint) {
 			lock (_lock) {
 				ThrowIfDisposed();
 
 				if (!_channels.TryGetValue(endPoint, out var channel)) {
 					channel = ChannelFactory.CreateChannel(
 						settings: _settings,
-						endPoint: endPoint,
-						https: https ?? !_settings.ConnectivitySettings.Insecure);
+						endPoint: endPoint);
 					_channels[endPoint] = channel;
 				}
 

--- a/src/EventStore.Client/ChannelFactory.cs
+++ b/src/EventStore.Client/ChannelFactory.cs
@@ -8,13 +8,10 @@ namespace EventStore.Client {
 	internal static class ChannelFactory {
 		private const int MaxReceiveMessageLength = 17 * 1024 * 1024;
 
-		public static TChannel CreateChannel(EventStoreClientSettings settings, EndPoint endPoint, bool https) =>
-			CreateChannel(settings, endPoint.ToUri(https));
+		public static TChannel CreateChannel(EventStoreClientSettings settings, EndPoint endPoint) {
+			var address = endPoint.ToUri(!settings.ConnectivitySettings.Insecure);
 
-		public static TChannel CreateChannel(EventStoreClientSettings settings, Uri? address) {
-			address ??= settings.ConnectivitySettings.Address;
-
-			if (address.Scheme == Uri.UriSchemeHttp ||settings.ConnectivitySettings.Insecure) {
+			if (settings.ConnectivitySettings.Insecure) {
 				//this must be switched on before creation of the HttpMessageHandler
 				AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
 			}

--- a/src/EventStore.Client/EventStoreClientBase.cs
+++ b/src/EventStore.Client/EventStoreClientBase.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Client.Interceptors;
@@ -19,29 +18,23 @@ namespace EventStore.Client {
 		private readonly CancellationTokenSource _cts;
 		private readonly ChannelCache _channelCache;
 		private readonly SharingProvider<ReconnectionRequired, ChannelInfo> _channelInfoProvider;
-
-		/// <summary>
+		private readonly Lazy<HttpFallback> _httpFallback;
+		
 		/// The name of the connection.
-		/// </summary>
 		public string ConnectionName { get; }
-
-		/// <summary>
+		
 		/// The <see cref="EventStoreClientSettings"/>.
-		/// </summary>
 		protected EventStoreClientSettings Settings { get; }
 
-		/// <summary>
 		/// Constructs a new <see cref="EventStoreClientBase"/>.
-		/// </summary>
-		/// <param name="settings"></param>
-		/// <param name="exceptionMap"></param>
 		protected EventStoreClientBase(EventStoreClientSettings? settings,
 			IDictionary<string, Func<RpcException, Exception>> exceptionMap) {
 			Settings = settings ?? new EventStoreClientSettings();
 			_exceptionMap = exceptionMap;
 			_cts = new CancellationTokenSource();
 			_channelCache = new(Settings);
-
+			_httpFallback = new Lazy<HttpFallback>(() => new HttpFallback(Settings));
+			
 			ConnectionName = Settings.ConnectionName ?? $"ES-{Guid.NewGuid()}";
 
 			var channelSelector = new ChannelSelector(Settings, _channelCache);
@@ -51,7 +44,7 @@ namespace EventStore.Client {
 				initialInput: ReconnectionRequired.Rediscover.Instance,
 				loggerFactory: Settings.LoggerFactory);
 		}
-
+		
 		// Select a channel and query its capabilities. This is an expensive call that
 		// we don't want to do often.
 		private async Task<ChannelInfo> GetChannelInfoExpensive(
@@ -84,11 +77,10 @@ namespace EventStore.Client {
 
 			return new(channel, caps, invoker);
 		}
-
-#pragma warning disable 1591
+		
+		/// Gets the current channel info.
 		protected async ValueTask<ChannelInfo> GetChannelInfo(CancellationToken cancellationToken) =>
 			await _channelInfoProvider.CurrentAsync.WithCancellation(cancellationToken).ConfigureAwait(false);
-#pragma warning restore 1591
 
 		// only exists so that we can manually trigger rediscovery in the tests (by reflection)
 		// in cases where the server doesn't yet let the client know that it needs to.
@@ -99,11 +91,33 @@ namespace EventStore.Client {
 			_channelInfoProvider.Reset();
 		}
 
+		/// Returns the result of an HTTP Get request based on the client settings.
+		protected async Task<T> HttpGet<T>(string path, Action onNotFound, ChannelInfo channelInfo,
+			TimeSpan? deadline, UserCredentials? userCredentials, CancellationToken cancellationToken) {
+			
+			return await _httpFallback.Value
+				.HttpGetAsync<T>(path, channelInfo, deadline, userCredentials, onNotFound, cancellationToken)
+				.ConfigureAwait(false);
+		}
+
+		/// Executes an HTTP Post request based on the client settings.
+		protected async Task HttpPost(string path, string query, Action onNotFound, ChannelInfo channelInfo,
+			TimeSpan? deadline, UserCredentials? userCredentials, CancellationToken cancellationToken) {
+			
+			await _httpFallback.Value
+				.HttpPostAsync(path, query, channelInfo, deadline, userCredentials, onNotFound, cancellationToken)
+				.ConfigureAwait(false);
+		}
+
 		/// <inheritdoc />
 		public virtual void Dispose() {
 			_cts.Cancel();
 			_cts.Dispose();
 			_channelCache.Dispose();
+			
+			if (_httpFallback.IsValueCreated) {
+				_httpFallback.Value.Dispose();
+			}
 		}
 
 		/// <inheritdoc />
@@ -111,13 +125,13 @@ namespace EventStore.Client {
 			_cts.Cancel();
 			_cts.Dispose();
 			await _channelCache.DisposeAsync().ConfigureAwait(false);
+
+			if (_httpFallback.IsValueCreated) {
+				_httpFallback.Value.Dispose();
+			}
 		}
 
-		/// <summary>
-		///
-		/// </summary>
-		/// <param name="option">The invalid option</param>
-		/// <typeparam name="T">The type of the option</typeparam>
+		/// Returns an InvalidOperation exception.
 		protected Exception InvalidOption<T>(T option) where T : Enum =>
 			new InvalidOperationException($"The {typeof(T).Name} {option:x} was not valid.");
 	}

--- a/src/EventStore.Client/EventStoreClientSettings.ConnectionString.cs
+++ b/src/EventStore.Client/EventStoreClientSettings.ConnectionString.cs
@@ -195,6 +195,10 @@ namespace EventStore.Client {
 						connSettings.IpGossipSeeds = Array.ConvertAll(hosts, x => (IPEndPoint)x);
 				}
 
+				if (typedOptions.TryGetValue(TlsVerifyCert, out var tlsVerifyCert)) {
+					settings.ConnectivitySettings.TlsVerifyCert = (bool)tlsVerifyCert;
+				}
+				
 				settings.CreateHttpMessageHandler = () => {
 					var handler = new SocketsHttpHandler {
 						KeepAlivePingDelay = settings.ConnectivitySettings.KeepAliveInterval,
@@ -202,7 +206,7 @@ namespace EventStore.Client {
 						EnableMultipleHttp2Connections = true,
 					};
 
-					if (typedOptions.TryGetValue(TlsVerifyCert, out var tlsVerifyCert) && !(bool)tlsVerifyCert) {
+					if (!settings.ConnectivitySettings.TlsVerifyCert) {
 						handler.SslOptions.RemoteCertificateValidationCallback = delegate { return true; };
 					}
 

--- a/src/EventStore.Client/GrpcServerCapabilitiesClient.cs
+++ b/src/EventStore.Client/GrpcServerCapabilitiesClient.cs
@@ -27,7 +27,11 @@ namespace EventStore.Client {
 			try {
 				var supportsBatchAppend = false;
 				var supportsPersistentSubscriptionsToAll = false;
-
+				var supportsPersistentSubscriptionsGetInfo = false;
+				var supportsPersistentSubscriptionsRestartSubsystem = false;
+				var supportsPersistentSubscriptionsReplayParked = false;
+				var supportsPersistentSubscriptionsList = false;
+				
 				var response = await call.ResponseAsync.ConfigureAwait(false);
 
 				foreach (var supportedMethod in response.Methods) {
@@ -38,12 +42,28 @@ namespace EventStore.Client {
 						case ("event_store.client.persistent_subscriptions.persistentsubscriptions", "read"):
 							supportsPersistentSubscriptionsToAll = supportedMethod.Features.Contains("all");
 							continue;
+						case ("event_store.client.persistent_subscriptions.persistentsubscriptions", "getinfo"):
+							supportsPersistentSubscriptionsGetInfo = true;
+							continue;
+						case ("event_store.client.persistent_subscriptions.persistentsubscriptions", "restartsubsystem"):
+							supportsPersistentSubscriptionsRestartSubsystem = true;
+							continue;
+						case ("event_store.client.persistent_subscriptions.persistentsubscriptions", "replayparked"):
+							supportsPersistentSubscriptionsReplayParked = true;
+							continue;
+						case ("event_store.client.persistent_subscriptions.persistentsubscriptions", "list"):
+							supportsPersistentSubscriptionsList = true;
+							continue;
 					}
 				}
 
 				return new(
 					SupportsBatchAppend: supportsBatchAppend,
-					SupportsPersistentSubscriptionsToAll: supportsPersistentSubscriptionsToAll);
+					SupportsPersistentSubscriptionsToAll: supportsPersistentSubscriptionsToAll,
+					SupportsPersistentSubscriptionsGetInfo: supportsPersistentSubscriptionsGetInfo,
+					SupportsPersistentSubscriptionsRestartSubsystem: supportsPersistentSubscriptionsRestartSubsystem,
+					SupportsPersistentSubscriptionsReplayParked: supportsPersistentSubscriptionsReplayParked,
+					SupportsPersistentSubscriptionsList: supportsPersistentSubscriptionsList);
 
 			} catch (Exception ex) when (ex.GetBaseException() is RpcException rpcException &&
 				rpcException.StatusCode == StatusCode.Unimplemented) {

--- a/src/EventStore.Client/HttpFallback.cs
+++ b/src/EventStore.Client/HttpFallback.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EventStore.Client {
+	internal class HttpFallback : IDisposable {
+		private readonly HttpClient _httpClient;
+		private readonly JsonSerializerOptions _jsonSettings;
+		private readonly UserCredentials? _defaultCredentials;
+		private readonly string _addressScheme;
+
+		internal HttpFallback (EventStoreClientSettings settings) {
+			_addressScheme = settings.ConnectivitySettings.Address.Scheme;
+            _defaultCredentials = settings.DefaultCredentials;
+			
+			var handler = new HttpClientHandler();
+			if (!settings.ConnectivitySettings.Insecure && !settings.ConnectivitySettings.TlsVerifyCert) {
+				handler.ClientCertificateOptions = ClientCertificateOption.Manual;
+				handler.ServerCertificateCustomValidationCallback = (_, _, _, _) => true;
+			}
+			
+			_httpClient = new HttpClient(handler);
+			if (settings.DefaultDeadline.HasValue) {
+				_httpClient.Timeout = settings.DefaultDeadline.Value;
+			}
+			
+			_jsonSettings = new JsonSerializerOptions {
+				PropertyNamingPolicy = JsonNamingPolicy.CamelCase 
+			};
+		}
+
+		internal async Task<T> HttpGetAsync<T>(string path, ChannelInfo channelInfo, TimeSpan? deadline,
+			UserCredentials? userCredentials, Action onNotFound, CancellationToken cancellationToken) {
+
+			var request = CreateRequest(path, HttpMethod.Get, channelInfo, userCredentials);
+			
+			var httpResult = await HttpSendAsync(request, onNotFound, deadline, cancellationToken).ConfigureAwait(false);
+			
+			var json = await httpResult.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+			var result = JsonSerializer.Deserialize<T>(json, _jsonSettings);
+			if (result == null) {
+				throw new InvalidOperationException("Unable to deserialize response into object of type " + typeof(T));
+			}
+
+			return result;
+		}
+
+		internal async Task HttpPostAsync(string path, string query, ChannelInfo channelInfo, TimeSpan? deadline,
+			UserCredentials? userCredentials, Action onNotFound, CancellationToken cancellationToken) {
+
+			var request = CreateRequest(path, query, HttpMethod.Post, channelInfo, userCredentials);
+			
+			await HttpSendAsync(request, onNotFound, deadline, cancellationToken).ConfigureAwait(false);
+		}
+
+		private async Task<HttpResponseMessage> HttpSendAsync(HttpRequestMessage request, Action onNotFound,
+			TimeSpan? deadline, CancellationToken cancellationToken) {
+
+			if (!deadline.HasValue) {
+				return await HttpSendAsync(request, onNotFound, cancellationToken).ConfigureAwait(false);				
+			}
+			
+			using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+			cts.CancelAfter(deadline.Value);
+				
+			return await HttpSendAsync(request, onNotFound, cts.Token).ConfigureAwait(false);
+		}
+		
+		async Task<HttpResponseMessage> HttpSendAsync(HttpRequestMessage request, Action onNotFound,
+			CancellationToken cancellationToken) {
+			
+			var httpResult = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+			if (httpResult.IsSuccessStatusCode) {
+				return httpResult;
+			}
+
+			if (httpResult.StatusCode == HttpStatusCode.Unauthorized) {
+				throw new AccessDeniedException();
+			}
+
+			if (httpResult.StatusCode == HttpStatusCode.NotFound) {
+				onNotFound();
+			}
+
+			throw new Exception($"The HTTP request failed with status code: {httpResult.StatusCode}");
+		}
+
+		private HttpRequestMessage CreateRequest(string path, HttpMethod method, ChannelInfo channelInfo,
+			UserCredentials? credentials) => CreateRequest(path, query: "", method, channelInfo, credentials);
+
+		private HttpRequestMessage CreateRequest(string path, string query, HttpMethod method, ChannelInfo channelInfo,
+			UserCredentials? credentials) {
+			
+			var uriBuilder = new UriBuilder($"{_addressScheme}://{channelInfo.Channel.Target}") {
+				Path = path,
+				Query = query
+			};
+
+			var httpRequest = new HttpRequestMessage(method, uriBuilder.Uri);
+			httpRequest.Headers.Add("accept", "application/json");
+			credentials ??= _defaultCredentials;
+			if (credentials != null) {
+				httpRequest.Headers.Add(Constants.Headers.Authorization, credentials.ToString());
+			}
+			
+			return httpRequest;
+		}
+
+		public void Dispose() {
+			_httpClient.Dispose();
+		}
+	}
+}

--- a/src/EventStore.Client/Position.cs
+++ b/src/EventStore.Client/Position.cs
@@ -153,5 +153,48 @@ namespace EventStore.Client {
 		/// </returns>
 		/// <filterpriority>2</filterpriority>
 		public override string ToString() => $"C:{CommitPosition}/P:{PreparePosition}";
+
+		/// <summary>
+		/// Tries to convert the string representation of a <see cref="Position" /> to its <see cref="Position" /> equivalent.
+		/// A return value indicates whether the conversion succeeded or failed.
+		/// </summary>
+		/// <param name="value">A string that represents the <see cref="Position" /> to convert.</param>
+		/// <param name="position">Contains the <see cref="Position" /> that is equivalent to the string
+		/// representation, if the conversion succeeded, or null if the conversion failed.</param>
+		/// <returns>true if the value was converted successfully; otherwise, false.</returns>
+		public static bool TryParse(string value, out Position? position) {
+			position = null;
+			var parts = value.Split("/");
+
+			if (parts.Length != 2) {
+				return false;
+			}
+
+			if (!TryParsePosition("C", parts[0], out var commitPosition)) {
+				return false;
+			}
+
+			if (!TryParsePosition("P", parts[1], out var preparePosition)) {
+				return false;
+			}
+
+			position = new Position(commitPosition, preparePosition);
+			return true;
+
+			static bool TryParsePosition(string expectedPrefix, string v, out ulong p) {
+				p = 0;
+				
+				var prts = v.Split(":");
+				if (prts.Length != 2) {
+					return false;
+				}
+				
+				if (prts[0] != expectedPrefix) {
+					return false;
+				}
+
+				return ulong.TryParse(prts[1], out p);
+			}
+		}
 	}
 }

--- a/src/EventStore.Client/ServerCapabilities.cs
+++ b/src/EventStore.Client/ServerCapabilities.cs
@@ -2,5 +2,9 @@ namespace EventStore.Client {
 #pragma warning disable 1591
 	public record ServerCapabilities(
 		bool SupportsBatchAppend = false,
-		bool SupportsPersistentSubscriptionsToAll = false);
+		bool SupportsPersistentSubscriptionsToAll = false,
+		bool SupportsPersistentSubscriptionsGetInfo = false,
+		bool SupportsPersistentSubscriptionsRestartSubsystem = false,
+		bool SupportsPersistentSubscriptionsReplayParked = false,
+		bool SupportsPersistentSubscriptionsList = false);
 }

--- a/src/EventStore.Client/SingleNodeChannelSelector.cs
+++ b/src/EventStore.Client/SingleNodeChannelSelector.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,7 +10,6 @@ namespace EventStore.Client {
 		private readonly ILogger _log;
 		private readonly ChannelCache _channelCache;
 		private readonly DnsEndPoint _endPoint;
-		private readonly bool _https;
 
 		public SingleNodeChannelSelector(
 			EventStoreClientSettings settings,
@@ -21,9 +19,9 @@ namespace EventStore.Client {
 				new NullLogger<SingleNodeChannelSelector>();
 
 			_channelCache = channelCache;
+			
 			var uri = settings.ConnectivitySettings.Address;
 			_endPoint = new DnsEndPoint(host: uri.Host, port: uri.Port);
-			_https = string.Compare(uri.Scheme, Uri.UriSchemeHttps, ignoreCase: true) == 0;
 		}
 
 		public Task<ChannelBase> SelectChannelAsync(CancellationToken cancellationToken) =>
@@ -32,7 +30,7 @@ namespace EventStore.Client {
 		public ChannelBase SelectChannel(DnsEndPoint endPoint) {
 			_log.LogInformation("Selected {endPoint}.", endPoint);
 
-			return _channelCache.GetChannelInfo(endPoint, _https);
+			return _channelCache.GetChannelInfo(endPoint);
 		}
 	}
 }

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -22,6 +22,8 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
+		<!-- https://github.com/advisories/GHSA-5crp-9r3c-p9vr -->
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
 	</ItemGroup>
 	<ItemGroup>
 		<CompilerVisibleProperty Include="RootNamespace"/>

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/Bugs/Issue_1125.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/Bugs/Issue_1125.cs
@@ -37,7 +37,7 @@ namespace EventStore.Client.Bugs {
 					_fixture.CreateTestEvents());
 			}
 
-			await _fixture.Client.CreateAsync(streamName, subscriptionName,
+			await _fixture.Client.CreateToStreamAsync(streamName, subscriptionName,
 				new PersistentSubscriptionSettings(
 					resolveLinkTos: true, startFrom: StreamPosition.Start, readBatchSize: 10, historyBufferSize: 20),
 				userCredentials: userCredentials);

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/EventStorePersistentSubscriptionsClientExtensions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/EventStorePersistentSubscriptionsClientExtensions.cs
@@ -6,7 +6,7 @@ namespace EventStore.Client {
 		public static async Task WarmUpAsync(this EventStorePersistentSubscriptionsClient self) {
 			await self.WarmUpWith(async cancellationToken => {
 				var id = Guid.NewGuid();
-				await self.CreateAsync(
+				await self.CreateToStreamAsync(
 						streamName: $"warmup-stream-{id}",
 						groupName: $"warmup-group-{id}",
 						settings: new(),

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/ReadOnlyMemoryExtensions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/ReadOnlyMemoryExtensions.cs
@@ -1,37 +1,33 @@
 ﻿using System;
-using System.Text;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using Newtonsoft.Json.Serialization;
+using System.Text.Json;
 
 namespace EventStore.Client {
 	public static class ReadOnlyMemoryExtensions {
 		public static Position ParsePosition(this ReadOnlyMemory<byte> json) {
-			var checkPoint = json.ParseJson<string>();
-			var parts = checkPoint.Split('/');
-			var commitPosition = ulong.Parse(parts[0].Split(':')[1]);
-			var preparePosition = ulong.Parse(parts[1].Split(':')[1]);
-			return new Position(commitPosition, preparePosition);
+			var doc = JsonDocument.Parse(json);
+			var checkPoint = doc.RootElement.GetString();
+
+			if (checkPoint == null) {
+				throw new Exception("Unable to parse Position, data is missing!");
+			}
+
+			Position.TryParse(checkPoint, out var position);
+			if (position.HasValue) {
+				return position.Value;
+			}
+			
+			throw new Exception("Unable to parse Position, invalid data!");
 		}
 
 		public static StreamPosition ParseStreamPosition(this ReadOnlyMemory<byte> json) {
-			var checkPoint = json.ParseJson<string>();
+			var doc = JsonDocument.Parse(json);
+			var checkPoint = doc.RootElement.GetString();
+
+			if (checkPoint == null) {
+				throw new Exception("Unable to parse Position, data is missing!");
+			}
+
 			return StreamPosition.FromInt64(int.Parse(checkPoint));
 		}
-
-		private static T ParseJson<T>(this ReadOnlyMemory<byte> json) =>
-			JsonConvert.DeserializeObject<T>(UTF8NoBom.GetString(json.ToArray()), JsonSettings)!;
-
-		private static readonly UTF8Encoding UTF8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-
-		private static readonly JsonSerializerSettings JsonSettings = new JsonSerializerSettings {
-			ContractResolver = new CamelCasePropertyNamesContractResolver(),
-			DateFormatHandling = DateFormatHandling.IsoDateFormat,
-			NullValueHandling = NullValueHandling.Ignore,
-			DefaultValueHandling = DefaultValueHandling.Ignore,
-			MissingMemberHandling = MissingMemberHandling.Ignore,
-			TypeNameHandling = TypeNameHandling.None,
-			Converters = new JsonConverter[] {new StringEnumConverter()}
-		};
 	}
 }

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/can_create_duplicate_name_on_different_streams.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/can_create_duplicate_name_on_different_streams.cs
@@ -22,7 +22,7 @@ namespace EventStore.Client.SubscriptionToAll {
 
 		[SupportsPSToAll.Fact]
 		public Task the_completion_succeeds() =>
-			_fixture.Client.CreateAsync("someother",
+			_fixture.Client.CreateToStreamAsync("someother",
 				"group3211", new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 	}
 }

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/get_info.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/get_info.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace EventStore.Client.SubscriptionToAll {
+	public class get_info : IClassFixture<get_info.Fixture> {
+		private readonly Fixture _fixture;
+		private const string GroupName = nameof(get_info);
+		private static readonly PersistentSubscriptionSettings _settings = new(
+			resolveLinkTos: true,
+			startFrom: Position.Start,
+			extraStatistics: true,
+			messageTimeout: TimeSpan.FromSeconds(9),
+			maxRetryCount: 11,
+			liveBufferSize: 303,
+			readBatchSize: 30,
+			historyBufferSize: 909,
+			checkPointAfter: TimeSpan.FromSeconds(1),
+			checkPointLowerBound: 1,
+			checkPointUpperBound: 1,
+			maxSubscriberCount: 500,
+			consumerStrategyName: SystemConsumerStrategies.Pinned
+		);
+		
+		public get_info(Fixture fixture) {
+			_fixture = fixture;
+		}
+
+		[Fact]
+		public async Task throws_when_not_supported() {
+			if (SupportsPSToAll.No) {
+				
+				await Assert.ThrowsAsync<NotSupportedException>(async () => {
+					await _fixture.Client.GetInfoToAllAsync(GroupName, userCredentials: TestCredentials.Root);
+				});
+			}
+		}
+		
+		[SupportsPSToAll.Fact]
+		public async Task returns_expected_result() {
+			var result = await _fixture.Client.GetInfoToAllAsync(GroupName, userCredentials: TestCredentials.Root);
+
+			Assert.Equal("$all", result.EventSource);
+			Assert.Equal(GroupName, result.GroupName);
+			Assert.Equal("Live", result.Status);
+			
+			Assert.NotNull(_settings.StartFrom);
+			Assert.True(result.Stats.TotalItems > 0);
+			Assert.True(result.Stats.OutstandingMessagesCount > 0);
+			Assert.True(result.Stats.AveragePerSecond >= 0);
+			Assert.True(result.Stats.ParkedMessageCount > 0);
+			Assert.True(result.Stats.AveragePerSecond >= 0);
+			Assert.True(result.Stats.CountSinceLastMeasurement >= 0);
+			Assert.True(result.Stats.TotalInFlightMessages >= 0);
+			Assert.NotNull(result.Stats.LastKnownEventPosition);
+			Assert.NotNull(result.Stats.LastCheckpointedEventPosition);
+			Assert.True(result.Stats.LiveBufferCount >= 0);
+
+			Assert.NotNull(result.Connections);
+			Assert.NotEmpty(result.Connections);
+
+			var connection = result.Connections.First();
+			Assert.NotNull(connection.From);
+			Assert.Equal(TestCredentials.Root.Username, connection.Username);
+			Assert.NotEmpty(connection.ConnectionName);
+			Assert.True(connection.AverageItemsPerSecond >= 0);
+			Assert.True(connection.TotalItems > 0);
+			Assert.True(connection.CountSinceLastMeasurement >= 0);
+			Assert.True(connection.AvailableSlots >= 0);
+			Assert.True(connection.InFlightMessages >= 0);
+			Assert.NotNull(connection.ExtraStatistics);
+			Assert.NotEmpty(connection.ExtraStatistics);
+			
+			AssertKeyAndValue(connection.ExtraStatistics, PersistentSubscriptionExtraStatistic.Highest);
+			AssertKeyAndValue(connection.ExtraStatistics, PersistentSubscriptionExtraStatistic.Mean);
+			AssertKeyAndValue(connection.ExtraStatistics, PersistentSubscriptionExtraStatistic.Median);
+			AssertKeyAndValue(connection.ExtraStatistics, PersistentSubscriptionExtraStatistic.Fastest);
+			AssertKeyAndValue(connection.ExtraStatistics, PersistentSubscriptionExtraStatistic.Quintile1);
+			AssertKeyAndValue(connection.ExtraStatistics, PersistentSubscriptionExtraStatistic.Quintile2);
+			AssertKeyAndValue(connection.ExtraStatistics, PersistentSubscriptionExtraStatistic.Quintile3);
+			AssertKeyAndValue(connection.ExtraStatistics, PersistentSubscriptionExtraStatistic.Quintile4);
+			AssertKeyAndValue(connection.ExtraStatistics, PersistentSubscriptionExtraStatistic.Quintile5);
+			AssertKeyAndValue(connection.ExtraStatistics, PersistentSubscriptionExtraStatistic.NinetyPercent);
+			AssertKeyAndValue(connection.ExtraStatistics, PersistentSubscriptionExtraStatistic.NinetyFivePercent);
+			AssertKeyAndValue(connection.ExtraStatistics, PersistentSubscriptionExtraStatistic.NinetyNinePercent);
+			AssertKeyAndValue(connection.ExtraStatistics, PersistentSubscriptionExtraStatistic.NinetyNinePointFivePercent);
+			AssertKeyAndValue(connection.ExtraStatistics, PersistentSubscriptionExtraStatistic.NinetyNinePointNinePercent);
+			
+			Assert.NotNull(result.Settings);
+			Assert.Equal(_settings.StartFrom, result.Settings!.StartFrom);
+			Assert.Equal(_settings.ResolveLinkTos, result.Settings!.ResolveLinkTos);
+			Assert.Equal(_settings.ExtraStatistics, result.Settings!.ExtraStatistics);
+			Assert.Equal(_settings.MessageTimeout, result.Settings!.MessageTimeout);
+			Assert.Equal(_settings.MaxRetryCount, result.Settings!.MaxRetryCount);
+			Assert.Equal(_settings.LiveBufferSize, result.Settings!.LiveBufferSize);
+			Assert.Equal(_settings.ReadBatchSize, result.Settings!.ReadBatchSize);
+			Assert.Equal(_settings.HistoryBufferSize, result.Settings!.HistoryBufferSize);
+			Assert.Equal(_settings.CheckPointAfter, result.Settings!.CheckPointAfter);
+			Assert.Equal(_settings.CheckPointLowerBound, result.Settings!.CheckPointLowerBound);
+			Assert.Equal(_settings.CheckPointUpperBound, result.Settings!.CheckPointUpperBound);
+			Assert.Equal(_settings.MaxSubscriberCount, result.Settings!.MaxSubscriberCount);
+			Assert.Equal(_settings.ConsumerStrategyName, result.Settings!.ConsumerStrategyName);
+		}
+		
+		[SupportsPSToAll.Fact]
+		public async Task throws_with_non_existing_subscription() {
+			await Assert.ThrowsAsync<PersistentSubscriptionNotFoundException>(async () => {
+				await _fixture.Client.GetInfoToAllAsync(
+					groupName: "NonExisting",
+					userCredentials: TestCredentials.Root);
+			});
+		}
+
+		[SupportsPSToAll.Fact]
+		public async Task throws_with_no_credentials() {
+			await Assert.ThrowsAsync<AccessDeniedException>(async () => {
+				await _fixture.Client.GetInfoToAllAsync("NonExisting");
+			});
+		}
+		
+		[SupportsPSToAll.Fact]
+		public async Task throws_with_non_existing_user() {
+			await Assert.ThrowsAsync<NotAuthenticatedException>(async () => {
+				await _fixture.Client.GetInfoToAllAsync(
+					groupName: "NonExisting",
+					userCredentials: TestCredentials.TestBadUser);
+			});
+		}
+		
+		[SupportsPSToAll.Fact]
+		public async Task returns_result_with_normal_user_credentials() {
+			var result = await _fixture.Client.GetInfoToAllAsync(
+				groupName: GroupName,
+				userCredentials: TestCredentials.TestUser1);
+			
+			Assert.Equal("$all", result.EventSource);
+		}
+		
+		public class Fixture : EventStoreClientFixture {
+			protected override async Task Given() {
+				if (SupportsPSToAll.No) {
+					return;
+				}
+				
+				await Client.CreateToAllAsync(
+					groupName: GroupName,
+					settings: _settings,
+					userCredentials: TestCredentials.Root);
+			}
+
+			protected override async Task When() {
+				if (SupportsPSToAll.No) {
+					return;
+				}
+
+				var counter = 0;
+				var tcs = new TaskCompletionSource();
+
+				await Client.SubscribeToAllAsync(
+					GroupName,
+					eventAppeared: (s, e, r, ct) => {
+						counter++;
+						
+						if (counter == 1) {
+							s.Nack(PersistentSubscriptionNakEventAction.Park, "Test", e);
+						}
+						
+						if (counter > 10) {
+							tcs.TrySetResult();
+						}
+						
+						return Task.CompletedTask;
+					},
+					userCredentials: TestCredentials.Root);
+
+				await tcs.Task;
+			}
+		}
+		
+		private void AssertKeyAndValue(IDictionary<string, long> items, string key) {
+			Assert.True(items.ContainsKey(key));
+			Assert.True(items[key] > 0);
+		}
+	}
+}

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/list_with_persistent_subscriptions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/list_with_persistent_subscriptions.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace EventStore.Client.SubscriptionToAll {
+	public class list_with_persistent_subscriptions : IClassFixture<list_with_persistent_subscriptions.Fixture> {
+		private readonly Fixture _fixture;
+		private const int AllStreamSubscriptionCount = 3;
+		private const int StreamSubscriptionCount = 4;
+		private const string GroupName = nameof(list_with_persistent_subscriptions);
+		private const string StreamName = nameof(list_with_persistent_subscriptions);
+
+		public list_with_persistent_subscriptions(Fixture fixture) {
+			_fixture = fixture;
+		}
+
+		private int TotalSubscriptionCount => SupportsPSToAll.No
+			? StreamSubscriptionCount
+			: StreamSubscriptionCount + AllStreamSubscriptionCount;
+
+		[Fact]
+		public async Task throws_when_not_supported() {
+			if (SupportsPSToAll.No) {
+				
+				await Assert.ThrowsAsync<NotSupportedException>(async () => {
+					await _fixture.Client.ListToAllAsync(userCredentials: TestCredentials.Root);
+				});
+			}
+		}
+		
+		[SupportsPSToAll.Fact]
+		public async Task returns_subscriptions_to_all_stream() {
+			var result = (await _fixture.Client.ListToAllAsync(userCredentials: TestCredentials.Root)).ToList();
+			Assert.Equal(AllStreamSubscriptionCount, result.Count);
+			Assert.All(result, s => Assert.Equal("$all", s.EventSource));
+		}
+
+		[Fact]
+		public async Task returns_all_subscriptions() {
+			var result = (await _fixture.Client.ListAllAsync(userCredentials: TestCredentials.Root)).ToList();
+			Assert.Equal(TotalSubscriptionCount, result.Count());
+		}
+		
+		[SupportsPSToAll.Fact]
+        public async Task throws_with_no_credentials() {
+	        await Assert.ThrowsAsync<AccessDeniedException>(async () =>
+		        await _fixture.Client.ListToAllAsync());
+        }
+		
+        [SupportsPSToAll.Fact]
+        public async Task throws_with_non_existing_user() {
+	        await Assert.ThrowsAsync<NotAuthenticatedException>(async () =>
+		        await _fixture.Client.ListToAllAsync(userCredentials: TestCredentials.TestBadUser));
+        }
+        
+        [SupportsPSToAll.Fact]
+        public async Task returns_result_with_normal_user_credentials() {
+	        var result = await _fixture.Client.ListToAllAsync(userCredentials: TestCredentials.TestUser1);
+	        Assert.Equal(AllStreamSubscriptionCount, result.Count());
+        }
+        
+		public class Fixture : EventStoreClientFixture {
+			public Fixture () : base(skipPSWarmUp: true) {
+			}
+			
+			protected override async Task Given() {
+				for (int i = 0; i < StreamSubscriptionCount; i++) {
+					await Client.CreateToStreamAsync(
+						StreamName,
+						GroupName + i,
+						new PersistentSubscriptionSettings(),
+						userCredentials: TestCredentials.Root);
+				}
+
+				if (SupportsPSToAll.No) {
+					return;
+				}
+				
+				for (int i = 0; i < AllStreamSubscriptionCount; i++) {
+					await Client.CreateToAllAsync(
+						GroupName + i,
+						new PersistentSubscriptionSettings(),
+						userCredentials: TestCredentials.Root);
+				}
+			}
+				
+			protected override Task When() => Task.CompletedTask;
+		}
+	}
+}

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/list_without_persistent_subscriptions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/list_without_persistent_subscriptions.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace EventStore.Client.SubscriptionToAll {
+	public class list_without_persistent_subscriptions : IClassFixture<list_without_persistent_subscriptions.Fixture> {
+		private readonly Fixture _fixture;
+		
+		public list_without_persistent_subscriptions(Fixture fixture) {
+			_fixture = fixture;
+		}
+
+		[Fact]
+		public async Task throws() {
+			if (SupportsPSToAll.No) {
+				
+				await Assert.ThrowsAsync<NotSupportedException>(async () => {
+					await _fixture.Client.ListToAllAsync(userCredentials: TestCredentials.Root);
+				});
+				
+				return;
+			}
+			
+			await Assert.ThrowsAsync<PersistentSubscriptionNotFoundException>(async () => 
+				await _fixture.Client.ListToAllAsync(userCredentials: TestCredentials.Root));
+		}
+
+		public class Fixture : EventStoreClientFixture {
+			protected override Task Given() => Task.CompletedTask;
+			protected override Task When() => Task.CompletedTask;
+		}
+	}
+}

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/replay_parked.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/replay_parked.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace EventStore.Client.SubscriptionToAll {
+	public class replay_parked : IClassFixture<replay_parked.Fixture> {
+		private readonly Fixture _fixture;
+		private const string GroupName = nameof(replay_parked);
+
+		public replay_parked(Fixture fixture) {
+			_fixture = fixture;
+		}
+
+		[Fact]
+		public async Task throws_when_not_supported() {
+			if (SupportsPSToAll.No) {
+				
+				await Assert.ThrowsAsync<NotSupportedException>(async () => {
+					await _fixture.Client.ReplayParkedMessagesToAllAsync(
+						GroupName,
+						userCredentials: TestCredentials.Root);
+				});
+			}
+		}
+		
+		[SupportsPSToAll.Fact]
+		public async Task does_not_throw() {
+			await _fixture.Client.ReplayParkedMessagesToAllAsync(
+				GroupName,
+				userCredentials: TestCredentials.Root);
+			
+			await _fixture.Client.ReplayParkedMessagesToAllAsync(
+				GroupName,
+				stopAt: 100,
+				userCredentials: TestCredentials.Root);
+		}
+
+		[SupportsPSToAll.Fact]
+		public async Task throws_when_given_non_existing_subscription() {
+			await Assert.ThrowsAsync<PersistentSubscriptionNotFoundException>(() => 
+				_fixture.Client.ReplayParkedMessagesToAllAsync(
+					groupName: "NonExisting",
+					userCredentials: TestCredentials.Root));
+		}
+		
+		[SupportsPSToAll.Fact]
+		public async Task throws_with_no_credentials() {
+			await Assert.ThrowsAsync<AccessDeniedException>(() => 
+				_fixture.Client.ReplayParkedMessagesToAllAsync(GroupName));
+		}
+
+		[SupportsPSToAll.Fact]
+		public async Task throws_with_non_existing_user() {
+			await Assert.ThrowsAsync<NotAuthenticatedException>(() => 
+				_fixture.Client.ReplayParkedMessagesToAllAsync(
+					GroupName,
+					userCredentials: TestCredentials.TestBadUser));
+		}
+		
+		[SupportsPSToAll.Fact]
+		public async Task throws_with_normal_user_credentials() {
+			await Assert.ThrowsAsync<AccessDeniedException>(() => 
+				_fixture.Client.ReplayParkedMessagesToAllAsync(
+					GroupName,
+					userCredentials: TestCredentials.TestUser1));
+		}
+
+		public class Fixture : EventStoreClientFixture {
+			protected override async Task Given() {
+				if (SupportsPSToAll.No) {
+					return;
+				}
+				
+				await Client.CreateToAllAsync(
+					GroupName,
+					new PersistentSubscriptionSettings(),
+					userCredentials: TestCredentials.Root);
+			}
+				
+			protected override Task When() => Task.CompletedTask;
+		}
+	}
+}

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/can_create_duplicate_name_on_different_streams.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/can_create_duplicate_name_on_different_streams.cs
@@ -17,13 +17,13 @@ namespace EventStore.Client.SubscriptionToStream {
 			protected override Task Given() => Task.CompletedTask;
 
 			protected override Task When() =>
-				Client.CreateAsync(Stream, "group3211",
+				Client.CreateToStreamAsync(Stream, "group3211",
 					new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 		}
 
 		[Fact]
 		public Task the_completion_succeeds() =>
-			_fixture.Client.CreateAsync("someother" + Stream,
+			_fixture.Client.CreateToStreamAsync("someother" + Stream,
 				"group3211", new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 	}
 }

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_max_one_client.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_max_one_client.cs
@@ -30,7 +30,7 @@ namespace EventStore.Client.SubscriptionToStream {
 
 		public class Fixture : EventStoreClientFixture {
 			protected override Task Given() =>
-				Client.CreateAsync(
+				Client.CreateToStreamAsync(
 					Stream,
 					Group,
 					new PersistentSubscriptionSettings(maxSubscriberCount: 1),

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_permissions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_permissions.cs
@@ -26,7 +26,7 @@ namespace EventStore.Client.SubscriptionToStream {
 
 		public class Fixture : EventStoreClientFixture {
 			protected override Task Given() =>
-				Client.CreateAsync(
+				Client.CreateToStreamAsync(
 					Stream,
 					"agroupname17",
 					new PersistentSubscriptionSettings(),

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_beginning_and_events_in_it.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_beginning_and_events_in_it.cs
@@ -38,7 +38,7 @@ namespace EventStore.Client.SubscriptionToStream {
 
 			protected override async Task Given() {
 				await StreamsClient.AppendToStreamAsync(Stream, StreamState.NoStream, Events);
-				await Client.CreateAsync(Stream, Group,
+				await Client.CreateToStreamAsync(Stream, Group,
 					new PersistentSubscriptionSettings(startFrom: StreamPosition.Start), userCredentials: TestCredentials.Root);
 			}
 

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_beginning_and_no_stream.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_beginning_and_no_stream.cs
@@ -37,7 +37,7 @@ namespace EventStore.Client.SubscriptionToStream {
 			}
 
 			protected override async Task Given() {
-				await Client.CreateAsync(Stream, Group,
+				await Client.CreateToStreamAsync(Stream, Group,
 					new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToStreamAsync(Stream, Group,
 					async (subscription, e, r, ct) => {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_not_set_and_events_in_it.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_not_set_and_events_in_it.cs
@@ -36,7 +36,7 @@ namespace EventStore.Client.SubscriptionToStream {
 
 			protected override async Task Given() {
 				await StreamsClient.AppendToStreamAsync(Stream, StreamState.NoStream, Events);
-				await Client.CreateAsync(Stream, Group,
+				await Client.CreateToStreamAsync(Stream, Group,
 					new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 			}
 

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_not_set_and_events_in_it_then_event_written.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_not_set_and_events_in_it_then_event_written.cs
@@ -42,7 +42,7 @@ namespace EventStore.Client.SubscriptionToStream {
 
 			protected override async Task Given() {
 				await StreamsClient.AppendToStreamAsync(Stream, StreamState.NoStream, Events.Take(10));
-				await Client.CreateAsync(Stream, Group,
+				await Client.CreateToStreamAsync(Stream, Group,
 					new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToStreamAsync(Stream, Group,
 					async (subscription, e, r, ct) => {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_set_to_end_position_and_events_in_it.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_set_to_end_position_and_events_in_it.cs
@@ -35,7 +35,7 @@ namespace EventStore.Client.SubscriptionToStream {
 
 			protected override async Task Given() {
 				await StreamsClient.AppendToStreamAsync(Stream, StreamState.NoStream, Events);
-				await Client.CreateAsync(Stream, Group,
+				await Client.CreateToStreamAsync(Stream, Group,
 					new PersistentSubscriptionSettings(startFrom: StreamPosition.End), userCredentials: TestCredentials.Root);
 			}
 

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_set_to_end_position_and_events_in_it_then_event_written.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_set_to_end_position_and_events_in_it_then_event_written.cs
@@ -42,7 +42,7 @@ namespace EventStore.Client.SubscriptionToStream {
 
 			protected override async Task Given() {
 				await StreamsClient.AppendToStreamAsync(Stream, StreamState.NoStream, Events.Take(10));
-				await Client.CreateAsync(Stream, Group,
+				await Client.CreateToStreamAsync(Stream, Group,
 					new PersistentSubscriptionSettings(startFrom: StreamPosition.End), userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToStreamAsync(Stream, Group,
 					async (subscription, e, r, ct) => {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_two_and_no_stream.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_two_and_no_stream.cs
@@ -36,7 +36,7 @@ namespace EventStore.Client.SubscriptionToStream {
 			}
 
 			protected override async Task Given() {
-				await Client.CreateAsync(Stream, Group,
+				await Client.CreateToStreamAsync(Stream, Group,
 					new PersistentSubscriptionSettings(startFrom: new StreamPosition(2)), userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToStreamAsync(Stream, Group,
 					async (subscription, e, r, ct) => {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_x_set_and_events_in_it.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_x_set_and_events_in_it.cs
@@ -35,7 +35,7 @@ namespace EventStore.Client.SubscriptionToStream {
 
 			protected override async Task Given() {
 				await StreamsClient.AppendToStreamAsync(Stream, StreamState.NoStream, Events.Take(10));
-				await Client.CreateAsync(Stream, Group,
+				await Client.CreateToStreamAsync(Stream, Group,
 					new PersistentSubscriptionSettings(startFrom: new StreamPosition(4)), userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToStreamAsync(Stream, Group,
 					async (subscription, e, r, ct) => {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_x_set_and_events_in_it_then_event_written.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_x_set_and_events_in_it_then_event_written.cs
@@ -40,7 +40,7 @@ namespace EventStore.Client.SubscriptionToStream {
 
 			protected override async Task Given() {
 				await StreamsClient.AppendToStreamAsync(Stream, StreamState.NoStream, Events.Take(10));
-				await Client.CreateAsync(Stream, Group,
+				await Client.CreateToStreamAsync(Stream, Group,
 					new PersistentSubscriptionSettings(startFrom: new StreamPosition(10)), userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToStreamAsync(Stream, Group,
 					async (subscription, e, r, ct) => {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_x_set_higher_than_x_and_events_in_it_then_event_written.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_x_set_higher_than_x_and_events_in_it_then_event_written.cs
@@ -43,7 +43,7 @@ namespace EventStore.Client.SubscriptionToStream {
 
 			protected override async Task Given() {
 				await StreamsClient.AppendToStreamAsync(Stream, StreamState.NoStream, Events.Take(11));
-				await Client.CreateAsync(Stream, Group,
+				await Client.CreateToStreamAsync(Stream, Group,
 					new PersistentSubscriptionSettings(startFrom: new StreamPosition(11)), userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToStreamAsync(Stream, Group,
 					async (subscription, e, r, ct) => {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_without_permissions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_without_permissions.cs
@@ -17,7 +17,7 @@ namespace EventStore.Client.SubscriptionToStream {
 
 		public class Fixture : EventStoreClientFixture {
 			protected override Task Given() =>
-				Client.CreateAsync(
+				Client.CreateToStreamAsync(
 					Stream,
 					"agroupname55",
 					new PersistentSubscriptionSettings(),

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_with_retries.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_with_retries.cs
@@ -32,7 +32,7 @@ namespace EventStore.Client.SubscriptionToStream {
 
 			protected override async Task Given() {
 				await StreamsClient.AppendToStreamAsync(Stream, StreamState.NoStream, Events);
-				await Client.CreateAsync(Stream, Group,
+				await Client.CreateToStreamAsync(Stream, Group,
 					new PersistentSubscriptionSettings(startFrom: StreamPosition.Start), userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToStreamAsync(Stream, Group,
 					async (subscription, e, r, ct) => {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connecting_to_a_persistent_subscription.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connecting_to_a_persistent_subscription.cs
@@ -43,7 +43,7 @@ namespace EventStore.Client.SubscriptionToStream {
 
 			protected override async Task Given() {
 				await StreamsClient.AppendToStreamAsync(Stream, StreamState.NoStream, Events.Take(11));
-				await Client.CreateAsync(Stream, Group,
+				await Client.CreateToStreamAsync(Stream, Group,
 					new PersistentSubscriptionSettings(startFrom: new StreamPosition(11)), userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToStreamAsync(Stream, Group,
 					async (subscription, e, r, ct) => {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/create_after_deleting_the_same.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/create_after_deleting_the_same.cs
@@ -16,16 +16,16 @@ namespace EventStore.Client.SubscriptionToStream {
 
 			protected override async Task When() {
 				await StreamsClient.AppendToStreamAsync(Stream, StreamState.Any, CreateTestEvents());
-				await Client.CreateAsync(Stream, "existing",
+				await Client.CreateToStreamAsync(Stream, "existing",
 					new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
-				await Client.DeleteAsync(Stream, "existing",
+				await Client.DeleteToStreamAsync(Stream, "existing",
 					userCredentials: TestCredentials.Root);
 			}
 		}
 
 		[Fact]
 		public async Task the_completion_succeeds() {
-			await _fixture.Client.CreateAsync(Stream, "existing",
+			await _fixture.Client.CreateToStreamAsync(Stream, "existing",
 				new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 		}
 	}

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/create_duplicate.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/create_duplicate.cs
@@ -17,14 +17,14 @@ namespace EventStore.Client.SubscriptionToStream {
 			protected override Task Given() => Task.CompletedTask;
 
 			protected override Task When() =>
-				Client.CreateAsync(Stream, "group32",
+				Client.CreateToStreamAsync(Stream, "group32",
 					new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 		}
 
 		[Fact]
 		public async Task the_completion_fails() {
 			var ex = await Assert.ThrowsAsync<RpcException>(
-				() => _fixture.Client.CreateAsync(Stream, "group32",
+				() => _fixture.Client.CreateToStreamAsync(Stream, "group32",
 					new PersistentSubscriptionSettings(),
 					userCredentials: TestCredentials.Root));
 			Assert.Equal(StatusCode.AlreadyExists, ex.StatusCode);

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/create_on_existing_stream.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/create_on_existing_stream.cs
@@ -20,7 +20,7 @@ namespace EventStore.Client.SubscriptionToStream {
 
 		[Fact]
 		public Task the_completion_succeeds()
-			=> _fixture.Client.CreateAsync(
+			=> _fixture.Client.CreateToStreamAsync(
 				Stream, "existing", new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 	}
 }

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/create_on_non_existing_stream.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/create_on_non_existing_stream.cs
@@ -18,7 +18,7 @@ namespace EventStore.Client.SubscriptionToStream {
 
 		[Fact]
 		public async Task the_completion_succeeds() {
-			await _fixture.Client.CreateAsync(Stream, "nonexistinggroup",
+			await _fixture.Client.CreateToStreamAsync(Stream, "nonexistinggroup",
 				new PersistentSubscriptionSettings(),
 				userCredentials: TestCredentials.Root);
 		}

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/create_persistent_subscription_with_dont_timeout.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/create_persistent_subscription_with_dont_timeout.cs
@@ -19,7 +19,7 @@ namespace EventStore.Client.SubscriptionToStream {
 
 		[Fact]
 		public Task the_subscription_is_created_without_error() =>
-			_fixture.Client.CreateAsync(Stream, "dont-timeout",
+			_fixture.Client.CreateToStreamAsync(Stream, "dont-timeout",
 				new PersistentSubscriptionSettings(messageTimeout: TimeSpan.Zero),
 				userCredentials: TestCredentials.Root);
 	}

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/create_without_permissions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/create_without_permissions.cs
@@ -19,7 +19,7 @@ namespace EventStore.Client.SubscriptionToStream {
 		[Fact]
 		public Task the_completion_fails_with_access_denied() =>
 			Assert.ThrowsAsync<AccessDeniedException>(() =>
-				_fixture.Client.CreateAsync(Stream, "group57",
+				_fixture.Client.CreateToStreamAsync(Stream, "group57",
 					new PersistentSubscriptionSettings()));
 	}
 }

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/deleting_existing_with_permissions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/deleting_existing_with_permissions.cs
@@ -15,14 +15,14 @@ namespace EventStore.Client.SubscriptionToStream {
 			protected override Task Given() => Task.CompletedTask;
 
 			protected override Task When() =>
-				Client.CreateAsync(Stream, "groupname123",
+				Client.CreateToStreamAsync(Stream, "groupname123",
 					new PersistentSubscriptionSettings(),
 					userCredentials: TestCredentials.Root);
 		}
 
 		[Fact]
 		public Task the_delete_of_group_succeeds() =>
-			_fixture.Client.DeleteAsync(Stream, "groupname123",
+			_fixture.Client.DeleteToStreamAsync(Stream, "groupname123",
 				userCredentials: TestCredentials.Root);
 	}
 }

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/deleting_existing_with_subscriber.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/deleting_existing_with_subscriber.cs
@@ -22,7 +22,7 @@ namespace EventStore.Client.SubscriptionToStream {
 			}
 
 			protected override async Task Given() {
-				await Client.CreateAsync(Stream, "groupname123",
+				await Client.CreateToStreamAsync(Stream, "groupname123",
 					new PersistentSubscriptionSettings(),
 					userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToStreamAsync(Stream, "groupname123",
@@ -31,7 +31,7 @@ namespace EventStore.Client.SubscriptionToStream {
 			}
 
 			protected override Task When() =>
-				Client.DeleteAsync(Stream, "groupname123",
+				Client.DeleteToStreamAsync(Stream, "groupname123",
 					userCredentials: TestCredentials.Root);
 
 			public override Task DisposeAsync() {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/deleting_nonexistent.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/deleting_nonexistent.cs
@@ -15,7 +15,7 @@ namespace EventStore.Client.SubscriptionToStream {
 		[Fact]
 		public async Task the_delete_fails_with_argument_exception() {
 			await Assert.ThrowsAsync<PersistentSubscriptionNotFoundException>(
-				() => _fixture.Client.DeleteAsync(Stream,
+				() => _fixture.Client.DeleteToStreamAsync(Stream,
 					Guid.NewGuid().ToString(), userCredentials: TestCredentials.Root));
 		}
 

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/deleting_without_permissions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/deleting_without_permissions.cs
@@ -15,7 +15,7 @@ namespace EventStore.Client.SubscriptionToStream {
 		[Fact]
 		public async Task the_delete_fails_with_access_denied() {
 			await Assert.ThrowsAsync<AccessDeniedException>(
-				() => _fixture.Client.DeleteAsync(Stream,
+				() => _fixture.Client.DeleteToStreamAsync(Stream,
 					Guid.NewGuid().ToString()));
 		}
 

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/get_info.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/get_info.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace EventStore.Client.SubscriptionToStream {
+	public class get_info : IClassFixture<get_info.Fixture> {
+		private readonly Fixture _fixture;
+		private const string GroupName = nameof(get_info);
+		private const string StreamName = nameof(get_info);
+		private static readonly PersistentSubscriptionSettings _settings = new(
+			resolveLinkTos: true,
+			startFrom: StreamPosition.Start,
+			extraStatistics: true,
+			messageTimeout: TimeSpan.FromSeconds(9),
+			maxRetryCount: 11,
+			liveBufferSize: 303,
+			readBatchSize: 30,
+			historyBufferSize: 909,
+			checkPointAfter: TimeSpan.FromSeconds(1),
+			checkPointLowerBound: 1,
+			checkPointUpperBound: 1,
+			maxSubscriberCount: 500,
+			consumerStrategyName: SystemConsumerStrategies.RoundRobin
+		);
+
+		public get_info(Fixture fixture) {
+			_fixture = fixture;
+		}
+
+		public static IEnumerable<object[]> AllowedUsers() {
+			yield return new object[] {TestCredentials.Root};
+			yield return new object[] {TestCredentials.TestUser1};
+		}
+		
+		[Theory, MemberData(nameof(AllowedUsers))]
+		public async Task returns_expected_result(UserCredentials credentials) {
+			var result = await _fixture.Client.GetInfoToStreamAsync(
+				StreamName,
+				GroupName,
+				userCredentials: credentials);
+
+			Assert.Equal(StreamName, result.EventSource);
+			Assert.Equal(GroupName, result.GroupName);
+			Assert.NotNull(_settings.StartFrom);
+			Assert.True(result.Stats.TotalItems > 0);
+			Assert.True(result.Stats.OutstandingMessagesCount > 0);
+			Assert.True(result.Stats.AveragePerSecond >= 0);
+			Assert.True(result.Stats.ParkedMessageCount >= 0);
+			Assert.True(result.Stats.AveragePerSecond >= 0);
+			Assert.True(result.Stats.ReadBufferCount >= 0);
+			Assert.True(result.Stats.RetryBufferCount >= 0);
+			Assert.True(result.Stats.CountSinceLastMeasurement >= 0);
+			Assert.True(result.Stats.TotalInFlightMessages >= 0);
+			Assert.NotNull(result.Stats.LastKnownEventPosition);
+			Assert.NotNull(result.Stats.LastCheckpointedEventPosition);
+			Assert.True(result.Stats.LiveBufferCount >= 0);
+
+			Assert.NotNull(result.Connections);
+			Assert.NotEmpty(result.Connections);
+			var connection = result.Connections.First();
+			Assert.NotNull(connection.From);
+			Assert.Equal(TestCredentials.Root.Username, connection.Username);
+			Assert.NotEmpty(connection.ConnectionName);
+			Assert.True(connection.AverageItemsPerSecond >= 0);
+			Assert.True(connection.TotalItems >= 0);
+			Assert.True(connection.CountSinceLastMeasurement >= 0);
+			Assert.True(connection.AvailableSlots >= 0);
+			Assert.True(connection.InFlightMessages >= 0);
+			Assert.NotNull(connection.ExtraStatistics);
+			Assert.NotEmpty(connection.ExtraStatistics);
+			
+			AssertKeyAndValue(connection.ExtraStatistics, PersistentSubscriptionExtraStatistic.Highest);
+			AssertKeyAndValue(connection.ExtraStatistics, PersistentSubscriptionExtraStatistic.Mean);
+			AssertKeyAndValue(connection.ExtraStatistics, PersistentSubscriptionExtraStatistic.Median);
+			AssertKeyAndValue(connection.ExtraStatistics, PersistentSubscriptionExtraStatistic.Fastest);
+			AssertKeyAndValue(connection.ExtraStatistics, PersistentSubscriptionExtraStatistic.Quintile1);
+			AssertKeyAndValue(connection.ExtraStatistics, PersistentSubscriptionExtraStatistic.Quintile2);
+			AssertKeyAndValue(connection.ExtraStatistics, PersistentSubscriptionExtraStatistic.Quintile3);
+			AssertKeyAndValue(connection.ExtraStatistics, PersistentSubscriptionExtraStatistic.Quintile4);
+			AssertKeyAndValue(connection.ExtraStatistics, PersistentSubscriptionExtraStatistic.Quintile5);
+			AssertKeyAndValue(connection.ExtraStatistics, PersistentSubscriptionExtraStatistic.NinetyPercent);
+			AssertKeyAndValue(connection.ExtraStatistics, PersistentSubscriptionExtraStatistic.NinetyFivePercent);
+			AssertKeyAndValue(connection.ExtraStatistics, PersistentSubscriptionExtraStatistic.NinetyNinePercent);
+			AssertKeyAndValue(connection.ExtraStatistics, PersistentSubscriptionExtraStatistic.NinetyNinePointFivePercent);
+			AssertKeyAndValue(connection.ExtraStatistics, PersistentSubscriptionExtraStatistic.NinetyNinePointNinePercent);
+			
+			Assert.NotNull(result.Settings);
+			Assert.Equal(_settings.StartFrom, result.Settings!.StartFrom);
+			Assert.Equal(_settings.ResolveLinkTos, result.Settings!.ResolveLinkTos);
+			Assert.Equal(_settings.ExtraStatistics, result.Settings!.ExtraStatistics);
+			Assert.Equal(_settings.MessageTimeout, result.Settings!.MessageTimeout);
+			Assert.Equal(_settings.MaxRetryCount, result.Settings!.MaxRetryCount);
+			Assert.Equal(_settings.LiveBufferSize, result.Settings!.LiveBufferSize);
+			Assert.Equal(_settings.ReadBatchSize, result.Settings!.ReadBatchSize);
+			Assert.Equal(_settings.HistoryBufferSize, result.Settings!.HistoryBufferSize);
+			Assert.Equal(_settings.CheckPointAfter, result.Settings!.CheckPointAfter);
+			Assert.Equal(_settings.CheckPointLowerBound, result.Settings!.CheckPointLowerBound);
+			Assert.Equal(_settings.CheckPointUpperBound, result.Settings!.CheckPointUpperBound);
+			Assert.Equal(_settings.MaxSubscriberCount, result.Settings!.MaxSubscriberCount);
+			Assert.Equal(_settings.ConsumerStrategyName, result.Settings!.ConsumerStrategyName);
+		}
+
+		[Fact]
+		public async Task throws_when_given_non_existing_subscription() {
+			await Assert.ThrowsAsync<PersistentSubscriptionNotFoundException>(async () => {
+				await _fixture.Client.GetInfoToStreamAsync(
+					streamName: "NonExisting",
+					groupName: "NonExisting",
+					userCredentials: TestCredentials.Root);
+			});
+		}
+		
+		[Fact(Skip = "Unable to produce same behavior with HTTP fallback!")]
+		public async Task throws_with_non_existing_user() {
+			await Assert.ThrowsAsync<NotAuthenticatedException>(async () => {
+				await _fixture.Client.GetInfoToStreamAsync(
+					streamName: "NonExisting",
+					groupName: "NonExisting",
+					userCredentials: TestCredentials.TestBadUser);
+			});
+		}
+		
+		[Fact]
+		public async Task throws_with_no_credentials() {
+			await Assert.ThrowsAsync<AccessDeniedException>(async () => {
+				await _fixture.Client.GetInfoToStreamAsync(
+					streamName: "NonExisting",
+					groupName: "NonExisting");
+			});
+		}
+		
+		[Fact]
+		public async Task returns_result_for_normal_user() {
+			var result = await _fixture.Client.GetInfoToStreamAsync(
+				StreamName,
+				GroupName,
+				userCredentials: TestCredentials.TestUser1);
+			
+			Assert.NotNull(result);
+		}
+		
+		public class Fixture : EventStoreClientFixture {
+			protected override Task Given() =>
+				Client.CreateToStreamAsync(
+					groupName: GroupName,
+					streamName: StreamName,
+					settings: _settings,
+					userCredentials: TestCredentials.Root);
+
+			protected override async Task When() {
+				var counter = 0;
+				var tcs = new TaskCompletionSource();
+				
+				await Client.SubscribeToStreamAsync(
+					StreamName,
+					GroupName,
+					eventAppeared: (s, e, r, ct) => {
+						counter++;
+						
+						if (counter == 1) {
+							s.Nack(PersistentSubscriptionNakEventAction.Park, "Test", e);
+						}
+						
+						if (counter > 10) {
+							tcs.TrySetResult();
+						}
+						
+						return Task.CompletedTask;
+					},
+					userCredentials: TestCredentials.Root);
+
+				for (int i = 0; i < 15; i++) {
+					await StreamsClient.AppendToStreamAsync(StreamName, StreamState.Any, new [] {
+						new EventData(Uuid.NewUuid(), "test-event", ReadOnlyMemory<byte>.Empty)
+					});
+				}
+				
+				await tcs.Task;
+			}
+		}
+		
+		private void AssertKeyAndValue(IDictionary<string, long> items, string key) {
+			Assert.True(items.ContainsKey(key));
+			Assert.True(items[key] > 0);
+		}
+	}
+}

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/happy_case_catching_up_to_link_to_events_manual_ack.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/happy_case_catching_up_to_link_to_events_manual_ack.cs
@@ -45,7 +45,7 @@ namespace EventStore.Client.SubscriptionToStream {
 					await StreamsClient.AppendToStreamAsync(Stream, StreamState.Any, new[] {e});
 				}
 
-				await Client.CreateAsync(Stream, Group,
+				await Client.CreateToStreamAsync(Stream, Group,
 					new PersistentSubscriptionSettings(startFrom: StreamPosition.Start, resolveLinkTos: true),
 					userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToStreamAsync(Stream, Group,

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/happy_case_catching_up_to_normal_events_manual_ack.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/happy_case_catching_up_to_normal_events_manual_ack.cs
@@ -40,7 +40,7 @@ namespace EventStore.Client.SubscriptionToStream {
 					await StreamsClient.AppendToStreamAsync(Stream, StreamState.Any, new[] {e});
 				}
 
-				await Client.CreateAsync(Stream, Group,
+				await Client.CreateToStreamAsync(Stream, Group,
 					new PersistentSubscriptionSettings(startFrom: StreamPosition.Start, resolveLinkTos: true),
 					userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToStreamAsync(Stream, Group,

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/happy_case_writing_and_subscribing_to_normal_events_manual_ack.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/happy_case_writing_and_subscribing_to_normal_events_manual_ack.cs
@@ -36,7 +36,7 @@ namespace EventStore.Client.SubscriptionToStream {
 			}
 
 			protected override async Task Given() {
-				await Client.CreateAsync(Stream, Group,
+				await Client.CreateToStreamAsync(Stream, Group,
 					new PersistentSubscriptionSettings(startFrom: StreamPosition.End, resolveLinkTos: true),
 					userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToStreamAsync(Stream, Group,

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/list_with_persistent_subscriptions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/list_with_persistent_subscriptions.cs
@@ -1,0 +1,86 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace EventStore.Client.SubscriptionToStream {
+	public class list_with_persistent_subscriptions : IClassFixture<list_with_persistent_subscriptions.Fixture> {
+		private readonly Fixture _fixture;
+		private const int AllStreamSubscriptionCount = 4;
+		private const int StreamSubscriptionCount = 3;
+		private const string GroupName = nameof(list_with_persistent_subscriptions);
+		private const string StreamName = nameof(list_with_persistent_subscriptions);
+
+		public list_with_persistent_subscriptions(Fixture fixture) {
+			_fixture = fixture;
+		}
+
+		private int TotalSubscriptionCount => SupportsPSToAll.No
+			? StreamSubscriptionCount
+			: AllStreamSubscriptionCount + StreamSubscriptionCount;
+		
+		[Fact]
+		public async Task returns_subscriptions_to_stream() {
+			var result = (await _fixture.Client.ListToStreamAsync(StreamName, userCredentials: TestCredentials.Root)).ToList();
+			Assert.Equal(StreamSubscriptionCount, result.Count);
+			Assert.All(result, p => Assert.Equal(StreamName, p.EventSource));
+		}
+
+		[Fact]
+		public async Task returns_all_subscriptions() {
+			var result = (await _fixture.Client.ListAllAsync(userCredentials: TestCredentials.Root)).ToList();
+			Assert.Equal(TotalSubscriptionCount, result.Count);
+		}
+
+		[Fact]
+		public async Task throws_for_non_existing() {
+			await Assert.ThrowsAsync<PersistentSubscriptionNotFoundException>(async () =>
+				await _fixture.Client.ListToStreamAsync("NonExistingStream", userCredentials: TestCredentials.Root));
+		}
+
+		[Fact]
+		public async Task throws_with_no_credentials() {
+			await Assert.ThrowsAsync<AccessDeniedException>(async () =>
+				await _fixture.Client.ListToStreamAsync("NonExistingStream"));
+		}
+		
+		[Fact]
+		public async Task throws_with_non_existing_user() {
+			await Assert.ThrowsAsync<NotAuthenticatedException>(async () =>
+				await _fixture.Client.ListAllAsync(userCredentials: TestCredentials.TestBadUser));
+		}
+		
+		[Fact]
+		public async Task returns_result_with_normal_user_credentials() {
+			var result = await _fixture.Client.ListAllAsync(userCredentials: TestCredentials.TestUser1);
+			Assert.Equal(TotalSubscriptionCount, result.Count());
+		}
+
+		public class Fixture : EventStoreClientFixture {
+			public Fixture () : base(skipPSWarmUp: true) {
+			}
+			
+			protected override async Task Given() {
+				for (int i = 0; i < StreamSubscriptionCount; i++) {
+					await Client.CreateToStreamAsync(
+						StreamName,
+						GroupName + i,
+						new PersistentSubscriptionSettings(),
+						userCredentials: TestCredentials.Root);
+				}
+
+				if (SupportsPSToAll.No) {
+					return;
+				}
+				
+				for (int i = 0; i < AllStreamSubscriptionCount; i++) {
+					await Client.CreateToAllAsync(
+						GroupName + i,
+						new PersistentSubscriptionSettings(),
+						userCredentials: TestCredentials.Root);
+				}
+			}
+			
+			protected override Task When() => Task.CompletedTask;
+		}
+	}
+}

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/list_without_persistent_subscriptions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/list_without_persistent_subscriptions.cs
@@ -1,0 +1,42 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace EventStore.Client.SubscriptionToStream;
+
+public class list_without_persistent_subscriptions : IClassFixture<list_without_persistent_subscriptions.Fixture> {
+	private readonly Fixture _fixture;
+		
+	public list_without_persistent_subscriptions(Fixture fixture) {
+		_fixture = fixture;
+	}
+
+	[SupportsPSToAll.Fact]
+	public async Task throws() {
+		if (SupportsPSToAll.No) {
+			return;
+		}
+		
+		await Assert.ThrowsAsync<PersistentSubscriptionNotFoundException>(async () => 
+			await _fixture.Client.ListToStreamAsync("stream", userCredentials: TestCredentials.Root));
+	}
+	
+	[Fact]
+	public async Task returns_empty_collection() {
+		if (SupportsPSToAll.No) {
+			return;
+		}
+
+		var result = await _fixture.Client.ListAllAsync(userCredentials: TestCredentials.Root);
+		
+		Assert.Empty(result);
+	}
+	
+	public class Fixture : EventStoreClientFixture {
+		public Fixture () : base(skipPSWarmUp: true) {
+		}
+		
+		protected override Task Given() => Task.CompletedTask;
+
+		protected override Task When() => Task.CompletedTask;
+	}
+}

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/replay_parked.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/replay_parked.cs
@@ -1,0 +1,71 @@
+using System.Threading.Tasks;
+using Xunit;
+
+namespace EventStore.Client.SubscriptionToStream {
+	public class replay_parked : IClassFixture<replay_parked.Fixture> {
+		private readonly Fixture _fixture;
+		private const string GroupName = nameof(replay_parked);
+		private const string StreamName = nameof(replay_parked);
+
+		public replay_parked(Fixture fixture) {
+			_fixture = fixture;
+		}
+		
+		[Fact]
+		public async Task does_not_throw() {
+			await _fixture.Client.ReplayParkedMessagesToStreamAsync(
+				StreamName,
+				GroupName,
+				userCredentials: TestCredentials.Root);
+			
+			await _fixture.Client.ReplayParkedMessagesToStreamAsync(
+				StreamName,
+				GroupName,
+				stopAt: 100,
+				userCredentials: TestCredentials.Root);
+		}
+
+		[Fact]
+		public async Task throws_when_given_non_existing_subscription() {
+			await Assert.ThrowsAsync<PersistentSubscriptionNotFoundException>(() => 
+				_fixture.Client.ReplayParkedMessagesToStreamAsync(
+					streamName: "NonExisting",
+					groupName: "NonExisting",
+					userCredentials: TestCredentials.Root));
+		}
+		
+		[Fact]
+		public async Task throws_with_no_credentials() {
+			await Assert.ThrowsAsync<AccessDeniedException>(() =>
+				_fixture.Client.ReplayParkedMessagesToStreamAsync(StreamName, GroupName));
+		}
+
+		[Fact(Skip = "Unable to produce same behavior with HTTP fallback!")]
+        public async Task throws_with_non_existing_user() {
+        	await Assert.ThrowsAsync<NotAuthenticatedException>(() =>
+        		_fixture.Client.ReplayParkedMessagesToStreamAsync(
+        			StreamName,
+        			GroupName,
+        			userCredentials: TestCredentials.TestBadUser));
+        }
+		
+		[Fact]
+		public async Task throws_with_normal_user_credentials() {
+			await Assert.ThrowsAsync<AccessDeniedException>(() =>
+				_fixture.Client.ReplayParkedMessagesToStreamAsync(
+					StreamName,
+					GroupName,
+					userCredentials: TestCredentials.TestUser1));
+		}
+		
+		public class Fixture : EventStoreClientFixture {
+			protected override Task Given() =>
+				Client.CreateToStreamAsync(
+					StreamName,
+					GroupName,
+					new PersistentSubscriptionSettings(),
+					userCredentials: TestCredentials.Root);
+			protected override Task When() => Task.CompletedTask;
+		}
+	}
+}

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/update_existing.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/update_existing.cs
@@ -14,14 +14,14 @@ namespace EventStore.Client.SubscriptionToStream {
 
 		[Fact]
 		public async Task the_completion_succeeds() {
-			await _fixture.Client.UpdateAsync(Stream, Group,
+			await _fixture.Client.UpdateToStreamAsync(Stream, Group,
 				new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 		}
 
 		public class Fixture : EventStoreClientFixture {
 			protected override async Task Given() {
 				await StreamsClient.AppendToStreamAsync(Stream, StreamState.NoStream, CreateTestEvents());
-				await Client.CreateAsync(Stream, Group, new PersistentSubscriptionSettings(),
+				await Client.CreateToStreamAsync(Stream, Group, new PersistentSubscriptionSettings(),
 					userCredentials: TestCredentials.Root);
 			}
 

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/update_existing_with_check_point.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/update_existing_with_check_point.cs
@@ -11,11 +11,9 @@ namespace EventStore.Client.SubscriptionToStream {
 		private const string Stream = nameof(update_existing_with_check_point);
 		private const string Group = "existing-with-check-point";
 		private readonly Fixture _fixture;
-		private readonly ITestOutputHelper _testOutput;
 
-		public update_existing_with_check_point(Fixture fixture, ITestOutputHelper testOutput) {
+		public update_existing_with_check_point(Fixture fixture) {
 			_fixture = fixture;
-			_testOutput = testOutput;
 		}
 
 		[Fact]
@@ -49,7 +47,7 @@ namespace EventStore.Client.SubscriptionToStream {
 			protected override async Task Given() {
 				await StreamsClient.AppendToStreamAsync(Stream, StreamState.NoStream, _events);
 
-				await Client.CreateAsync(Stream, Group,
+				await Client.CreateToStreamAsync(Stream, Group,
 					new PersistentSubscriptionSettings(
 						checkPointLowerBound: 5,
 						checkPointAfter: TimeSpan.FromSeconds(1),
@@ -90,7 +88,7 @@ namespace EventStore.Client.SubscriptionToStream {
 
 			protected override async Task When() {
 				// Force restart of the subscription
-				await Client.UpdateAsync(Stream, Group, new PersistentSubscriptionSettings(),
+				await Client.UpdateToStreamAsync(Stream, Group, new PersistentSubscriptionSettings(),
 					userCredentials: TestCredentials.Root);
 
 				await _droppedSource.Task.WithTimeout();

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/update_existing_with_subscribers.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/update_existing_with_subscribers.cs
@@ -33,14 +33,14 @@ namespace EventStore.Client.SubscriptionToStream {
 
 			protected override async Task Given() {
 				await StreamsClient.AppendToStreamAsync(Stream, StreamState.NoStream, CreateTestEvents());
-				await Client.CreateAsync(Stream, Group, new PersistentSubscriptionSettings(),
+				await Client.CreateToStreamAsync(Stream, Group, new PersistentSubscriptionSettings(),
 					userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToStreamAsync(Stream, Group,
 					delegate { return Task.CompletedTask; },
 					(_, reason, ex) => _droppedSource.TrySetResult((reason, ex)), TestCredentials.Root);
 			}
 
-			protected override Task When() => Client.UpdateAsync(Stream, Group,
+			protected override Task When() => Client.UpdateToStreamAsync(Stream, Group,
 				new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 
 			public override Task DisposeAsync() {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/update_existing_without_permissions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/update_existing_without_permissions.cs
@@ -15,14 +15,14 @@ namespace EventStore.Client.SubscriptionToStream {
 		[Fact]
 		public async Task the_completion_fails_with_access_denied() {
 			await Assert.ThrowsAsync<AccessDeniedException>(
-				() => _fixture.Client.UpdateAsync(Stream, Group,
+				() => _fixture.Client.UpdateToStreamAsync(Stream, Group,
 					new PersistentSubscriptionSettings()));
 		}
 
 		public class Fixture : EventStoreClientFixture {
 			protected override async Task Given() {
 				await StreamsClient.AppendToStreamAsync(Stream, StreamState.NoStream, CreateTestEvents());
-				await Client.CreateAsync(Stream, Group, new PersistentSubscriptionSettings(),
+				await Client.CreateToStreamAsync(Stream, Group, new PersistentSubscriptionSettings(),
 					userCredentials: TestCredentials.Root);
 			}
 

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/update_non_existent.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/update_non_existent.cs
@@ -15,7 +15,7 @@ namespace EventStore.Client.SubscriptionToStream {
 		[Regression.Fact(21, "20.x returns the wrong exception")]
 		public async Task the_completion_fails_with_not_found() {
 			await Assert.ThrowsAsync<PersistentSubscriptionNotFoundException>(
-				() => _fixture.Client.UpdateAsync(Stream, Group,
+				() => _fixture.Client.UpdateToStreamAsync(Stream, Group,
 					new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root));
 		}
 

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/when_writing_and_subscribing_to_normal_events_manual_nack.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/when_writing_and_subscribing_to_normal_events_manual_nack.cs
@@ -37,7 +37,7 @@ namespace EventStore.Client.SubscriptionToStream {
 			}
 
 			protected override async Task Given() {
-				await Client.CreateAsync(Stream, Group,
+				await Client.CreateToStreamAsync(Stream, Group,
 					new PersistentSubscriptionSettings(startFrom: StreamPosition.Start, resolveLinkTos: true),
 					userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToStreamAsync(Stream, Group,

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SupportsPSToAllFact.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SupportsPSToAllFact.cs
@@ -1,17 +1,19 @@
-using System;
-
 namespace EventStore.Client {
 	internal class SupportsPSToAll {
+		private const int SupportedFromMajorVersion = 21;
 		private static readonly string SkipMessage =
 			"Persistent Subscriptions to $all are not supported on " +
 			$"{EventStoreTestServer.Version?.ToString(3) ?? "unknown"}";
 
 		internal class FactAttribute : Regression.FactAttribute {
-			public FactAttribute() : base(21, SkipMessage) { }
+			public FactAttribute() : base(SupportedFromMajorVersion, SkipMessage) { }
 		}
 
 		internal class TheoryAttribute : Regression.TheoryAttribute {
-			public TheoryAttribute() : base(21, SkipMessage) { }
+			public TheoryAttribute() : base(SupportedFromMajorVersion, SkipMessage) { }
 		}
+
+		internal static bool No => !Yes;
+		internal static bool Yes => (EventStoreTestServer.Version?.Major ?? int.MaxValue) >= SupportedFromMajorVersion;
 	}
 }

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/restart_subsystem.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/restart_subsystem.cs
@@ -1,0 +1,40 @@
+using System.Threading.Tasks;
+using Xunit;
+
+namespace EventStore.Client {
+	public class restart_subsystem : IClassFixture<restart_subsystem.Fixture> {
+		private readonly Fixture _fixture;
+		
+		public restart_subsystem(Fixture fixture) {
+			_fixture = fixture;
+		}
+
+		[Fact]
+		public async Task does_not_throw() {
+			await _fixture.Client.RestartSubsystemAsync(userCredentials: TestCredentials.Root);
+		}
+
+		[Fact]
+		public async Task throws_with_no_credentials() {
+			await Assert.ThrowsAsync<AccessDeniedException>(async () =>
+				await _fixture.Client.RestartSubsystemAsync());
+		}
+
+		[Fact(Skip = "Unable to produce same behavior with HTTP fallback!")]
+		public async Task throws_with_non_existing_user() {
+			await Assert.ThrowsAsync<NotAuthenticatedException>(async () =>
+				await _fixture.Client.RestartSubsystemAsync(userCredentials: TestCredentials.TestBadUser));
+		}
+		
+		[Fact]
+		public async Task throws_with_normal_user_credentials() {
+			await Assert.ThrowsAsync<AccessDeniedException>(async () =>
+				await _fixture.Client.RestartSubsystemAsync(userCredentials: TestCredentials.TestUser1));
+		}
+		
+		public class Fixture : EventStoreClientFixture {
+			protected override Task Given() => Task.CompletedTask;
+			protected override Task When() => Task.CompletedTask;
+		}
+	}
+}

--- a/test/EventStore.Client.ProjectionManagement.Tests/AssertEx.cs
+++ b/test/EventStore.Client.ProjectionManagement.Tests/AssertEx.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Threading;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Xunit.Sdk;
+
+namespace EventStore.Client {
+	public static class AssertEx {
+		/// <summary>
+		/// Asserts the given function will return true before the timeout expires.
+		/// Repeatedly evaluates the function until true is returned or the timeout expires.
+		/// Will return immediately when the condition is true.
+		/// Evaluates the timeout until expired.
+		/// Will not yield the thread by default, if yielding is required to resolve deadlocks set yieldThread to true.
+		/// </summary>
+		/// <param name="func">The function to evaluate.</param>
+		/// <param name="timeout">A timeout in milliseconds. If not specified, defaults to 1000.</param>
+		/// <param name="msg">A message to display if the condition is not satisfied.</param>
+		/// <param name="yieldThread">If true, the thread relinquishes the remainder of its time
+		/// slice to any thread of equal priority that is ready to run.</param>
+		public static async Task IsOrBecomesTrue(Func<Task<bool>> func, TimeSpan? timeout = null,
+			string msg = "AssertEx.IsOrBecomesTrue() timed out", bool yieldThread = false,
+			[CallerMemberName] string memberName = "",
+			[CallerFilePath] string sourceFilePath = "",
+			[CallerLineNumber] int sourceLineNumber = 0) {
+
+			if (await IsOrBecomesTrueImpl(func, timeout, yieldThread))
+				return;
+
+			throw new XunitException($"{msg} in {memberName} {sourceFilePath}:{sourceLineNumber}");
+		}
+		
+		private static async Task<bool> IsOrBecomesTrueImpl(
+			Func<Task<bool>> func,
+			TimeSpan? timeout = null,
+			bool yieldThread = false) {
+			
+			if (await func()) {
+				return true; 
+			}
+
+			var expire = DateTime.UtcNow + (timeout ?? TimeSpan.FromMilliseconds(1000));
+			var spin = new SpinWait();
+
+			while (DateTime.UtcNow <= expire) {
+				if (yieldThread) {
+					Thread.Sleep(0);
+				}
+
+				while (!spin.NextSpinWillYield) {
+					spin.SpinOnce(); 
+				}
+
+				if (await func()) {
+					return true; 
+				}
+
+				spin = new SpinWait();
+			}
+
+			return false;
+		}
+	}
+}

--- a/test/EventStore.Client.ProjectionManagement.Tests/get_result.cs
+++ b/test/EventStore.Client.ProjectionManagement.Tests/get_result.cs
@@ -11,8 +11,17 @@ namespace EventStore.Client {
 
 		[Fact]
 		public async Task returns_expected_result() {
-			var result = await _fixture.Client.GetResultAsync<Result>(nameof(get_result), userCredentials: TestCredentials.TestUser1);
-			Assert.Equal(1, result.Count);
+			Result? result = null;
+
+			await AssertEx.IsOrBecomesTrue(async () => {
+				result = await _fixture.Client
+					.GetResultAsync<Result>(nameof(get_result), userCredentials: TestCredentials.TestUser1);
+
+				return result.Count > 0;
+			});
+
+			Assert.NotNull(result);
+			Assert.Equal(1, result!.Count);
 		}
 
 		private class Result {

--- a/test/EventStore.Client.ProjectionManagement.Tests/get_state.cs
+++ b/test/EventStore.Client.ProjectionManagement.Tests/get_state.cs
@@ -11,10 +11,17 @@ namespace EventStore.Client {
 
 		[Fact]
 		public async Task returns_expected_result() {
-			var result =
-				await _fixture.Client.GetStateAsync<Result>(nameof(get_state),
-					userCredentials: TestCredentials.TestUser1);
-			Assert.Equal(1, result.Count);
+			Result? result = null;
+			
+			await AssertEx.IsOrBecomesTrue(async () => {
+				result = await _fixture.Client
+					.GetStateAsync<Result>(nameof(get_state), userCredentials: TestCredentials.TestUser1);
+
+				return result.Count > 0;
+			});
+			
+			Assert.NotNull(result);
+			Assert.Equal(1, result!.Count);
 		}
 
 		private class Result {

--- a/test/EventStore.Client.Tests.Common/EventStoreClientFixtureBase.cs
+++ b/test/EventStore.Client.Tests.Common/EventStoreClientFixtureBase.cs
@@ -73,7 +73,7 @@ namespace EventStore.Client {
 				TestServer = new EventStoreTestServerExternal();
 			} else {
 				TestServer = GlobalEnvironment.UseCluster
-					? (IEventStoreTestServer)new EventStoreTestServerCluster(hostCertificatePath, Settings.ConnectivitySettings.Address, env)
+					? new EventStoreTestServerCluster(hostCertificatePath, Settings.ConnectivitySettings.Address, env) 
 					: new EventStoreTestServer(hostCertificatePath, Settings.ConnectivitySettings.Address, env);
 			}
 		}

--- a/test/EventStore.Client.Tests.Common/EventStoreTestServer.cs
+++ b/test/EventStore.Client.Tests.Common/EventStoreTestServer.cs
@@ -19,7 +19,6 @@ namespace EventStore.Client {
 		private readonly IContainerService _eventStore;
 		private readonly HttpClient _httpClient;
 		private static readonly string ContainerName = "es-client-dotnet-test";
-		private static readonly string DockerImage = $"ghcr.io/eventstore/eventstore:{GlobalEnvironment.ImageTag}";
 
 		private static Version? _version;
 		public static Version Version => _version ??= GetVersion();
@@ -29,7 +28,7 @@ namespace EventStore.Client {
 
 			using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 			using var eventstore = new Builder().UseContainer()
-				.UseImage(DockerImage)
+				.UseImage(GlobalEnvironment.DockerImage)
 				.Command("--version")
 				.Build()
 				.Start();
@@ -74,7 +73,7 @@ namespace EventStore.Client {
 
 			_eventStore = new Builder()
 				.UseContainer()
-				.UseImage(DockerImage)
+				.UseImage(GlobalEnvironment.DockerImage)
 				.WithEnvironment(env.Select(pair => $"{pair.Key}={pair.Value}").ToArray())
 				.WithName(ContainerName)
 				.MountVolume(_hostCertificatePath, "/etc/eventstore/certs", MountType.ReadOnly)

--- a/test/EventStore.Client.Tests.Common/GlobalEnvironment.cs
+++ b/test/EventStore.Client.Tests.Common/GlobalEnvironment.cs
@@ -18,6 +18,7 @@ namespace EventStore.Client {
 
 		public static bool UseCluster { get; } = false;
 		public static bool UseExternalServer { get; } = false;
+		public static string DockerImage => $"{ContainerRegistry}:{ImageTag}";
 		public static string ImageTag => GetEnvironmentVariable(ImageTagName, ImageTagDefault);
 		public static string DbLogFormat => GetEnvironmentVariable(DbLogFormatName, DbLogFormatDefault);
 
@@ -47,6 +48,7 @@ namespace EventStore.Client {
 
 		static string UseClusterName => "ES_USE_CLUSTER";
 		static string UseExternalServerName => "ES_USE_EXTERNAL_SERVER";
+		private static string ContainerRegistry => "ghcr.io/eventstore/eventstore";
 		static string ImageTagName => "ES_DOCKER_TAG";
 		static string ImageTagDefault => "ci"; // e.g. "21.10.1-focal";
 		static string DbLogFormatName => "EVENTSTORE_DB_LOG_FORMAT";

--- a/test/EventStore.Client.Tests/GrpcServerCapabilitiesClientTests.cs
+++ b/test/EventStore.Client.Tests/GrpcServerCapabilitiesClientTests.cs
@@ -1,5 +1,5 @@
-using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Threading.Tasks;
 using EventStore.Client.ServerFeatures;
 using Grpc.Core;
@@ -69,7 +69,7 @@ namespace EventStore.Client {
 							new EventStoreClientSettings {
 								CreateHttpMessageHandler = kestrel.CreateHandler
 							},
-							new UriBuilder().Uri)
+							new DnsEndPoint("localhost", 80))
 						.CreateCallInvoker(),
 					cancellationToken: default);
 

--- a/test/EventStore.Client.Tests/PositionTests.cs
+++ b/test/EventStore.Client.Tests/PositionTests.cs
@@ -45,5 +45,22 @@ namespace EventStore.Client {
 				Customize<Position>(composer => composer.FromFactory<ulong>(value => new Position(value, value)));
 			}
 		}
+		
+		[Theory, MemberData(nameof(ParseTestCases))]
+		public void TryParse(string s, bool success, Position? expected) {
+			Position? p;
+			Assert.Equal(success, Position.TryParse(s, out p));
+			Assert.Equal(expected, p);
+		}
+		
+		public static IEnumerable<object?[]> ParseTestCases() {
+			yield return new object?[] {"", false, null};
+			yield return new object?[] {"CP", false, null};
+			yield return new object?[] {"C:6\\P:5", false, null};
+			yield return new object[] {Position.Start.ToString(), true, Position.Start};
+			yield return new object[] {Position.End.ToString(), true, Position.End};
+			yield return new object[] {"C:6/P:5", true, new Position(6, 5)};
+			yield return new object[] {"C: 6/P:5", true, new Position(6, 5)};
+		}
 	}
 }


### PR DESCRIPTION
Added: Support `GetInfo()` over gRPC for returning details of a persistent subscription
Added: Support `ReplayParked()` over gRPC for replaying parked messages
Added: Support `List()` over gRPC for listing persistent subscriptions
Added: Support `RestartSubsystem()` over gRPC for restarting the persistent subscription subsystem

Closes #147
Closes #185 
