### PR TITLE
Removed redundant lines from snippets that were causing formatting issues

### DIFF
--- a/samples/connecting-to-a-cluster/Program.cs
+++ b/samples/connecting-to-a-cluster/Program.cs
@@ -9,7 +9,6 @@ namespace connecting_to_a_cluster {
 
 		private static void ConnectingToACluster() {
 			#region connecting-to-a-cluster
-			
 			using var client = new EventStoreClient(
 				EventStoreClientSettings.Create("esdb://localhost:1114,localhost:2114,localhost:3114")
 			);
@@ -18,7 +17,6 @@ namespace connecting_to_a_cluster {
 
 		private static void ProvidingDefaultCredentials() {
 			#region providing-default-credentials
-			
 			using var client = new EventStoreClient(
 				EventStoreClientSettings.Create("esdb://admin:changeit@localhost:1114,localhost:2114,localhost:3114")
 			);
@@ -27,7 +25,6 @@ namespace connecting_to_a_cluster {
 
 		private static void ConnectingToAClusterComplex() {
 			#region connecting-to-a-cluster-complex
-			
 			using var client = new EventStoreClient(
 				EventStoreClientSettings.Create("esdb://admin:changeit@localhost:1114,localhost:2114,localhost:3114?DiscoveryInterval=30000;GossipTimeout=10000;NodePreference=leader;MaxDiscoverAttempts=5")
 			);

--- a/samples/connecting-to-a-single-node/Program.cs
+++ b/samples/connecting-to-a-single-node/Program.cs
@@ -9,7 +9,6 @@ namespace connecting_to_a_single_node {
 
 		private static void SimpleConnection() {
 			#region creating-simple-connection
-			
 			using var client = new EventStoreClient(
 				EventStoreClientSettings.Create("esdb://localhost:2113")
 			);
@@ -18,7 +17,6 @@ namespace connecting_to_a_single_node {
 
 		private static void ProvidingDefaultCredentials() {
 			#region providing-default-credentials
-
 			using var client = new EventStoreClient(
 				EventStoreClientSettings.Create("esdb://admin:changeit@localhost:2113")
 			);
@@ -27,7 +25,6 @@ namespace connecting_to_a_single_node {
 
 		private static void SpecifyingAConnectionName() {
 			#region setting-the-connection-name
-
 			using var client = new EventStoreClient(
 				EventStoreClientSettings.Create("esdb://admin:changeit@localhost:2113?ConnectionName=SomeConnection")
 			);
@@ -36,7 +33,6 @@ namespace connecting_to_a_single_node {
 
 		private static void OverridingTheTimeout() {
 			#region overriding-timeout
-
 			using var client = new EventStoreClient(
 				EventStoreClientSettings.Create($"esdb://admin:changeit@localhost:2113?OperationTimeout=30000")
 			);
@@ -45,7 +41,6 @@ namespace connecting_to_a_single_node {
 		
 		private static void CombiningSettings() {
 			#region overriding-timeout
-
 			using var client = new EventStoreClient(
 				EventStoreClientSettings.Create($"esdb://admin:changeit@localhost:2113?ConnectionName=SomeConnection&OperationTimeout=30000")
 			);

--- a/samples/persistent-subscriptions/Program.cs
+++ b/samples/persistent-subscriptions/Program.cs
@@ -7,7 +7,7 @@ namespace persistent_subscriptions
     class Program
     {
 	    static async Task Main(string[] args) {
-		    using var client = new EventStorePersistentSubscriptionsClient(
+		    await using var client = new EventStorePersistentSubscriptionsClient(
 			    EventStoreClientSettings.Create("esdb://admin:changeit@localhost:2113?TlsVerifyCert=false")
 		    );
 		    await CreatePersistentSubscription(client);
@@ -21,7 +21,6 @@ namespace persistent_subscriptions
 
 	    static async Task CreatePersistentSubscription(EventStorePersistentSubscriptionsClient client) {
 		    #region create-persistent-subscription-to-stream
-
 		    var userCredentials = new UserCredentials("admin", "changeit");
 
 		    var settings = new PersistentSubscriptionSettings();
@@ -30,13 +29,11 @@ namespace persistent_subscriptions
 			    "subscription-group",
 			    settings,
 			    userCredentials);
-
 		    #endregion create-persistent-subscription-to-stream
 	    }
 
 	    static async Task ConnectToPersistentSubscriptionToStream(EventStorePersistentSubscriptionsClient client) {
 		    #region subscribe-to-persistent-subscription-to-stream
-
 		    var subscription = await client.SubscribeToStreamAsync(
 			    "test-stream",
 			    "subscription-group",
@@ -46,13 +43,11 @@ namespace persistent_subscriptions
 			    }, (subscription, dropReason, exception) => {
 				    Console.WriteLine($"Subscription was dropped due to {dropReason}. {exception}");
 			    });
-
 		    #endregion subscribe-to-persistent-subscription-to-stream
 	    }
 
 	    static async Task CreatePersistentSubscriptionToAll(EventStorePersistentSubscriptionsClient client) {
 		    #region create-persistent-subscription-to-all
-
 		    var userCredentials = new UserCredentials("admin", "changeit");
 		    var filter = StreamFilter.Prefix("test");
 
@@ -62,13 +57,11 @@ namespace persistent_subscriptions
 			    filter,
 			    settings,
 			    userCredentials);
-
 		    #endregion create-persistent-subscription-to-all
 	    }
 
 	    static async Task ConnectToPersistentSubscriptionToAll(EventStorePersistentSubscriptionsClient client) {
 		    #region subscribe-to-persistent-subscription-to-all
-
 		    await client.SubscribeToAllAsync(
 			    "subscription-group",
 			    async (subscription, evnt, retryCount, cancellationToken) => {
@@ -76,13 +69,11 @@ namespace persistent_subscriptions
 			    }, (subscription, dropReason, exception) => {
 				    Console.WriteLine($"Subscription was dropped due to {dropReason}. {exception}");
 			    });
-
 		    #endregion subscribe-to-persistent-subscription-to-all
 	    }
 
 	    static async Task ConnectToPersistentSubscriptionWithManualAcks(EventStorePersistentSubscriptionsClient client) {
 		    #region subscribe-to-persistent-subscription-with-manual-acks
-
 		    var subscription = await client.SubscribeToStreamAsync(
 			    "test-stream",
 			    "subscription-group",
@@ -96,13 +87,11 @@ namespace persistent_subscriptions
 			    }, (subscription, dropReason, exception) => {
 				    Console.WriteLine($"Subscription was dropped due to {dropReason}. {exception}");
 			    });
-
 		    #endregion subscribe-to-persistent-subscription-with-manual-acks
 	    }
 
 	    static async Task UpdatePersistentSubscription(EventStorePersistentSubscriptionsClient client) {
 		    #region update-persistent-subscription
-
 		    var userCredentials = new UserCredentials("admin", "changeit");
 		    var settings = new PersistentSubscriptionSettings(
 			    resolveLinkTos: true,
@@ -113,19 +102,16 @@ namespace persistent_subscriptions
 			    "subscription-group",
 			    settings,
 			    userCredentials);
-
 		    #endregion update-persistent-subscription
 	    }
 
 	    static async Task DeletePersistentSubscription(EventStorePersistentSubscriptionsClient client) {
 		    #region delete-persistent-subscription
-
 		    var userCredentials = new UserCredentials("admin", "changeit");
 		    await client.DeleteAsync(
 			    "test-stream",
 			    "subscription-group",
 			    userCredentials);
-
 		    #endregion delete-persistent-subscription
 	    }
 

--- a/samples/reading-events/Program.cs
+++ b/samples/reading-events/Program.cs
@@ -52,17 +52,14 @@ namespace reading_events {
 
 		private static async Task ReadFromStreamMessages(EventStoreClient client) {
 			#region read-from-stream-messages
-
 			var streamPosition = StreamPosition.Start;
 			var results = client.ReadStreamAsync(
 				Direction.Forwards,
 				"some-stream",
 				streamPosition);
-
 			#endregion read-from-stream-messages
 
 			#region iterate-stream-messages
-
 			await foreach (var message in results.Messages) {
 				switch (message) {
 					case StreamMessage.Ok ok:
@@ -85,7 +82,6 @@ namespace reading_events {
 						break;
 				}
 			}
-
 			#endregion iterate-stream-messages
 		}
 
@@ -138,16 +134,13 @@ namespace reading_events {
 
 		private static async Task ReadFromStreamMessagesBackwards(EventStoreClient client) {
 			#region read-from-stream-messages-backwards
-
 			var results = client.ReadStreamAsync(
 				Direction.Forwards,
 				"some-stream",
 				StreamPosition.End);
-
 			#endregion read-from-stream-messages-backwards
 
 			#region iterate-stream-messages-backwards
-
 			await foreach (var message in results.Messages) {
 				switch (message) {
 					case StreamMessage.Ok ok:
@@ -164,7 +157,6 @@ namespace reading_events {
 						break;
 				}
 			}
-
 			#endregion iterate-stream-messages-backwards
 		}
 
@@ -184,16 +176,13 @@ namespace reading_events {
 
 		private static async Task ReadFromAllStreamMessages(EventStoreClient client) {
 			#region read-from-all-stream-messages
-
 			var position = Position.Start;
 			var results = client.ReadAllAsync(
 				Direction.Forwards,
 				position: position);
-
 			#endregion read-from-all-stream-messages
 
 			#region iterate-all-stream-messages
-
 			await foreach (var message in results.Messages) {
 				switch (message) {
 					case StreamMessage.Event(var resolvedEvent):
@@ -204,7 +193,6 @@ namespace reading_events {
 						break;
 				}
 			}
-
 			#endregion iterate-all-stream-messages
 		}
 
@@ -238,16 +226,13 @@ namespace reading_events {
 
 		private static async Task ReadFromAllStreamBackwardsMessages(EventStoreClient client) {
 			#region read-from-all-stream-messages-backwards
-
 			var position = Position.End;
 			var results = client.ReadAllAsync(
 				Direction.Backwards,
 				position: position);
-
 			#endregion read-from-all-stream-messages-backwards
 
 			#region iterate-all-stream-messages-backwards
-
 			await foreach (var message in results.Messages) {
 				switch (message) {
 					case StreamMessage.Event(var resolvedEvent):
@@ -259,7 +244,6 @@ namespace reading_events {
 						break;
 				}
 			}
-
 			#endregion iterate-all-stream-messages-backwards
 		}
 

--- a/samples/setting-up-dependency-injection/Startup.cs
+++ b/samples/setting-up-dependency-injection/Startup.cs
@@ -19,7 +19,6 @@ namespace setting_up_dependency_injection {
 			services.AddControllers();
 
 			#region setting-up-dependency
-			
 			services.AddEventStoreClient("esdb://admin:changeit@localhost:2113?TlsVerifyCert=false");
 			#endregion setting-up-dependency
 		}

--- a/samples/subscribing-to-streams/Program.cs
+++ b/samples/subscribing-to-streams/Program.cs
@@ -89,7 +89,6 @@ namespace subscribing_to_streams {
 			#endregion subscribe-to-all-live
 			
 			#region subscribe-to-all-subscription-dropped
-
 			var checkpoint = Position.Start;
 			await client.SubscribeToAllAsync(
 				checkpoint,


### PR DESCRIPTION
To be correctly rendered without redundant lines/spaces, there shouldn't be new lines after `#region` or `#endregion` in the snippets.

Fixed also samples build after change to `AsyncDisposable`.