### PR TITLE
Adjustments to Disposal

### DIFF
--- a/src/EventStore.Client.Operations/EventStoreOperationsClient.cs
+++ b/src/EventStore.Client.Operations/EventStoreOperationsClient.cs
@@ -11,7 +11,7 @@ namespace EventStore.Client {
 	/// <summary>
 	/// The client used to perform maintenance and other administrative tasks on the EventStoreDB.
 	/// </summary>
-	public partial class EventStoreOperationsClient : EventStoreClientBase {
+	public sealed partial class EventStoreOperationsClient : EventStoreClientBase {
 		private static readonly IDictionary<string, Func<RpcException, Exception>> ExceptionMap =
 			new Dictionary<string, Func<RpcException, Exception>> {
 				[Constants.Exceptions.ScavengeNotFound] = ex => new ScavengeNotFoundException(ex.Trailers

--- a/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClient.cs
+++ b/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClient.cs
@@ -10,7 +10,7 @@ namespace EventStore.Client {
 	/// <summary>
 	/// The client used to manage persistent subscriptions in the EventStoreDB.
 	/// </summary>
-	public partial class EventStorePersistentSubscriptionsClient : EventStoreClientBase {
+	public sealed partial class EventStorePersistentSubscriptionsClient : EventStoreClientBase {
 		private readonly ILogger _log;
 
 		/// <summary>

--- a/src/EventStore.Client.ProjectionManagement/EventStoreProjectionManagementClient.cs
+++ b/src/EventStore.Client.ProjectionManagement/EventStoreProjectionManagementClient.cs
@@ -10,7 +10,7 @@ namespace EventStore.Client {
 	/// <summary>
 	///The client used to manage projections on the EventStoreDB.
 	/// </summary>
-	public partial class EventStoreProjectionManagementClient : EventStoreClientBase {
+	public sealed partial class EventStoreProjectionManagementClient : EventStoreClientBase {
 		private readonly ILogger _log;
 
 		/// <summary>

--- a/src/EventStore.Client.UserManagement/EventStoreUserManagementClient.cs
+++ b/src/EventStore.Client.UserManagement/EventStoreUserManagementClient.cs
@@ -14,7 +14,7 @@ namespace EventStore.Client {
 	/// <summary>
 	/// The client used for operations on internal users.
 	/// </summary>
-	public class EventStoreUserManagementClient : EventStoreClientBase {
+	public sealed class EventStoreUserManagementClient : EventStoreClientBase {
 		private readonly ILogger _log;
 
 		/// <summary>

--- a/src/EventStore.Client/EventStoreClientBase.cs
+++ b/src/EventStore.Client/EventStoreClientBase.cs
@@ -98,7 +98,7 @@ namespace EventStore.Client {
 
 #if !GRPC_CORE
 		/// <inheritdoc />
-		public void Dispose() {
+		public virtual void Dispose() {
 			_cts.Cancel();
 			_cts.Dispose();
 			_channelCache.Dispose();
@@ -106,7 +106,7 @@ namespace EventStore.Client {
 #endif
 
 		/// <inheritdoc />
-		public async ValueTask DisposeAsync() {
+		public virtual async ValueTask DisposeAsync() {
 			_cts.Cancel();
 			_cts.Dispose();
 			await _channelCache.DisposeAsync().ConfigureAwait(false);


### PR DESCRIPTION
- Seal the Client classes (no finalizers here)
- Make dispose/async virtual instead of explicit so it will be called in the standard way
- When disposing EventStoreClient don't create a batchappender if there wasn't one.