### PR TITLE
Adjust batch appender

### DIFF
--- a/src/EventStore.Client.Streams/EventStoreClient.cs
+++ b/src/EventStore.Client.Streams/EventStoreClient.cs
@@ -88,7 +88,7 @@ namespace EventStore.Client {
 			return new StreamAppender(Settings, GetCall(), _disposedTokenSource.Token, SwapStreamAppender);
 
 			async Task<AsyncDuplexStreamingCall<BatchAppendReq, BatchAppendResp>?> GetCall() {
-				var channelInfo = await GetChannelInfo(cancellationToken: default).ConfigureAwait(false);
+				var channelInfo = await GetChannelInfo(_disposedTokenSource.Token).ConfigureAwait(false);
 				if (!channelInfo.ServerCapabilities.SupportsBatchAppend)
 					return null;
 


### PR DESCRIPTION
- Recreate batch appender on discovery failure
- Make certain a request cannot be added to a batch appender that is cleaning up
- Make certain IsUsable is called on the same batchappender that we will append with
- Complete the call tidily in the happy path
