### PR TITLE
Implement RFC 032 gRPC Client Deadlines

### DIFF
--- a/samples/appending-events/Program.cs
+++ b/samples/appending-events/Program.cs
@@ -101,11 +101,11 @@ namespace appending_events {
 			await client.AppendToStreamAsync("concurrency-stream", StreamRevision.None,
 				new[] {new EventData(Uuid.NewUuid(), "-", ReadOnlyMemory<byte>.Empty)});
 			#region append-with-concurrency-check
+
 			var clientOneRead = client.ReadStreamAsync(
 				Direction.Forwards,
 				"concurrency-stream",
-				StreamPosition.Start,
-				configureOperationOptions: options => options.ThrowOnAppendFailure = false);
+				StreamPosition.Start);
 			var clientOneRevision = (await clientOneRead.LastAsync()).Event.EventNumber.ToUInt64();
 
 			var clientTwoRead = client.ReadStreamAsync(Direction.Forwards, "concurrency-stream", StreamPosition.Start);

--- a/samples/persistent-subscriptions/Program.cs
+++ b/samples/persistent-subscriptions/Program.cs
@@ -28,7 +28,7 @@ namespace persistent_subscriptions
 			    "test-stream",
 			    "subscription-group",
 			    settings,
-			    userCredentials);
+			    userCredentials: userCredentials);
 		    #endregion create-persistent-subscription-to-stream
 	    }
 
@@ -56,7 +56,7 @@ namespace persistent_subscriptions
 			    "subscription-group",
 			    filter,
 			    settings,
-			    userCredentials);
+			    userCredentials: userCredentials);
 		    #endregion create-persistent-subscription-to-all
 	    }
 
@@ -101,7 +101,7 @@ namespace persistent_subscriptions
 			    "test-stream",
 			    "subscription-group",
 			    settings,
-			    userCredentials);
+			    userCredentials: userCredentials);
 		    #endregion update-persistent-subscription
 	    }
 
@@ -111,7 +111,7 @@ namespace persistent_subscriptions
 		    await client.DeleteAsync(
 			    "test-stream",
 			    "subscription-group",
-			    userCredentials);
+			    userCredentials: userCredentials);
 		    #endregion delete-persistent-subscription
 	    }
 

--- a/src/EventStore.Client.Operations/EventStoreOperationsClient.Admin.cs
+++ b/src/EventStore.Client.Operations/EventStoreOperationsClient.Admin.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Client.Operations;
@@ -10,48 +11,54 @@ namespace EventStore.Client {
 		/// <summary>
 		/// Shuts down the EventStoreDB node.
 		/// </summary>
+		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
 		public async Task ShutdownAsync(
+			TimeSpan? deadline = null,
 			UserCredentials? userCredentials = null,
 			CancellationToken cancellationToken = default) {
 			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
 			using var call = new Operations.Operations.OperationsClient(
 				channelInfo.CallInvoker).ShutdownAsync(EmptyResult,
-				EventStoreCallOptions.Create(Settings, Settings.OperationOptions, userCredentials, cancellationToken));
+				EventStoreCallOptions.CreateNonStreaming(Settings, deadline, userCredentials, cancellationToken));
 			await call.ResponseAsync.ConfigureAwait(false);
 		}
 
 		/// <summary>
 		/// Initiates an index merge operation.
 		/// </summary>
+		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
 		public async Task MergeIndexesAsync(
+			TimeSpan? deadline = null,
 			UserCredentials? userCredentials = null,
 			CancellationToken cancellationToken = default) {
 			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
 			using var call = new Operations.Operations.OperationsClient(
 				channelInfo.CallInvoker).MergeIndexesAsync(EmptyResult,
-				EventStoreCallOptions.Create(Settings, Settings.OperationOptions, userCredentials, cancellationToken));
+				EventStoreCallOptions.CreateNonStreaming(Settings, deadline, userCredentials, cancellationToken));
 			await call.ResponseAsync.ConfigureAwait(false);
 		}
 
 		/// <summary>
 		/// Resigns a node.
 		/// </summary>
+		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
 		public async Task ResignNodeAsync(
+			TimeSpan? deadline = null,
 			UserCredentials? userCredentials = null,
 			CancellationToken cancellationToken = default) {
 			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
 			using var call = new Operations.Operations.OperationsClient(
 				channelInfo.CallInvoker).ResignNodeAsync(EmptyResult,
-				EventStoreCallOptions.Create(Settings, Settings.OperationOptions, userCredentials, cancellationToken));
+				EventStoreCallOptions.CreateNonStreaming(Settings, deadline, userCredentials, cancellationToken));
 			await call.ResponseAsync.ConfigureAwait(false);
 		}
 
@@ -59,33 +66,38 @@ namespace EventStore.Client {
 		/// Sets the node priority.
 		/// </summary>
 		/// <param name="nodePriority"></param>
+		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
 		public async Task SetNodePriorityAsync(int nodePriority,
+			TimeSpan? deadline = null,
 			UserCredentials? userCredentials = null,
 			CancellationToken cancellationToken = default) {
 			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
 			using var call = new Operations.Operations.OperationsClient(
 				channelInfo.CallInvoker).SetNodePriorityAsync(
 				new SetNodePriorityReq {Priority = nodePriority},
-				EventStoreCallOptions.Create(Settings, Settings.OperationOptions, userCredentials, cancellationToken));
+				EventStoreCallOptions.CreateNonStreaming(Settings, deadline, userCredentials, cancellationToken));
 			await call.ResponseAsync.ConfigureAwait(false);
 		}
 
 		/// <summary>
 		/// Restart persistent subscriptions
 		/// </summary>
+		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
-		public async Task RestartPersistentSubscriptions(UserCredentials? userCredentials = null,
+		public async Task RestartPersistentSubscriptions(
+			TimeSpan? deadline = null,
+			UserCredentials? userCredentials = null,
 			CancellationToken cancellationToken = default) {
 			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
 			using var call = new Operations.Operations.OperationsClient(
 				channelInfo.CallInvoker).RestartPersistentSubscriptionsAsync(
 				EmptyResult,
-				EventStoreCallOptions.Create(Settings, Settings.OperationOptions, userCredentials, cancellationToken));
+				EventStoreCallOptions.CreateNonStreaming(Settings, deadline, userCredentials, cancellationToken));
 			await call.ResponseAsync.ConfigureAwait(false);
 		}
 	}

--- a/src/EventStore.Client.Operations/EventStoreOperationsClient.Scavenge.cs
+++ b/src/EventStore.Client.Operations/EventStoreOperationsClient.Scavenge.cs
@@ -11,6 +11,7 @@ namespace EventStore.Client {
 		/// </summary>
 		/// <param name="threadCount"></param>
 		/// <param name="startFromChunk"></param>
+		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
@@ -18,6 +19,7 @@ namespace EventStore.Client {
 		public async Task<DatabaseScavengeResult> StartScavengeAsync(
 			int threadCount = 1,
 			int startFromChunk = 0,
+			TimeSpan? deadline = null,
 			UserCredentials? userCredentials = null,
 			CancellationToken cancellationToken = default) {
 			if (threadCount <= 0) {
@@ -37,8 +39,7 @@ namespace EventStore.Client {
 						StartFromChunk = startFromChunk
 					}
 				},
-				EventStoreCallOptions.Create(Settings, Settings.OperationOptions, userCredentials,
-					cancellationToken));
+				EventStoreCallOptions.CreateNonStreaming(Settings, deadline, userCredentials, cancellationToken));
 			var result = await call.ResponseAsync.ConfigureAwait(false);
 
 			return result.ScavengeResult switch {
@@ -53,11 +54,13 @@ namespace EventStore.Client {
 		/// Stops a scavenge operation.
 		/// </summary>
 		/// <param name="scavengeId"></param>
+		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
 		public async Task<DatabaseScavengeResult> StopScavengeAsync(
 			string scavengeId,
+			TimeSpan? deadline = null,
 			UserCredentials? userCredentials = null,
 			CancellationToken cancellationToken = default) {
 			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
@@ -66,7 +69,7 @@ namespace EventStore.Client {
 				Options = new StopScavengeReq.Types.Options {
 					ScavengeId = scavengeId
 				}
-			}, EventStoreCallOptions.Create(Settings, Settings.OperationOptions, userCredentials, cancellationToken));
+			}, EventStoreCallOptions.CreateNonStreaming(Settings, deadline, userCredentials, cancellationToken));
 
 			return result.ScavengeResult switch {
 				ScavengeResp.Types.ScavengeResult.Started => DatabaseScavengeResult.Started(result.ScavengeId),

--- a/src/EventStore.Client.Operations/EventStoreOperationsClientServiceCollectionExtensions.cs
+++ b/src/EventStore.Client.Operations/EventStoreOperationsClientServiceCollectionExtensions.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Net.Http;
 using EventStore.Client;
-using EventStore.Client.Operations;
 using Grpc.Core.Interceptors;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;

--- a/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClient.Delete.cs
+++ b/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClient.Delete.cs
@@ -11,11 +11,12 @@ namespace EventStore.Client {
 		/// </summary>
 		/// <param name="streamName"></param>
 		/// <param name="groupName"></param>
+		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
-		public async Task DeleteAsync(string streamName, string groupName, UserCredentials? userCredentials = null,
-			CancellationToken cancellationToken = default) {
+		public async Task DeleteAsync(string streamName, string groupName, TimeSpan? deadline = null,
+			UserCredentials? userCredentials = null, CancellationToken cancellationToken = default) {
 			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
 
 			if (streamName == SystemStreams.AllStream &&
@@ -34,10 +35,11 @@ namespace EventStore.Client {
 			}
 
 			using var call =
-				new PersistentSubscriptions.PersistentSubscriptions.PersistentSubscriptionsClient(channelInfo.CallInvoker)
-				.DeleteAsync(new DeleteReq {Options = deleteOptions},
-					EventStoreCallOptions.Create(Settings, Settings.OperationOptions, userCredentials,
-						cancellationToken));
+				new PersistentSubscriptions.PersistentSubscriptions.PersistentSubscriptionsClient(
+						channelInfo.CallInvoker)
+					.DeleteAsync(new DeleteReq {Options = deleteOptions},
+						EventStoreCallOptions.CreateNonStreaming(Settings, deadline, userCredentials,
+							cancellationToken));
 			await call.ResponseAsync.ConfigureAwait(false);
 		}
 
@@ -45,16 +47,13 @@ namespace EventStore.Client {
 		/// Deletes a persistent subscription to $all.
 		/// </summary>
 		/// <param name="groupName"></param>
+		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
-		public async Task DeleteToAllAsync(string groupName, UserCredentials? userCredentials = null,
-			CancellationToken cancellationToken = default) =>
-			await DeleteAsync(
-					streamName: SystemStreams.AllStream,
-					groupName: groupName,
-					userCredentials: userCredentials,
-					cancellationToken: cancellationToken)
+		public async Task DeleteToAllAsync(string groupName, TimeSpan? deadline = null,
+			UserCredentials? userCredentials = null, CancellationToken cancellationToken = default) =>
+			await DeleteAsync(SystemStreams.AllStream, groupName, deadline, userCredentials, cancellationToken)
 				.ConfigureAwait(false);
 	}
 }

--- a/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClient.Read.cs
+++ b/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClient.Read.cs
@@ -32,8 +32,8 @@ namespace EventStore.Client {
 					$"AutoAck is no longer supported. Please use {nameof(SubscribeToStreamAsync)} with manual acks instead.");
 			}
 
-			return await SubscribeToStreamAsync(streamName, groupName, eventAppeared, subscriptionDropped, userCredentials,
-				bufferSize, cancellationToken).ConfigureAwait(false);
+			return await SubscribeToStreamAsync(streamName, groupName, eventAppeared, subscriptionDropped,
+				userCredentials, bufferSize, cancellationToken).ConfigureAwait(false);
 		}
 
 		/// <summary>
@@ -79,9 +79,6 @@ namespace EventStore.Client {
 				throw new ArgumentOutOfRangeException(nameof(bufferSize));
 			}
 
-			var operationOptions = Settings.OperationOptions.Clone();
-			operationOptions.TimeoutAfter = new TimeSpan?();
-
 			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
 
 			if (streamName == SystemStreams.AllStream &&
@@ -101,8 +98,7 @@ namespace EventStore.Client {
 				readOptions.StreamIdentifier = streamName;
 			}
 
-			return await PersistentSubscription.Confirm(channelInfo.Channel, channelInfo.CallInvoker, Settings, 
-				operationOptions, userCredentials, readOptions, _log, eventAppeared,
+			return await PersistentSubscription.Confirm(channelInfo.Channel, channelInfo.CallInvoker, Settings, userCredentials, readOptions, _log, eventAppeared,
 				subscriptionDropped ?? delegate { }, cancellationToken).ConfigureAwait(false);
 		}
 
@@ -121,14 +117,8 @@ namespace EventStore.Client {
 			Action<PersistentSubscription, SubscriptionDroppedReason, Exception?>? subscriptionDropped = null,
 			UserCredentials? userCredentials = null, int bufferSize = 10,
 			CancellationToken cancellationToken = default) =>
-			await SubscribeToStreamAsync(
-					streamName: SystemStreams.AllStream,
-					groupName: groupName,
-					eventAppeared: eventAppeared,
-					subscriptionDropped: subscriptionDropped,
-					userCredentials: userCredentials,
-					bufferSize: bufferSize,
-					cancellationToken: cancellationToken)
+			await SubscribeToStreamAsync(SystemStreams.AllStream, groupName, eventAppeared, subscriptionDropped,
+					userCredentials, bufferSize, cancellationToken)
 				.ConfigureAwait(false);
 	}
 }

--- a/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClient.Update.cs
+++ b/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClient.Update.cs
@@ -64,12 +64,13 @@ namespace EventStore.Client {
 		/// <param name="streamName"></param>
 		/// <param name="groupName"></param>
 		/// <param name="settings"></param>
+		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
 		/// <exception cref="ArgumentNullException"></exception>
 		public async Task UpdateAsync(string streamName, string groupName, PersistentSubscriptionSettings settings,
-			UserCredentials? userCredentials = null,
+			TimeSpan? deadline = null, UserCredentials? userCredentials = null,
 			CancellationToken cancellationToken = default) {
 			if (streamName == null) {
 				throw new ArgumentNullException(nameof(streamName));
@@ -141,8 +142,7 @@ namespace EventStore.Client {
 							}
 						}
 					},
-					EventStoreCallOptions.Create(Settings, Settings.OperationOptions, userCredentials,
-						cancellationToken));
+					EventStoreCallOptions.CreateNonStreaming(Settings, deadline, userCredentials, cancellationToken));
 			await call.ResponseAsync.ConfigureAwait(false);
 		}
 
@@ -151,18 +151,15 @@ namespace EventStore.Client {
 		/// </summary>
 		/// <param name="groupName"></param>
 		/// <param name="settings"></param>
+		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
 		public async Task UpdateToAllAsync(string groupName, PersistentSubscriptionSettings settings,
-			UserCredentials? userCredentials = null,
+			TimeSpan? deadline = null, UserCredentials? userCredentials = null,
 			CancellationToken cancellationToken = default) =>
-			await UpdateAsync(
-					streamName: SystemStreams.AllStream,
-					groupName: groupName,
-					settings: settings,
-					userCredentials: userCredentials,
-					cancellationToken: cancellationToken)
+			await UpdateAsync(SystemStreams.AllStream, groupName, settings, deadline, userCredentials,
+					cancellationToken)
 				.ConfigureAwait(false);
 	}
 }

--- a/src/EventStore.Client.PersistentSubscriptions/PersistentSubscription.cs
+++ b/src/EventStore.Client.PersistentSubscriptions/PersistentSubscription.cs
@@ -28,9 +28,8 @@ namespace EventStore.Client {
 		public string SubscriptionId { get; }
 
 		internal static async Task<PersistentSubscription> Confirm(
-			ChannelBase channel, CallInvoker callInvoker, EventStoreClientSettings settings,
-			EventStoreClientOperationOptions operationOptions, UserCredentials? userCredentials,
-			ReadReq.Types.Options options, ILogger log,
+			ChannelBase channel, CallInvoker callInvoker, EventStoreClientSettings settings, 
+			UserCredentials? userCredentials, ReadReq.Types.Options options, ILogger log,
 			Func<PersistentSubscription, ResolvedEvent, int?, CancellationToken, Task> eventAppeared,
 			Action<PersistentSubscription, SubscriptionDroppedReason, Exception?> subscriptionDropped,
 			CancellationToken cancellationToken = default) {
@@ -43,7 +42,8 @@ namespace EventStore.Client {
 #endif
 
 			var call = new PersistentSubscriptions.PersistentSubscriptions.PersistentSubscriptionsClient(callInvoker)
-				.Read(EventStoreCallOptions.Create(settings, operationOptions, userCredentials, cts.Token));
+				.Read(EventStoreCallOptions.CreateStreaming(settings, userCredentials: userCredentials,
+					cancellationToken: cts.Token));
 
 			await call.RequestStream.WriteAsync(new ReadReq {
 				Options = options

--- a/src/EventStore.Client.ProjectionManagement/EventStoreProjectionManagementClient.Control.cs
+++ b/src/EventStore.Client.ProjectionManagement/EventStoreProjectionManagementClient.Control.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Client.Projections;
@@ -9,10 +10,11 @@ namespace EventStore.Client {
 		/// Enables a projection.
 		/// </summary>
 		/// <param name="name"></param>
+		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
-		public async Task EnableAsync(string name, UserCredentials? userCredentials = null,
+		public async Task EnableAsync(string name, TimeSpan? deadline = null, UserCredentials? userCredentials = null,
 			CancellationToken cancellationToken = default) {
 			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
 			using var call = new Projections.Projections.ProjectionsClient(
@@ -20,7 +22,7 @@ namespace EventStore.Client {
 				Options = new EnableReq.Types.Options {
 					Name = name
 				}
-			}, EventStoreCallOptions.Create(Settings, Settings.OperationOptions, userCredentials, cancellationToken));
+			}, EventStoreCallOptions.CreateNonStreaming(Settings, deadline, userCredentials, cancellationToken));
 			await call.ResponseAsync.ConfigureAwait(false);
 		}
 
@@ -28,10 +30,11 @@ namespace EventStore.Client {
 		/// Resets a projection. This will re-emit events. Streams that are written to from the projection will also be soft deleted.
 		/// </summary>
 		/// <param name="name"></param>
+		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
-		public async Task ResetAsync(string name, UserCredentials? userCredentials = null,
+		public async Task ResetAsync(string name, TimeSpan? deadline = null, UserCredentials? userCredentials = null,
 			CancellationToken cancellationToken = default) {
 			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
 			using var call = new Projections.Projections.ProjectionsClient(
@@ -40,7 +43,7 @@ namespace EventStore.Client {
 					Name = name,
 					WriteCheckpoint = true
 				}
-			}, EventStoreCallOptions.Create(Settings, Settings.OperationOptions, userCredentials, cancellationToken));
+			}, EventStoreCallOptions.CreateNonStreaming(Settings, deadline, userCredentials, cancellationToken));
 			await call.ResponseAsync.ConfigureAwait(false);
 		}
 
@@ -48,26 +51,44 @@ namespace EventStore.Client {
 		/// Aborts a projection. Does not save the projection's checkpoint.
 		/// </summary>
 		/// <param name="name"></param>
+		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
-		public Task AbortAsync(string name, UserCredentials? userCredentials = null,
+		public Task AbortAsync(string name, TimeSpan? deadline = null, UserCredentials? userCredentials = null,
 			CancellationToken cancellationToken = default) =>
-			DisableInternalAsync(name, false, userCredentials, cancellationToken);
+			DisableInternalAsync(name, false, deadline, userCredentials, cancellationToken);
 
 		/// <summary>
 		/// Disables a projection. Saves the projection's checkpoint.
 		/// </summary>
 		/// <param name="name"></param>
+		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
-		public Task DisableAsync(string name, UserCredentials? userCredentials = null,
+		public Task DisableAsync(string name, TimeSpan? deadline = null, UserCredentials? userCredentials = null,
 			CancellationToken cancellationToken = default) =>
-			DisableInternalAsync(name, true, userCredentials, cancellationToken);
+			DisableInternalAsync(name, true, deadline, userCredentials, cancellationToken);
 
-		private async Task DisableInternalAsync(string name, bool writeCheckpoint, UserCredentials? userCredentials,
-			CancellationToken cancellationToken) {
+		/// <summary>
+		/// Restarts the projection subsystem.
+		/// </summary>
+		/// <param name="deadline"></param>
+		/// <param name="userCredentials"></param>
+		/// <param name="cancellationToken"></param>
+		/// <returns></returns>
+		public async Task RestartSubsystemAsync(TimeSpan? deadline = null, UserCredentials? userCredentials = null,
+			CancellationToken cancellationToken = default) {
+			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
+			using var call = new Projections.Projections.ProjectionsClient(
+				channelInfo.CallInvoker).RestartSubsystemAsync(new Empty(),
+				EventStoreCallOptions.CreateNonStreaming(Settings, deadline, userCredentials, cancellationToken));
+			await call.ResponseAsync.ConfigureAwait(false);
+		}
+		
+		private async Task DisableInternalAsync(string name, bool writeCheckpoint, TimeSpan? deadline,
+			UserCredentials? userCredentials, CancellationToken cancellationToken) {
 			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
 			using var call = new Projections.Projections.ProjectionsClient(
 				channelInfo.CallInvoker).DisableAsync(new DisableReq {
@@ -75,22 +96,7 @@ namespace EventStore.Client {
 					Name = name,
 					WriteCheckpoint = writeCheckpoint
 				}
-			}, EventStoreCallOptions.Create(Settings, Settings.OperationOptions, userCredentials, cancellationToken));
-			await call.ResponseAsync.ConfigureAwait(false);
-		}
-
-		/// <summary>
-		/// Restarts the projection subsystem.
-		/// </summary>
-		/// <param name="userCredentials"></param>
-		/// <param name="cancellationToken"></param>
-		/// <returns></returns>
-		public async Task RestartSubsystemAsync(UserCredentials? userCredentials = null,
-			CancellationToken cancellationToken = default) {
-			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
-			using var call = new Projections.Projections.ProjectionsClient(
-				channelInfo.CallInvoker).RestartSubsystemAsync(new Empty(),
-				EventStoreCallOptions.Create(Settings, Settings.OperationOptions, userCredentials, cancellationToken));
+			}, EventStoreCallOptions.CreateNonStreaming(Settings, deadline, userCredentials, cancellationToken));
 			await call.ResponseAsync.ConfigureAwait(false);
 		}
 	}

--- a/src/EventStore.Client.ProjectionManagement/EventStoreProjectionManagementClient.Create.cs
+++ b/src/EventStore.Client.ProjectionManagement/EventStoreProjectionManagementClient.Create.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Client.Projections;
@@ -9,11 +10,12 @@ namespace EventStore.Client {
 		/// Creates a one-time projection.
 		/// </summary>
 		/// <param name="query"></param>
+		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
-		public async Task CreateOneTimeAsync(string query, UserCredentials? userCredentials = null,
-			CancellationToken cancellationToken = default) {
+		public async Task CreateOneTimeAsync(string query, TimeSpan? deadline = null,
+			UserCredentials? userCredentials = null, CancellationToken cancellationToken = default) {
 			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
 			using var call = new Projections.Projections.ProjectionsClient(
 				channelInfo.CallInvoker).CreateAsync(new CreateReq {
@@ -21,7 +23,7 @@ namespace EventStore.Client {
 					OneTime = new Empty(),
 					Query = query
 				}
-			}, EventStoreCallOptions.Create(Settings, Settings.OperationOptions, userCredentials, cancellationToken));
+			}, EventStoreCallOptions.CreateNonStreaming(Settings, deadline, userCredentials, cancellationToken));
 			await call.ResponseAsync.ConfigureAwait(false);
 		}
 
@@ -31,11 +33,13 @@ namespace EventStore.Client {
 		/// <param name="name"></param>
 		/// <param name="query"></param>
 		/// <param name="trackEmittedStreams"></param>
+		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
 		public async Task CreateContinuousAsync(string name, string query, bool trackEmittedStreams = false,
-			UserCredentials? userCredentials = null, CancellationToken cancellationToken = default) {
+			TimeSpan? deadline = null, UserCredentials? userCredentials = null,
+			CancellationToken cancellationToken = default) {
 			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
 			using var call = new Projections.Projections.ProjectionsClient(
 				channelInfo.CallInvoker).CreateAsync(new CreateReq {
@@ -46,7 +50,7 @@ namespace EventStore.Client {
 					},
 					Query = query
 				}
-			}, EventStoreCallOptions.Create(Settings, Settings.OperationOptions, userCredentials, cancellationToken));
+			}, EventStoreCallOptions.CreateNonStreaming(Settings, deadline, userCredentials, cancellationToken));
 			await call.ResponseAsync.ConfigureAwait(false);
 		}
 
@@ -55,11 +59,12 @@ namespace EventStore.Client {
 		/// </summary>
 		/// <param name="name"></param>
 		/// <param name="query"></param>
+		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
-		public async Task CreateTransientAsync(string name, string query, UserCredentials? userCredentials = null,
-			CancellationToken cancellationToken = default) {
+		public async Task CreateTransientAsync(string name, string query, TimeSpan? deadline = null,
+			UserCredentials? userCredentials = null, CancellationToken cancellationToken = default) {
 			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
 			using var call = new Projections.Projections.ProjectionsClient(
 				channelInfo.CallInvoker).CreateAsync(new CreateReq {
@@ -69,7 +74,7 @@ namespace EventStore.Client {
 					},
 					Query = query
 				}
-			}, EventStoreCallOptions.Create(Settings, Settings.OperationOptions, userCredentials, cancellationToken));
+			}, EventStoreCallOptions.CreateNonStreaming(Settings, deadline, userCredentials, cancellationToken));
 			await call.ResponseAsync.ConfigureAwait(false);
 		}
 	}

--- a/src/EventStore.Client.ProjectionManagement/EventStoreProjectionManagementClient.Update.cs
+++ b/src/EventStore.Client.ProjectionManagement/EventStoreProjectionManagementClient.Update.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Client.Projections;
@@ -11,11 +12,13 @@ namespace EventStore.Client {
 		/// <param name="name"></param>
 		/// <param name="query"></param>
 		/// <param name="emitEnabled"></param>
+		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
 		public async Task UpdateAsync(string name, string query, bool? emitEnabled = null,
-			UserCredentials? userCredentials = null, CancellationToken cancellationToken = default) {
+			TimeSpan? deadline = null, UserCredentials? userCredentials = null,
+			CancellationToken cancellationToken = default) {
 			var options = new UpdateReq.Types.Options {
 				Name = name,
 				Query = query
@@ -30,7 +33,7 @@ namespace EventStore.Client {
 			using var call = new Projections.Projections.ProjectionsClient(
 				channelInfo.CallInvoker).UpdateAsync(new UpdateReq {
 				Options = options
-			}, EventStoreCallOptions.Create(Settings, Settings.OperationOptions, userCredentials, cancellationToken));
+			}, EventStoreCallOptions.CreateNonStreaming(Settings, deadline, userCredentials, cancellationToken));
 
 			await call.ResponseAsync.ConfigureAwait(false);
 		}

--- a/src/EventStore.Client.Streams/DeadLine.cs
+++ b/src/EventStore.Client.Streams/DeadLine.cs
@@ -1,16 +1,13 @@
 ﻿using System;
-using System.Threading;
 
 #nullable enable
 namespace EventStore.Client {
-	internal static class DeadLine {
-		public static DateTime? After(TimeSpan? timeoutAfter){
-			if(!timeoutAfter.HasValue) return null;
-			if (timeoutAfter.Value == TimeSpan.MaxValue ||
-			    timeoutAfter.Value == System.Threading.Timeout.InfiniteTimeSpan) return DateTime.MaxValue;
-			return DateTime.UtcNow.Add(timeoutAfter.Value);
-		}
-
+#pragma warning disable CS1591
+	public static class DeadLine {
+#pragma warning restore CS1591
+		/// <summary>
+		/// Represents no deadline (i.e., wait infinitely)
+		/// </summary>
 		public static TimeSpan? None = null;
 	}
 }

--- a/src/EventStore.Client.Streams/EventStoreClient.Subscriptions.cs
+++ b/src/EventStore.Client.Streams/EventStoreClient.Subscriptions.cs
@@ -11,7 +11,6 @@ namespace EventStore.Client {
 		/// </summary>
 		/// <param name="start">A <see cref="FromAll"/> (exclusive of) to start the subscription from.</param>
 		/// <param name="eventAppeared">A Task invoked and awaited when a new event is received over the subscription.</param>
-		/// <param name="configureOperationOptions">An <see cref="Action{EventStoreClientOperationOptions}"/> to configure the operation's options.</param>
 		/// <param name="resolveLinkTos">Whether to resolve LinkTo events automatically.</param>
 		/// <param name="subscriptionDropped">An action invoked if the subscription is dropped.</param>
 		/// <param name="filterOptions">The optional <see cref="SubscriptionFilterOptions"/> to apply.</param>
@@ -24,25 +23,17 @@ namespace EventStore.Client {
 			bool resolveLinkTos = false,
 			Action<StreamSubscription, SubscriptionDroppedReason, Exception?>? subscriptionDropped = default,
 			SubscriptionFilterOptions? filterOptions = null,
-			Action<EventStoreClientOperationOptions>? configureOperationOptions = null,
 			UserCredentials? userCredentials = null,
-			CancellationToken cancellationToken = default) {
-			var operationOptions = Settings.OperationOptions.Clone();
-			configureOperationOptions?.Invoke(operationOptions);
-
-			operationOptions.TimeoutAfter = DeadLine.None;
-
-			return StreamSubscription.Confirm(ReadInternal(new ReadReq {
-					Options = new ReadReq.Types.Options {
-						ReadDirection = ReadReq.Types.Options.Types.ReadDirection.Forwards,
-						ResolveLinks = resolveLinkTos,
-						All = ReadReq.Types.Options.Types.AllOptions.FromSubscriptionPosition(start),
-						Subscription = new ReadReq.Types.Options.Types.SubscriptionOptions(),
-						Filter = GetFilterOptions(filterOptions)!
-					}
-				}, operationOptions, userCredentials, cancellationToken), eventAppeared, subscriptionDropped, _log,
-				filterOptions?.CheckpointReached, cancellationToken);
-		}
+			CancellationToken cancellationToken = default) => StreamSubscription.Confirm(ReadInternal(new ReadReq {
+				Options = new ReadReq.Types.Options {
+					ReadDirection = ReadReq.Types.Options.Types.ReadDirection.Forwards,
+					ResolveLinks = resolveLinkTos,
+					All = ReadReq.Types.Options.Types.AllOptions.FromSubscriptionPosition(start),
+					Subscription = new ReadReq.Types.Options.Types.SubscriptionOptions(),
+					Filter = GetFilterOptions(filterOptions)!
+				}
+			}, userCredentials, cancellationToken), eventAppeared, subscriptionDropped, _log,
+			filterOptions?.CheckpointReached, cancellationToken);
 
 		/// <summary>
 		/// Subscribes to a stream from a <see cref="StreamPosition">checkpoint</see>.
@@ -50,7 +41,6 @@ namespace EventStore.Client {
 		/// <param name="start">A <see cref="FromStream"/> (exclusive of) to start the subscription from.</param>
 		/// <param name="streamName">The name of the stream to read events from.</param>
 		/// <param name="eventAppeared">A Task invoked and awaited when a new event is received over the subscription.</param>
-		/// <param name="configureOperationOptions">An <see cref="Action{EventStoreClientOperationOptions}"/> to configure the operation's options.</param>
 		/// <param name="resolveLinkTos">Whether to resolve LinkTo events automatically.</param>
 		/// <param name="subscriptionDropped">An action invoked if the subscription is dropped.</param>
 		/// <param name="userCredentials">The optional user credentials to perform operation with.</param>
@@ -61,23 +51,15 @@ namespace EventStore.Client {
 			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
 			bool resolveLinkTos = false,
 			Action<StreamSubscription, SubscriptionDroppedReason, Exception?>? subscriptionDropped = default,
-			Action<EventStoreClientOperationOptions>? configureOperationOptions = null,
 			UserCredentials? userCredentials = null,
-			CancellationToken cancellationToken = default) {
-			var operationOptions = Settings.OperationOptions.Clone();
-			configureOperationOptions?.Invoke(operationOptions);
-
-			operationOptions.TimeoutAfter = DeadLine.None;
-
-			return StreamSubscription.Confirm(ReadInternal(new ReadReq {
-					Options = new ReadReq.Types.Options {
-						ReadDirection = ReadReq.Types.Options.Types.ReadDirection.Forwards,
-						ResolveLinks = resolveLinkTos,
-						Stream = ReadReq.Types.Options.Types.StreamOptions.FromSubscriptionPosition(streamName, start),
-						Subscription = new ReadReq.Types.Options.Types.SubscriptionOptions()
-					}
-				}, operationOptions, userCredentials, cancellationToken), eventAppeared, subscriptionDropped, _log,
-				cancellationToken: cancellationToken);
-		}
+			CancellationToken cancellationToken = default) => StreamSubscription.Confirm(ReadInternal(new ReadReq {
+				Options = new ReadReq.Types.Options {
+					ReadDirection = ReadReq.Types.Options.Types.ReadDirection.Forwards,
+					ResolveLinks = resolveLinkTos,
+					Stream = ReadReq.Types.Options.Types.StreamOptions.FromSubscriptionPosition(streamName, start),
+					Subscription = new ReadReq.Types.Options.Types.SubscriptionOptions()
+				}
+			}, userCredentials, cancellationToken), eventAppeared, subscriptionDropped, _log,
+			cancellationToken: cancellationToken);
 	}
 }

--- a/src/EventStore.Client.Streams/EventStoreClient.Tombstone.cs
+++ b/src/EventStore.Client.Streams/EventStoreClient.Tombstone.cs
@@ -7,84 +7,55 @@ using Microsoft.Extensions.Logging;
 #nullable enable
 namespace EventStore.Client {
 	public partial class EventStoreClient {
-		private Task<DeleteResult> TombstoneAsync(
-			string streamName,
-			StreamRevision expectedRevision,
-			EventStoreClientOperationOptions operationOptions,
-			UserCredentials? userCredentials = null,
-			CancellationToken cancellationToken = default) =>
-			TombstoneInternal(new TombstoneReq {
-				Options = new TombstoneReq.Types.Options {
-					StreamIdentifier = streamName,
-					Revision = expectedRevision
-				}
-			}, operationOptions, userCredentials, cancellationToken);
-
 		/// <summary>
 		/// Tombstones a stream asynchronously. Note: Tombstoned streams can never be recreated.
 		/// </summary>
 		/// <param name="streamName">The name of the stream to tombstone.</param>
 		/// <param name="expectedRevision">The expected <see cref="StreamRevision"/> of the stream being deleted.</param>
-		/// <param name="configureOperationOptions">An <see cref="Action{EventStoreClientOperationOptions}"/> to configure the operation's options.</param>
+		/// <param name="deadline"></param>
 		/// <param name="userCredentials">The optional <see cref="UserCredentials"/> to perform operation with.</param>
 		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
 		/// <returns></returns>
 		public Task<DeleteResult> TombstoneAsync(
 			string streamName,
 			StreamRevision expectedRevision,
-			Action<EventStoreClientOperationOptions>? configureOperationOptions = null,
+			TimeSpan? deadline = null,
 			UserCredentials? userCredentials = null,
-			CancellationToken cancellationToken = default) {
-
-			var operationOptions = Settings.OperationOptions.Clone();
-			configureOperationOptions?.Invoke(operationOptions);
-			
-			return TombstoneAsync(streamName, expectedRevision, operationOptions, userCredentials, cancellationToken);
-		}
-
-		private Task<DeleteResult> TombstoneAsync(
-			string streamName,
-			StreamState expectedState,
-			EventStoreClientOperationOptions operationOptions,
-			UserCredentials? userCredentials = null,
-			CancellationToken cancellationToken = default) =>
-			TombstoneInternal(new TombstoneReq {
-				Options = new TombstoneReq.Types.Options {
-					StreamIdentifier = streamName
-				}
-			}.WithAnyStreamRevision(expectedState), operationOptions, userCredentials, cancellationToken);
+			CancellationToken cancellationToken = default) => TombstoneInternal(new TombstoneReq {
+			Options = new TombstoneReq.Types.Options {
+				StreamIdentifier = streamName,
+				Revision = expectedRevision
+			}
+		}, deadline, userCredentials, cancellationToken);
 
 		/// <summary>
 		/// Tombstones a stream asynchronously. Note: Tombstoned streams can never be recreated.
 		/// </summary>
 		/// <param name="streamName">The name of the stream to tombstone.</param>
 		/// <param name="expectedState">The expected <see cref="StreamState"/> of the stream being deleted.</param>
-		/// <param name="configureOperationOptions">An <see cref="Action{EventStoreClientOperationOptions}"/> to configure the operation's options.</param>
+		/// <param name="deadline"></param>
 		/// <param name="userCredentials">The optional <see cref="UserCredentials"/> to perform operation with.</param>
 		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
 		/// <returns></returns>
 		public Task<DeleteResult> TombstoneAsync(
 			string streamName,
 			StreamState expectedState,
-			Action<EventStoreClientOperationOptions>? configureOperationOptions = null,
+			TimeSpan? deadline = null,
 			UserCredentials? userCredentials = null,
-			CancellationToken cancellationToken = default) {
+			CancellationToken cancellationToken = default) => TombstoneInternal(new TombstoneReq {
+			Options = new TombstoneReq.Types.Options {
+				StreamIdentifier = streamName
+			}
+		}.WithAnyStreamRevision(expectedState), deadline, userCredentials, cancellationToken);
 
-			var operationOptions = Settings.OperationOptions.Clone();
-			configureOperationOptions?.Invoke(operationOptions);
-			
-			return TombstoneAsync(streamName, expectedState, operationOptions, userCredentials, cancellationToken);
-		}
-
-		private async Task<DeleteResult> TombstoneInternal(TombstoneReq request,
-			EventStoreClientOperationOptions operationOptions, UserCredentials? userCredentials,
-			CancellationToken cancellationToken) {
+		private async Task<DeleteResult> TombstoneInternal(TombstoneReq request, TimeSpan? deadline,
+			UserCredentials? userCredentials, CancellationToken cancellationToken) {
 			_log.LogDebug("Tombstoning stream {streamName}.", request.Options.StreamIdentifier);
 
 			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
 			using var call = new Streams.Streams.StreamsClient(
 				channelInfo.CallInvoker).TombstoneAsync(request,
-				EventStoreCallOptions.Create(Settings, operationOptions, userCredentials, cancellationToken));
+				EventStoreCallOptions.CreateNonStreaming(Settings, deadline, userCredentials, cancellationToken));
 			var result = await call.ResponseAsync.ConfigureAwait(false);
 
 			return new DeleteResult(new Position(result.Position.CommitPosition, result.Position.PreparePosition));

--- a/src/EventStore.Client.Streams/EventStoreClient.cs
+++ b/src/EventStore.Client.Streams/EventStoreClient.cs
@@ -93,11 +93,9 @@ namespace EventStore.Client {
 					return null;
 
 				var client = new Streams.Streams.StreamsClient(channelInfo.CallInvoker);
-				var operationOptions = Settings.OperationOptions.Clone();
-				operationOptions.TimeoutAfter = new TimeSpan?();
 
-				return client.BatchAppend(EventStoreCallOptions.Create(Settings,
-					operationOptions, Settings.DefaultCredentials, _disposedTokenSource.Token));
+				return client.BatchAppend(EventStoreCallOptions.CreateStreaming(Settings,
+					userCredentials: Settings.DefaultCredentials, cancellationToken: _disposedTokenSource.Token));
 			}
 		}
 #endif

--- a/src/EventStore.Client.Streams/EventStoreClientExtensions.cs
+++ b/src/EventStore.Client.Streams/EventStoreClientExtensions.cs
@@ -21,6 +21,7 @@ namespace EventStore.Client {
 		/// </summary>
 		/// <param name="client"></param>
 		/// <param name="settings"></param>
+		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
@@ -28,13 +29,14 @@ namespace EventStore.Client {
 		public static Task SetSystemSettingsAsync(
 			this EventStoreClient client,
 			SystemSettings settings,
-			UserCredentials? userCredentials = null, CancellationToken cancellationToken = default) {
+			TimeSpan? deadline = null, UserCredentials? userCredentials = null,
+			CancellationToken cancellationToken = default) {
 			if (client == null) throw new ArgumentNullException(nameof(client));
 			return client.AppendToStreamAsync(SystemStreams.SettingsStream, StreamState.Any,
 				new[] {
 					new EventData(Uuid.NewUuid(), SystemEventTypes.Settings,
 						JsonSerializer.SerializeToUtf8Bytes(settings, SystemSettingsJsonSerializerOptions))
-				}, userCredentials: userCredentials, cancellationToken: cancellationToken);
+				}, deadline: deadline, userCredentials: userCredentials, cancellationToken: cancellationToken);
 		}
 
 		/// <summary>
@@ -44,6 +46,7 @@ namespace EventStore.Client {
 		/// <param name="streamName"></param>
 		/// <param name="expectedRevision"></param>
 		/// <param name="eventData"></param>
+		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
@@ -53,6 +56,7 @@ namespace EventStore.Client {
 			string streamName,
 			StreamRevision expectedRevision,
 			IEnumerable<EventData> eventData,
+			TimeSpan? deadline = null,
 			UserCredentials? userCredentials = null,
 			CancellationToken cancellationToken = default) {
 			if (client == null) {
@@ -60,7 +64,7 @@ namespace EventStore.Client {
 			}
 			try {
 				var result = await client.AppendToStreamAsync(streamName, expectedRevision, eventData,
-						options => options.ThrowOnAppendFailure = false, userCredentials, cancellationToken)
+						options => options.ThrowOnAppendFailure = false, deadline, userCredentials, cancellationToken)
 					.ConfigureAwait(false);
 				return ConditionalWriteResult.FromWriteResult(result);
 			} catch (StreamDeletedException) {
@@ -75,6 +79,7 @@ namespace EventStore.Client {
 		/// <param name="streamName"></param>
 		/// <param name="expectedState"></param>
 		/// <param name="eventData"></param>
+		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
@@ -84,6 +89,7 @@ namespace EventStore.Client {
 			string streamName,
 			StreamState expectedState,
 			IEnumerable<EventData> eventData,
+			TimeSpan? deadline = null,
 			UserCredentials? userCredentials = null,
 			CancellationToken cancellationToken = default) {
 			if (client == null) {
@@ -91,7 +97,7 @@ namespace EventStore.Client {
 			}
 			try {
 				var result = await client.AppendToStreamAsync(streamName, expectedState, eventData,
-						options => options.ThrowOnAppendFailure = false, userCredentials, cancellationToken)
+						options => options.ThrowOnAppendFailure = false, deadline, userCredentials, cancellationToken)
 					.ConfigureAwait(false);
 				return ConditionalWriteResult.FromWriteResult(result);
 			} catch (StreamDeletedException) {

--- a/src/EventStore.Client.Streams/StreamMetadata.cs
+++ b/src/EventStore.Client.Streams/StreamMetadata.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Buffers.Binary;
-using System.Collections.Generic;
-using System.Linq.Expressions;
 using System.Text.Json;
 
 #nullable enable

--- a/src/EventStore.Client.Streams/Streams/BatchAppendResp.cs
+++ b/src/EventStore.Client.Streams/Streams/BatchAppendResp.cs
@@ -1,4 +1,5 @@
 using System;
+using Grpc.Core;
 using static EventStore.Client.WrongExpectedVersion.CurrentStreamRevisionOptionOneofCase;
 using static EventStore.Client.WrongExpectedVersion.ExpectedStreamPositionOptionOneofCase;
 
@@ -22,7 +23,8 @@ namespace EventStore.Client.Streams {
 				{ } when Error.Details.Is(StreamDeleted.Descriptor) =>
 					throw new StreamDeletedException(StreamIdentifier),
 				{ } when Error.Details.Is(AccessDenied.Descriptor) => throw new AccessDeniedException(),
-				{ } when Error.Details.Is(Timeout.Descriptor) => throw new TimeoutException(),
+				{ } when Error.Details.Is(Timeout.Descriptor) => throw new RpcException(
+					new Status(StatusCode.DeadlineExceeded, Error.Message)),
 				{ } when Error.Details.Is(Unknown.Descriptor) => throw new InvalidOperationException(Error.Message),
 				{ } when Error.Details.Is(MaximumAppendSizeExceeded.Descriptor) =>
 					throw new MaximumAppendSizeExceededException(

--- a/src/EventStore.Client.UserManagement/EventStoreUserManagementClient.cs
+++ b/src/EventStore.Client.UserManagement/EventStoreUserManagementClient.cs
@@ -34,13 +34,14 @@ namespace EventStore.Client {
 		/// <param name="fullName"></param>
 		/// <param name="groups"></param>
 		/// <param name="password"></param>
+		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
 		/// <exception cref="ArgumentNullException"></exception>
 		/// <exception cref="ArgumentOutOfRangeException"></exception>
 		public async Task CreateUserAsync(string loginName, string fullName, string[] groups, string password,
-			UserCredentials? userCredentials = null,
+			TimeSpan? deadline = null, UserCredentials? userCredentials = null,
 			CancellationToken cancellationToken = default) {
 			if (loginName == null) throw new ArgumentNullException(nameof(loginName));
 			if (fullName == null) throw new ArgumentNullException(nameof(fullName));
@@ -59,7 +60,7 @@ namespace EventStore.Client {
 					Password = password,
 					Groups = {groups}
 				}
-			}, EventStoreCallOptions.Create(Settings, Settings.OperationOptions, userCredentials, cancellationToken));
+			}, EventStoreCallOptions.CreateNonStreaming(Settings, deadline, userCredentials, cancellationToken));
 			await call.ResponseAsync.ConfigureAwait(false);
 		}
 
@@ -67,13 +68,14 @@ namespace EventStore.Client {
 		/// Gets the <see cref="UserDetails"/> of an internal user.
 		/// </summary>
 		/// <param name="loginName"></param>
+		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
 		/// <exception cref="ArgumentNullException"></exception>
 		/// <exception cref="ArgumentOutOfRangeException"></exception>
-		public async Task<UserDetails> GetUserAsync(string loginName, UserCredentials? userCredentials = null,
-			CancellationToken cancellationToken = default) {
+		public async Task<UserDetails> GetUserAsync(string loginName, TimeSpan? deadline = null,
+			UserCredentials? userCredentials = null, CancellationToken cancellationToken = default) {
 			if (loginName == null) {
 				throw new ArgumentNullException(nameof(loginName));
 			}
@@ -88,7 +90,7 @@ namespace EventStore.Client {
 				Options = new DetailsReq.Types.Options {
 					LoginName = loginName
 				}
-			}, EventStoreCallOptions.Create(Settings, Settings.OperationOptions, userCredentials, cancellationToken));
+			}, EventStoreCallOptions.CreateNonStreaming(Settings, deadline, userCredentials, cancellationToken));
 
 			await call.ResponseStream.MoveNext().ConfigureAwait(false);
 			var userDetails = call.ResponseStream.Current.UserDetails;
@@ -103,13 +105,14 @@ namespace EventStore.Client {
 		/// Deletes an internal user.
 		/// </summary>
 		/// <param name="loginName"></param>
+		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
 		/// <exception cref="ArgumentNullException"></exception>
 		/// <exception cref="ArgumentOutOfRangeException"></exception>
-		public async Task DeleteUserAsync(string loginName, UserCredentials? userCredentials = null,
-			CancellationToken cancellationToken = default) {
+		public async Task DeleteUserAsync(string loginName, TimeSpan? deadline = null,
+			UserCredentials? userCredentials = null, CancellationToken cancellationToken = default) {
 			if (loginName == null) {
 				throw new ArgumentNullException(nameof(loginName));
 			}
@@ -124,7 +127,7 @@ namespace EventStore.Client {
 				Options = new DeleteReq.Types.Options {
 					LoginName = loginName
 				}
-			}, EventStoreCallOptions.Create(Settings, Settings.OperationOptions, userCredentials, cancellationToken));
+			}, EventStoreCallOptions.CreateNonStreaming(Settings, deadline, userCredentials, cancellationToken));
 			await call.ResponseAsync.ConfigureAwait(false);
 		}
 
@@ -132,13 +135,14 @@ namespace EventStore.Client {
 		/// Enables a previously disabled internal user.
 		/// </summary>
 		/// <param name="loginName"></param>
+		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
 		/// <exception cref="ArgumentNullException"></exception>
 		/// <exception cref="ArgumentOutOfRangeException"></exception>
-		public async Task EnableUserAsync(string loginName, UserCredentials? userCredentials = null,
-			CancellationToken cancellationToken = default) {
+		public async Task EnableUserAsync(string loginName, TimeSpan? deadline = null,
+			UserCredentials? userCredentials = null, CancellationToken cancellationToken = default) {
 			if (loginName == null) {
 				throw new ArgumentNullException(nameof(loginName));
 			}
@@ -153,7 +157,7 @@ namespace EventStore.Client {
 				Options = new EnableReq.Types.Options {
 					LoginName = loginName
 				}
-			}, EventStoreCallOptions.Create(Settings, Settings.OperationOptions, userCredentials, cancellationToken));
+			}, EventStoreCallOptions.CreateNonStreaming(Settings, deadline, userCredentials, cancellationToken));
 			await call.ResponseAsync.ConfigureAwait(false);
 		}
 
@@ -161,12 +165,13 @@ namespace EventStore.Client {
 		/// Disables an internal user.
 		/// </summary>
 		/// <param name="loginName"></param>
+		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
 		/// <exception cref="ArgumentOutOfRangeException"></exception>
-		public async Task DisableUserAsync(string loginName, UserCredentials? userCredentials = null,
-			CancellationToken cancellationToken = default) {
+		public async Task DisableUserAsync(string loginName, TimeSpan? deadline = null,
+			UserCredentials? userCredentials = null, CancellationToken cancellationToken = default) {
 			if (loginName == string.Empty) throw new ArgumentOutOfRangeException(nameof(loginName));
 
 			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
@@ -175,22 +180,24 @@ namespace EventStore.Client {
 				Options = new DisableReq.Types.Options {
 					LoginName = loginName
 				}
-			}, EventStoreCallOptions.Create(Settings, Settings.OperationOptions, userCredentials, cancellationToken));
+			}, EventStoreCallOptions.CreateNonStreaming(Settings, deadline, userCredentials, cancellationToken));
 			await call.ResponseAsync.ConfigureAwait(false);
 		}
 
 		/// <summary>
 		/// Lists the <see cref="UserDetails"/> of all internal users.
 		/// </summary>
+		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
-		public async IAsyncEnumerable<UserDetails> ListAllAsync(UserCredentials? userCredentials = null,
+		public async IAsyncEnumerable<UserDetails> ListAllAsync(TimeSpan? deadline = null,
+			UserCredentials? userCredentials = null,
 			[EnumeratorCancellation] CancellationToken cancellationToken = default) {
 			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
 			using var call = new Users.Users.UsersClient(
 				channelInfo.CallInvoker).Details(new DetailsReq(),
-				EventStoreCallOptions.Create(Settings, Settings.OperationOptions, userCredentials, cancellationToken));
+				EventStoreCallOptions.CreateNonStreaming(Settings, deadline, userCredentials, cancellationToken));
 
 			await foreach (var userDetail in call.ResponseStream
 				.ReadAllAsync(cancellationToken)
@@ -207,13 +214,15 @@ namespace EventStore.Client {
 		/// <param name="loginName"></param>
 		/// <param name="currentPassword"></param>
 		/// <param name="newPassword"></param>
+		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
 		/// <exception cref="ArgumentNullException"></exception>
 		/// <exception cref="ArgumentOutOfRangeException"></exception>
 		public async Task ChangePasswordAsync(string loginName, string currentPassword, string newPassword,
-			UserCredentials? userCredentials = null, CancellationToken cancellationToken = default) {
+			TimeSpan? deadline = null, UserCredentials? userCredentials = null,
+			CancellationToken cancellationToken = default) {
 			if (loginName == null) throw new ArgumentNullException(nameof(loginName));
 			if (currentPassword == null) throw new ArgumentNullException(nameof(currentPassword));
 			if (newPassword == null) throw new ArgumentNullException(nameof(newPassword));
@@ -231,7 +240,7 @@ namespace EventStore.Client {
 						LoginName = loginName
 					}
 				},
-				EventStoreCallOptions.Create(Settings, Settings.OperationOptions, userCredentials, cancellationToken));
+				EventStoreCallOptions.CreateNonStreaming(Settings, deadline, userCredentials, cancellationToken));
 			await call.ResponseAsync.ConfigureAwait(false);
 		}
 
@@ -240,13 +249,15 @@ namespace EventStore.Client {
 		/// </summary>
 		/// <param name="loginName"></param>
 		/// <param name="newPassword"></param>
+		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
 		/// <exception cref="ArgumentNullException"></exception>
 		/// <exception cref="ArgumentOutOfRangeException"></exception>
 		public async Task ResetPasswordAsync(string loginName, string newPassword,
-			UserCredentials? userCredentials = null, CancellationToken cancellationToken = default) {
+			TimeSpan? deadline = null, UserCredentials? userCredentials = null,
+			CancellationToken cancellationToken = default) {
 			if (loginName == null) throw new ArgumentNullException(nameof(loginName));
 			if (newPassword == null) throw new ArgumentNullException(nameof(newPassword));
 			if (loginName == string.Empty) throw new ArgumentOutOfRangeException(nameof(loginName));
@@ -261,7 +272,7 @@ namespace EventStore.Client {
 						LoginName = loginName
 					}
 				},
-				EventStoreCallOptions.Create(Settings, Settings.OperationOptions, userCredentials, cancellationToken));
+				EventStoreCallOptions.CreateNonStreaming(Settings, deadline, userCredentials, cancellationToken));
 			await call.ResponseAsync.ConfigureAwait(false);
 		}
 

--- a/src/EventStore.Client.UserManagement/EventStoreUserManagerClientExtensions.cs
+++ b/src/EventStore.Client.UserManagement/EventStoreUserManagerClientExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -12,10 +13,11 @@ namespace EventStore.Client {
 		/// </summary>
 		/// <param name="users"></param>
 		/// <param name="userCredentials"></param>
+		/// <param name="deadline"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
 		public static Task<UserDetails> GetCurrentUserAsync(this EventStoreUserManagementClient users,
-			UserCredentials userCredentials, CancellationToken cancellationToken = default)
-			=> users.GetUserAsync(userCredentials.Username!, userCredentials, cancellationToken);
+			UserCredentials userCredentials, TimeSpan? deadline = null, CancellationToken cancellationToken = default)
+			=> users.GetUserAsync(userCredentials.Username!, deadline, userCredentials, cancellationToken);
 	}
 }

--- a/src/EventStore.Client/ChannelFactory.cs
+++ b/src/EventStore.Client/ChannelFactory.cs
@@ -1,5 +1,4 @@
 using System;
-using Grpc.Core;
 using EndPoint = System.Net.EndPoint;
 #if !GRPC_CORE
 using System.Net.Http;
@@ -7,6 +6,7 @@ using Grpc.Net.Client;
 using TChannel = Grpc.Net.Client.GrpcChannel;
 #else
 using System.Collections.Generic;
+using Grpc.Core;
 using TChannel = Grpc.Core.ChannelBase;
 #endif
 

--- a/src/EventStore.Client/ClusterMessage.cs
+++ b/src/EventStore.Client/ClusterMessage.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Net;
+﻿using System.Net;
 
 #nullable enable
 namespace EventStore.Client {

--- a/src/EventStore.Client/EventStoreClientOperationOptions.cs
+++ b/src/EventStore.Client/EventStoreClientOperationOptions.cs
@@ -9,11 +9,6 @@ namespace EventStore.Client {
 	/// </summary>
 	public class EventStoreClientOperationOptions {
 		/// <summary>
-		/// An optional <see cref="TimeSpan"/> to use for gRPC deadlines.
-		/// </summary>
-		public TimeSpan? TimeoutAfter { get; set; }
-
-		/// <summary>
 		/// Whether or not to immediately throw a <see cref="WrongExpectedVersionException"/> when an append fails.
 		/// </summary>
 		public bool ThrowOnAppendFailure { get; set; }
@@ -32,10 +27,9 @@ namespace EventStore.Client {
 		/// <summary>
 		/// The default <see cref="EventStoreClientOperationOptions"/>.
 		/// </summary>
-		public static EventStoreClientOperationOptions Default => new EventStoreClientOperationOptions {
-			TimeoutAfter = TimeSpan.FromSeconds(5),
+		public static EventStoreClientOperationOptions Default => new() {
 			ThrowOnAppendFailure = true,
-			GetAuthenticationHeaderValue = (userCredentials, ct) => new ValueTask<string>(userCredentials.ToString()),
+			GetAuthenticationHeaderValue = (userCredentials, _) => new ValueTask<string>(userCredentials.ToString()),
 			BatchAppendSize = 3 * 1024 * 1024
 		};
 
@@ -44,12 +38,10 @@ namespace EventStore.Client {
 		/// Clones a copy of the current <see cref="EventStoreClientOperationOptions"/>.
 		/// </summary>
 		/// <returns></returns>
-		public EventStoreClientOperationOptions Clone() =>
-			new EventStoreClientOperationOptions {
-				TimeoutAfter = TimeoutAfter,
-				ThrowOnAppendFailure = ThrowOnAppendFailure,
-				GetAuthenticationHeaderValue = GetAuthenticationHeaderValue,
-				BatchAppendSize = BatchAppendSize
-			};
+		public EventStoreClientOperationOptions Clone() => new() {
+			ThrowOnAppendFailure = ThrowOnAppendFailure,
+			GetAuthenticationHeaderValue = GetAuthenticationHeaderValue,
+			BatchAppendSize = BatchAppendSize
+		};
 	}
 }

--- a/src/EventStore.Client/EventStoreClientSettings.ConnectionString.cs
+++ b/src/EventStore.Client/EventStoreClientSettings.ConnectionString.cs
@@ -34,7 +34,7 @@ namespace EventStore.Client {
 			private const string GossipTimeout = nameof(GossipTimeout);
 			private const string NodePreference = nameof(NodePreference);
 			private const string TlsVerifyCert = nameof(TlsVerifyCert);
-			private const string OperationTimeout = nameof(OperationTimeout);
+			private const string DefaultDeadline = nameof(DefaultDeadline);
 			private const string ThrowOnAppendFailure = nameof(ThrowOnAppendFailure);
 			private const string KeepAliveInterval = nameof(KeepAliveInterval);
 			private const string KeepAliveTimeout = nameof(KeepAliveTimeout);
@@ -46,7 +46,7 @@ namespace EventStore.Client {
 			private static readonly bool DefaultUseTls = true;
 
 			private static readonly Dictionary<string, Type> SettingsType =
-				new Dictionary<string, Type>(StringComparer.InvariantCultureIgnoreCase) {
+				new(StringComparer.InvariantCultureIgnoreCase) {
 					{ConnectionName, typeof(string)},
 					{MaxDiscoverAttempts, typeof(int)},
 					{DiscoveryInterval, typeof(int)},
@@ -54,7 +54,7 @@ namespace EventStore.Client {
 					{NodePreference, typeof(string)},
 					{Tls, typeof(bool)},
 					{TlsVerifyCert, typeof(bool)},
-					{OperationTimeout, typeof(int)},
+					{DefaultDeadline, typeof(int)},
 					{ThrowOnAppendFailure, typeof(bool)},
 					{KeepAliveInterval, typeof(int)},
 					{KeepAliveTimeout, typeof(int)},
@@ -163,24 +163,24 @@ namespace EventStore.Client {
 					useTls = (bool)tls;
 				}
 
-				if (typedOptions.TryGetValue(OperationTimeout, out object operationTimeout))
-					settings.OperationOptions.TimeoutAfter = TimeSpan.FromMilliseconds((int)operationTimeout);
+				if (typedOptions.TryGetValue(DefaultDeadline, out object operationTimeout))
+					settings.DefaultDeadline = TimeSpan.FromMilliseconds((int)operationTimeout);
 
 				if (typedOptions.TryGetValue(ThrowOnAppendFailure, out object throwOnAppendFailure))
 					settings.OperationOptions.ThrowOnAppendFailure = (bool)throwOnAppendFailure;
 
 				if (typedOptions.TryGetValue(KeepAliveInterval, out var keepAliveIntervalMs)) {
 					settings.ConnectivitySettings.KeepAliveInterval = keepAliveIntervalMs switch {
-						int value when value == -1 => Timeout_.InfiniteTimeSpan,
-						int value when value >= 0 => TimeSpan.FromMilliseconds(value),
+						-1 => Timeout_.InfiniteTimeSpan,
+						int value and >= 0 => TimeSpan.FromMilliseconds(value),
 						_ => throw new InvalidSettingException($"Invalid KeepAliveInterval: {keepAliveIntervalMs}")
 					};
 				}
 
 				if (typedOptions.TryGetValue(KeepAliveTimeout, out var keepAliveTimeoutMs)) {
 					settings.ConnectivitySettings.KeepAliveTimeout = keepAliveTimeoutMs switch {
-						int value when value == -1 => Timeout_.InfiniteTimeSpan,
-						int value when value >= 0 => TimeSpan.FromMilliseconds(value),
+						-1 => Timeout_.InfiniteTimeSpan,
+						int value and >= 0 => TimeSpan.FromMilliseconds(value),
 						_ => throw new InvalidSettingException($"Invalid KeepAliveTimeout: {keepAliveTimeoutMs}")
 					};
 				}

--- a/src/EventStore.Client/EventStoreClientSettings.cs
+++ b/src/EventStore.Client/EventStoreClientSettings.cs
@@ -56,5 +56,10 @@ namespace EventStore.Client {
 		/// The optional <see cref="UserCredentials"/> to use if none have been supplied to the operation.
 		/// </summary>
 		public UserCredentials? DefaultCredentials { get; set; }
+
+		/// <summary>
+		/// The default deadline for calls. Will not be applied to reads or subscriptions.
+		/// </summary>
+		public TimeSpan? DefaultDeadline { get; set; } = TimeSpan.FromSeconds(10);
 	}
 }

--- a/src/EventStore.Client/Exceptions/WrongExpectedVersionException.cs
+++ b/src/EventStore.Client/Exceptions/WrongExpectedVersionException.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.Serialization;
 
 #nullable enable
 namespace EventStore.Client {

--- a/src/EventStore.Client/GrpcServerCapabilitiesClient.cs
+++ b/src/EventStore.Client/GrpcServerCapabilitiesClient.cs
@@ -18,10 +18,10 @@ namespace EventStore.Client {
 			var client = new ServerFeatures.ServerFeatures.ServerFeaturesClient(callInvoker);
 			using var call = client.GetSupportedMethodsAsync(
 				new(),
-				EventStoreCallOptions.Create(
+				EventStoreCallOptions.CreateNonStreaming(
 					_settings,
-					_settings.OperationOptions,
-					userCredentials: null,
+					_settings.ConnectivitySettings.GossipTimeout,
+					null,
 					cancellationToken));
 
 			try {

--- a/src/EventStore.Client/HashCode.cs
+++ b/src/EventStore.Client/HashCode.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.VisualBasic;
 
 #nullable enable
 namespace EventStore.Client {

--- a/src/EventStore.Client/IChannelSelector.cs
+++ b/src/EventStore.Client/IChannelSelector.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;

--- a/test/EventStore.Client.Operations.Tests/EventStoreOperationsClientExtensions.cs
+++ b/test/EventStore.Client.Operations.Tests/EventStoreOperationsClientExtensions.cs
@@ -5,7 +5,8 @@ namespace EventStore.Client {
 	public static class EventStoreOperationsClientExtensions {
 		public static async Task WarmUpAsync(this EventStoreOperationsClient self) {
 			await self.WarmUpWith(async cancellationToken => {
-				await self.RestartPersistentSubscriptions(TestCredentials.Root, cancellationToken);
+				await self.RestartPersistentSubscriptions(userCredentials: TestCredentials.Root,
+					cancellationToken: cancellationToken);
 			});
 		}
 	}

--- a/test/EventStore.Client.Operations.Tests/admin.cs
+++ b/test/EventStore.Client.Operations.Tests/admin.cs
@@ -11,7 +11,7 @@ namespace EventStore.Client {
 
 		[Fact]
 		public async Task merge_indexes_does_not_throw() {
-			await _fixture.Client.MergeIndexesAsync(TestCredentials.Root);
+			await _fixture.Client.MergeIndexesAsync(userCredentials: TestCredentials.Root);
 		}
 
 		[Fact]
@@ -21,7 +21,7 @@ namespace EventStore.Client {
 		
 		[Fact]
 		public async Task restart_persistent_subscriptions_does_not_throw() {
-			await _fixture.Client.RestartPersistentSubscriptions(TestCredentials.Root);
+			await _fixture.Client.RestartPersistentSubscriptions(userCredentials:TestCredentials.Root);
 		}
 
 		[Fact]

--- a/test/EventStore.Client.Operations.Tests/admin_resign_node.cs
+++ b/test/EventStore.Client.Operations.Tests/admin_resign_node.cs
@@ -11,7 +11,7 @@ namespace EventStore.Client {
 
 		[Fact]
 		public async Task resign_node_does_not_throw() {
-			await _fixture.Client.ResignNodeAsync(TestCredentials.Root);
+			await _fixture.Client.ResignNodeAsync(userCredentials: TestCredentials.Root);
 		}
 
 		[Fact]

--- a/test/EventStore.Client.Operations.Tests/scavenge.cs
+++ b/test/EventStore.Client.Operations.Tests/scavenge.cs
@@ -41,7 +41,7 @@ namespace EventStore.Client {
 		public async Task stop() {
 			var startResult = await _fixture.Client.StartScavengeAsync(userCredentials: TestCredentials.Root);
 			var stopResult = await _fixture.Client
-				.StopScavengeAsync(startResult.ScavengeId, TestCredentials.Root);
+				.StopScavengeAsync(startResult.ScavengeId, userCredentials: TestCredentials.Root);
 			Assert.Equal(DatabaseScavengeResult.Stopped(startResult.ScavengeId), stopResult);
 		}
 
@@ -49,7 +49,7 @@ namespace EventStore.Client {
 		public async Task stop_when_no_scavenge_is_running() {
 			var scavengeId = Guid.NewGuid().ToString();
 			var ex = await Assert.ThrowsAsync<ScavengeNotFoundException>(() =>
-				_fixture.Client.StopScavengeAsync(scavengeId, TestCredentials.Root));
+				_fixture.Client.StopScavengeAsync(scavengeId, userCredentials: TestCredentials.Root));
 			Assert.Null(ex.ScavengeId);
 		}
 

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/Bugs/Issue_1125.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/Bugs/Issue_1125.cs
@@ -57,7 +57,7 @@ namespace EventStore.Client.Bugs {
 						// This is a retry
 						await subscription.Ack(@event);
 					}
-				}, (s, dr, e) => {
+				},  (s, dr, e) => {
 					if (e != null)
 						completed.TrySetException(e);
 					else

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/can_create_duplicate_name_on_different_streams.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/can_create_duplicate_name_on_different_streams.cs
@@ -17,12 +17,12 @@ namespace EventStore.Client.SubscriptionToAll {
 
 			protected override Task When() =>
 				Client.CreateToAllAsync("group3211",
-					new PersistentSubscriptionSettings(), TestCredentials.Root);
+					new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 		}
 
 		[Fact]
 		public Task the_completion_succeeds() =>
 			_fixture.Client.CreateAsync("someother",
-				"group3211", new PersistentSubscriptionSettings(), TestCredentials.Root);
+				"group3211", new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 	}
 }

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/connect_to_existing_with_max_one_client.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/connect_to_existing_with_max_one_client.cs
@@ -33,7 +33,7 @@ namespace EventStore.Client.SubscriptionToAll {
 				Client.CreateToAllAsync(
 					Group,
 					new PersistentSubscriptionSettings(maxSubscriberCount: 1),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 
 			protected override Task When() => Task.CompletedTask;
 		}

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/connect_to_existing_with_permissions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/connect_to_existing_with_permissions.cs
@@ -19,7 +19,7 @@ namespace EventStore.Client.SubscriptionToAll {
 			var dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
 			using var subscription = await _fixture.Client.SubscribeToAllAsync(Group,
 				delegate { return Task.CompletedTask; }, (s, reason, ex) => dropped.TrySetResult((reason, ex)),
-				TestCredentials.Root).WithTimeout();
+				userCredentials: TestCredentials.Root).WithTimeout();
 			Assert.NotNull(subscription);
 
 			await Assert.ThrowsAsync<TimeoutException>(() => dropped.Task.WithTimeout());
@@ -30,7 +30,7 @@ namespace EventStore.Client.SubscriptionToAll {
 				Client.CreateToAllAsync(
 					Group,
 					new PersistentSubscriptionSettings(),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 
 			protected override Task When() => Task.CompletedTask;
 		}

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/connect_to_existing_with_start_from_beginning.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/connect_to_existing_with_start_from_beginning.cs
@@ -41,7 +41,7 @@ namespace EventStore.Client.SubscriptionToAll {
 				Events = await StreamsClient.ReadAllAsync(Direction.Forwards, Position.Start, 10, userCredentials: TestCredentials.Root).ToArrayAsync();
 
 				await Client.CreateToAllAsync(Group,
-					new PersistentSubscriptionSettings(startFrom: Position.Start), TestCredentials.Root);
+					new PersistentSubscriptionSettings(startFrom: Position.Start), userCredentials: TestCredentials.Root);
 			}
 
 			protected override async Task When() {
@@ -53,7 +53,7 @@ namespace EventStore.Client.SubscriptionToAll {
 						if (reason != SubscriptionDroppedReason.Disposed) {
 							_firstEventSource.TrySetException(ex!);
 						}
-					}, TestCredentials.Root);
+					}, userCredentials: TestCredentials.Root);
 			}
 
 			public override Task DisposeAsync() {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/connect_to_existing_with_start_from_not_set.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/connect_to_existing_with_start_from_not_set.cs
@@ -1,6 +1,4 @@
 using System;
-using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -39,7 +37,7 @@ namespace EventStore.Client.SubscriptionToAll {
 				}
 
 				await Client.CreateToAllAsync(Group,
-					new PersistentSubscriptionSettings(), TestCredentials.Root);
+					new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 			}
 
 			protected override async Task When() {
@@ -55,7 +53,7 @@ namespace EventStore.Client.SubscriptionToAll {
 						if (reason != SubscriptionDroppedReason.Disposed) {
 							_firstNonSystemEventSource.TrySetException(ex!);
 						}
-					}, TestCredentials.Root);
+					}, userCredentials: TestCredentials.Root);
 			}
 
 			public override Task DisposeAsync() {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/connect_to_existing_with_start_from_not_set_then_event_written.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/connect_to_existing_with_start_from_not_set_then_event_written.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
@@ -46,7 +45,7 @@ namespace EventStore.Client.SubscriptionToAll {
 						StreamState.Any, new[] {@event});
 				}
 
-				await Client.CreateToAllAsync(Group, new PersistentSubscriptionSettings(), TestCredentials.Root);
+				await Client.CreateToAllAsync(Group, new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToAllAsync(Group,
 					async (subscription, e, r, ct) => {
 						if (SystemStreams.IsSystemStream(e.OriginalStreamId)) {
@@ -59,7 +58,7 @@ namespace EventStore.Client.SubscriptionToAll {
 						if (reason != SubscriptionDroppedReason.Disposed) {
 							_firstNonSystemEventSource.TrySetException(ex!);
 						}
-					}, TestCredentials.Root);
+					}, userCredentials: TestCredentials.Root);
 			}
 
 			protected override async Task When() {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/connect_to_existing_with_start_from_set_to_end_position.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/connect_to_existing_with_start_from_set_to_end_position.cs
@@ -1,6 +1,4 @@
 using System;
-using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -39,7 +37,7 @@ namespace EventStore.Client.SubscriptionToAll {
 				}
 
 				await Client.CreateToAllAsync(Group,
-					new PersistentSubscriptionSettings(startFrom: Position.End), TestCredentials.Root);
+					new PersistentSubscriptionSettings(startFrom: Position.End), userCredentials: TestCredentials.Root);
 			}
 
 			protected override async Task When() {
@@ -55,7 +53,7 @@ namespace EventStore.Client.SubscriptionToAll {
 						if (reason != SubscriptionDroppedReason.Disposed) {
 							_firstNonSystemEventSource.TrySetException(ex!);
 						}
-					}, TestCredentials.Root);
+					}, userCredentials: TestCredentials.Root);
 			}
 
 			public override Task DisposeAsync() {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/connect_to_existing_with_start_from_set_to_end_position_then_event_written.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/connect_to_existing_with_start_from_set_to_end_position_then_event_written.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
@@ -46,7 +45,7 @@ namespace EventStore.Client.SubscriptionToAll {
 						StreamState.Any, new[] {@event});
 				}
 
-				await Client.CreateToAllAsync(Group, new PersistentSubscriptionSettings(startFrom: Position.End), TestCredentials.Root);
+				await Client.CreateToAllAsync(Group, new PersistentSubscriptionSettings(startFrom: Position.End), userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToAllAsync(Group,
 					async (subscription, e, r, ct) => {
 						if (SystemStreams.IsSystemStream(e.OriginalStreamId)) {
@@ -59,7 +58,7 @@ namespace EventStore.Client.SubscriptionToAll {
 						if (reason != SubscriptionDroppedReason.Disposed) {
 							_firstNonSystemEventSource.TrySetException(ex!);
 						}
-					}, TestCredentials.Root);
+					}, userCredentials: TestCredentials.Root);
 			}
 
 			protected override async Task When() {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/connect_to_existing_with_start_from_set_to_invalid_middle_position.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/connect_to_existing_with_start_from_set_to_invalid_middle_position.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -37,7 +36,7 @@ namespace EventStore.Client.SubscriptionToAll {
 			protected override async Task Given() {
 				var invalidPosition = new Position(1L, 1L);
 				await Client.CreateToAllAsync(Group,
-					new PersistentSubscriptionSettings(startFrom: invalidPosition), TestCredentials.Root);
+					new PersistentSubscriptionSettings(startFrom: invalidPosition), userCredentials: TestCredentials.Root);
 			}
 
 			protected override async Task When() {
@@ -45,7 +44,7 @@ namespace EventStore.Client.SubscriptionToAll {
 					async (subscription, e, r, ct) => await subscription.Ack(e),
 					(subscription, reason, ex) => {
 						_dropped.TrySetResult((reason, ex));
-					}, TestCredentials.Root);
+					}, userCredentials: TestCredentials.Root);
 			}
 
 			public override Task DisposeAsync() {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/connect_to_existing_with_start_from_set_to_valid_middle_position.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/connect_to_existing_with_start_from_set_to_valid_middle_position.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
@@ -41,7 +40,7 @@ namespace EventStore.Client.SubscriptionToAll {
 				ExpectedEvent = events[events.Length / 2]; //just a random event in the middle of the results
 
 				await Client.CreateToAllAsync(Group,
-					new PersistentSubscriptionSettings(startFrom: ExpectedEvent.OriginalPosition), TestCredentials.Root);
+					new PersistentSubscriptionSettings(startFrom: ExpectedEvent.OriginalPosition), userCredentials: TestCredentials.Root);
 			}
 
 			protected override async Task When() {
@@ -53,7 +52,7 @@ namespace EventStore.Client.SubscriptionToAll {
 						if (reason != SubscriptionDroppedReason.Disposed) {
 							_firstEventSource.TrySetException(ex!);
 						}
-					}, TestCredentials.Root);
+					}, userCredentials: TestCredentials.Root);
 			}
 
 			public override Task DisposeAsync() {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/connect_to_existing_without_permissions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/connect_to_existing_without_permissions.cs
@@ -20,7 +20,7 @@ namespace EventStore.Client.SubscriptionToAll {
 				Client.CreateToAllAsync(
 					"agroupname55",
 					new PersistentSubscriptionSettings(),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 
 			protected override Task When() => Task.CompletedTask;
 		}

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/connect_to_existing_without_read_all_permissions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/connect_to_existing_without_read_all_permissions.cs
@@ -20,7 +20,7 @@ namespace EventStore.Client.SubscriptionToAll {
 				Client.CreateToAllAsync(
 					"agroupname55",
 					new PersistentSubscriptionSettings(),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 
 			protected override Task When() => Task.CompletedTask;
 		}

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/connect_with_retries.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/connect_with_retries.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -29,7 +28,7 @@ namespace EventStore.Client.SubscriptionToAll {
 
 			protected override async Task Given() {
 				await Client.CreateToAllAsync(Group,
-					new PersistentSubscriptionSettings(startFrom: Position.Start), TestCredentials.Root);
+					new PersistentSubscriptionSettings(startFrom: Position.Start), userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToAllAsync(Group,
 					async (subscription, e, r, ct) => {
 						if (r > 4) {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/create_after_deleting_the_same.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/create_after_deleting_the_same.cs
@@ -16,15 +16,15 @@ namespace EventStore.Client.SubscriptionToAll {
 
 			protected override async Task When() {
 				await Client.CreateToAllAsync("existing",
-					new PersistentSubscriptionSettings(), TestCredentials.Root);
+					new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 				await Client.DeleteToAllAsync("existing",
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 			}
 		}
 
 		[Fact]
 		public async Task the_completion_succeeds() =>
 			await _fixture.Client.CreateToAllAsync("existing",
-				new PersistentSubscriptionSettings(), TestCredentials.Root);
+				new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 	}
 }

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/create_duplicate.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/create_duplicate.cs
@@ -18,7 +18,7 @@ namespace EventStore.Client.SubscriptionToAll {
 
 			protected override Task When() =>
 				Client.CreateToAllAsync("group32",
-					new PersistentSubscriptionSettings(), TestCredentials.Root);
+					new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 		}
 
 		[Fact]
@@ -26,7 +26,7 @@ namespace EventStore.Client.SubscriptionToAll {
 			var ex = await Assert.ThrowsAsync<RpcException>(
 				() => _fixture.Client.CreateToAllAsync("group32",
 					new PersistentSubscriptionSettings(),
-					TestCredentials.Root));
+					userCredentials: TestCredentials.Root));
 			Assert.Equal(StatusCode.AlreadyExists, ex.StatusCode);
 		}
 	}

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/create_filtered.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/create_filtered.cs
@@ -22,7 +22,7 @@ namespace EventStore.Client.SubscriptionToAll {
 				filterName,
 				filter,
 				new PersistentSubscriptionSettings(),
-				TestCredentials.Root);
+				userCredentials: TestCredentials.Root);
 		}
 		
 		public class Fixture : EventStoreClientFixture {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/create_on_all_stream.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/create_on_all_stream.cs
@@ -19,11 +19,11 @@ namespace EventStore.Client.SubscriptionToAll {
 		[Fact]
 		public Task the_completion_succeeds()
 			=> _fixture.Client.CreateToAllAsync(
-				"existing", new PersistentSubscriptionSettings(), TestCredentials.Root);
+				"existing", new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 
 		[Fact]
 		public Task throws_argument_exception_if_wrong_start_from_type_passed()
 			=> Assert.ThrowsAsync<ArgumentException>(() => _fixture.Client.CreateToAllAsync(
-				"existing", new PersistentSubscriptionSettings(startFrom: StreamPosition.End), TestCredentials.Root));
+				"existing", new PersistentSubscriptionSettings(startFrom: StreamPosition.End), userCredentials: TestCredentials.Root));
 	}
 }

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/create_persistent_subscription_with_dont_timeout.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/create_persistent_subscription_with_dont_timeout.cs
@@ -21,6 +21,6 @@ namespace EventStore.Client.SubscriptionToAll {
 		public Task the_subscription_is_created_without_error() =>
 			_fixture.Client.CreateToAllAsync("dont-timeout",
 				new PersistentSubscriptionSettings(messageTimeout: TimeSpan.Zero),
-				TestCredentials.Root);
+				userCredentials: TestCredentials.Root);
 	}
 }

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/create_with_commit_position_equal_to_last_indexed_position.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/create_with_commit_position_equal_to_last_indexed_position.cs
@@ -28,6 +28,6 @@ namespace EventStore.Client.SubscriptionToAll {
 			await _fixture.Client.CreateToAllAsync("group57",
 					new PersistentSubscriptionSettings(
 						startFrom: new Position(_fixture.LastCommitPosition, _fixture.LastCommitPosition)),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 	}
 }

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/create_with_commit_position_larger_than_last_indexed_position.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/create_with_commit_position_larger_than_last_indexed_position.cs
@@ -31,7 +31,7 @@ namespace EventStore.Client.SubscriptionToAll {
 				_fixture.Client.CreateToAllAsync("group57",
 					new PersistentSubscriptionSettings(
 						startFrom: new Position(_fixture.LastCommitPosition + 1, _fixture.LastCommitPosition)),
-					TestCredentials.Root));
+					userCredentials: TestCredentials.Root));
 			Assert.Equal(StatusCode.Internal, ex.StatusCode);
 		}
 	}

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/create_with_prepare_position_larger_than_commit_position.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/create_with_prepare_position_larger_than_commit_position.cs
@@ -23,6 +23,6 @@ namespace EventStore.Client.SubscriptionToAll {
 				_fixture.Client.CreateToAllAsync("group57",
 					new PersistentSubscriptionSettings(
 						startFrom: new Position(0, 1)),
-					TestCredentials.Root));
+					userCredentials: TestCredentials.Root));
 	}
 }

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/deleting_existing_with_permissions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/deleting_existing_with_permissions.cs
@@ -17,12 +17,12 @@ namespace EventStore.Client.SubscriptionToAll {
 			protected override Task When() =>
 				Client.CreateToAllAsync("groupname123",
 					new PersistentSubscriptionSettings(),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 		}
 
 		[Fact]
 		public Task the_delete_of_group_succeeds() =>
 			_fixture.Client.DeleteToAllAsync("groupname123",
-				TestCredentials.Root);
+				userCredentials: TestCredentials.Root);
 	}
 }

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/deleting_existing_with_subscriber.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/deleting_existing_with_subscriber.cs
@@ -24,17 +24,17 @@ namespace EventStore.Client.SubscriptionToAll {
 			protected override async Task Given() {
 				await Client.CreateToAllAsync("groupname123",
 					new PersistentSubscriptionSettings(),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToAllAsync("groupname123",
 					async (s, e, i, ct) => await s.Ack(e),
-					(s, r, e) => _dropped.TrySetResult((r, e)), TestCredentials.Root);
+					(s, r, e) => _dropped.TrySetResult((r, e)), userCredentials: TestCredentials.Root);
 				// todo: investigate why this test is flaky without this delay
 				await Task.Delay(500);
 			}
 
 			protected override Task When() =>
 				Client.DeleteToAllAsync("groupname123",
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 
 			public override Task DisposeAsync() {
 				_subscription?.Dispose();

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/deleting_filtered.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/deleting_filtered.cs
@@ -14,7 +14,7 @@ namespace EventStore.Client.SubscriptionToAll {
 
 		[Fact]
 		public async Task the_completion_succeeds() {
-			await _fixture.Client.DeleteToAllAsync(Group, TestCredentials.Root);
+			await _fixture.Client.DeleteToAllAsync(Group, userCredentials: TestCredentials.Root);
 		}
 
 		public class Fixture : EventStoreClientFixture {
@@ -23,7 +23,7 @@ namespace EventStore.Client.SubscriptionToAll {
 					Group,
 					EventTypeFilter.Prefix("prefix-filter-"),
 					new PersistentSubscriptionSettings(),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 			}
 
 			protected override Task When() => Task.CompletedTask;

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/deleting_nonexistent.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/deleting_nonexistent.cs
@@ -16,7 +16,7 @@ namespace EventStore.Client.SubscriptionToAll {
 		public async Task the_delete_fails_with_argument_exception() {
 			await Assert.ThrowsAsync<PersistentSubscriptionNotFoundException>(
 				() => _fixture.Client.DeleteToAllAsync(
-					Guid.NewGuid().ToString(), TestCredentials.Root));
+					Guid.NewGuid().ToString(), userCredentials: TestCredentials.Root));
 		}
 
 		public class Fixture : EventStoreClientFixture {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/happy_case_catching_up_to_link_to_events_manual_ack.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/happy_case_catching_up_to_link_to_events_manual_ack.cs
@@ -48,7 +48,7 @@ namespace EventStore.Client.SubscriptionToAll {
 
 				await Client.CreateToAllAsync(Group,
 					new PersistentSubscriptionSettings(startFrom: Position.Start, resolveLinkTos: true),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToAllAsync(Group,
 					async (subscription, e, retryCount, ct) => {
 						await subscription.Ack(e);

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/happy_case_catching_up_to_normal_events_manual_ack.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/happy_case_catching_up_to_normal_events_manual_ack.cs
@@ -43,7 +43,7 @@ namespace EventStore.Client.SubscriptionToAll {
 
 				await Client.CreateToAllAsync(Group,
 					new PersistentSubscriptionSettings(startFrom: Position.Start, resolveLinkTos: true),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToAllAsync(Group,
 					async(subscription, e, retryCount, ct) => {
 						await subscription.Ack(e);

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/happy_case_filtered.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/happy_case_filtered.cs
@@ -30,7 +30,7 @@ namespace EventStore.Client.SubscriptionToAll {
 			}
 			
 			await _fixture.Client.CreateToAllAsync(filterName, filter,
-				new PersistentSubscriptionSettings(startFrom: Position.Start), TestCredentials.Root);
+				new PersistentSubscriptionSettings(startFrom: Position.Start), userCredentials: TestCredentials.Root);
 			
 			using var subscription = await _fixture.Client.SubscribeToAllAsync(filterName,
 				eventAppeared: async (s, e, r, ct) => {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/happy_case_filtered_with_start_from_set.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/happy_case_filtered_with_start_from_set.cs
@@ -39,7 +39,7 @@ namespace EventStore.Client.SubscriptionToAll {
 			
 			await _fixture.Client.CreateToAllAsync(filterName, filter,
 				new PersistentSubscriptionSettings(startFrom: eventToCaptureResult.LogPosition),
-				TestCredentials.Root);
+				userCredentials: TestCredentials.Root);
 			
 			using var subscription = await _fixture.Client.SubscribeToAllAsync(filterName,
 				eventAppeared: async (s, e, r, ct) => {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/happy_case_writing_and_subscribing_to_normal_events_manual_ack.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/happy_case_writing_and_subscribing_to_normal_events_manual_ack.cs
@@ -39,7 +39,7 @@ namespace EventStore.Client.SubscriptionToAll {
 			protected override async Task Given() {
 				await Client.CreateToAllAsync(Group,
 					new PersistentSubscriptionSettings(startFrom: Position.End, resolveLinkTos: true),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToAllAsync(Group,
 					async (subscription, e, retryCount, ct) => {
 						await subscription.Ack(e);

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/update_existing.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/update_existing.cs
@@ -15,13 +15,13 @@ namespace EventStore.Client.SubscriptionToAll {
 		[Fact]
 		public async Task the_completion_succeeds() {
 			await _fixture.Client.UpdateToAllAsync(Group,
-				new PersistentSubscriptionSettings(), TestCredentials.Root);
+				new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 		}
 
 		public class Fixture : EventStoreClientFixture {
 			protected override async Task Given() {
 				await Client.CreateToAllAsync(Group, new PersistentSubscriptionSettings(),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 			}
 
 			protected override Task When() => Task.CompletedTask;

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/update_existing_filtered.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/update_existing_filtered.cs
@@ -17,7 +17,7 @@ namespace EventStore.Client.SubscriptionToAll {
 			await _fixture.Client.UpdateToAllAsync(
 				Group,
 				new PersistentSubscriptionSettings(resolveLinkTos: true),
-				TestCredentials.Root);
+				userCredentials: TestCredentials.Root);
 		}
 
 		public class Fixture : EventStoreClientFixture {
@@ -26,7 +26,7 @@ namespace EventStore.Client.SubscriptionToAll {
 					Group,
 					EventTypeFilter.Prefix("prefix-filter-"),
 					new PersistentSubscriptionSettings(),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 			}
 
 			protected override Task When() => Task.CompletedTask;

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/update_existing_with_check_point.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/update_existing_with_check_point.cs
@@ -53,7 +53,7 @@ namespace EventStore.Client.SubscriptionToAll {
 						checkPointLowerBound: 5,
 						checkPointAfter: TimeSpan.FromSeconds(1),
 						startFrom: Position.Start),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 
 				var checkPointStream = $"$persistentsubscription-$all::{Group}-checkpoint";
 				_checkPointSubscription = await StreamsClient.SubscribeToStreamAsync(checkPointStream,
@@ -79,7 +79,7 @@ namespace EventStore.Client.SubscriptionToAll {
 						await s.Ack(e);
 					},
 					(subscription, reason, ex) => _droppedSource.TrySetResult((reason, ex)),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 
 				await Task.WhenAll(_appeared.Task, _checkPointSource.Task).WithTimeout();
 
@@ -88,7 +88,7 @@ namespace EventStore.Client.SubscriptionToAll {
 
 			protected override async Task When() {
 				// Force restart of the subscription
-				await Client.UpdateToAllAsync(Group, new PersistentSubscriptionSettings(), TestCredentials.Root);
+				await Client.UpdateToAllAsync(Group, new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 
 				await _droppedSource.Task.WithTimeout();
 

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/update_existing_with_check_point_filtered.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/update_existing_with_check_point_filtered.cs
@@ -54,7 +54,7 @@ namespace EventStore.Client.SubscriptionToAll {
 						checkPointLowerBound: 5,
 						checkPointAfter: TimeSpan.FromSeconds(1),
 						startFrom: Position.Start),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 
 				var checkPointStream = $"$persistentsubscription-$all::{Group}-checkpoint";
 				_checkPointSubscription = await StreamsClient.SubscribeToStreamAsync(checkPointStream,
@@ -90,7 +90,7 @@ namespace EventStore.Client.SubscriptionToAll {
 
 			protected override async Task When() {
 				// Force restart of the subscription
-				await Client.UpdateToAllAsync(Group, new PersistentSubscriptionSettings(), TestCredentials.Root);
+				await Client.UpdateToAllAsync(Group, new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 
 				await _droppedSource.Task.WithTimeout();
 

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/update_existing_with_commit_position_equal_to_last_indexed_position.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/update_existing_with_commit_position_equal_to_last_indexed_position.cs
@@ -20,7 +20,7 @@ namespace EventStore.Client.SubscriptionToAll {
 			protected override async Task Given() {
 				await Client.CreateToAllAsync(Group,
 					new PersistentSubscriptionSettings(),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 
 				var lastEvent = await StreamsClient.ReadAllAsync(Direction.Backwards, Position.End, 1,
 					userCredentials: TestCredentials.Root).FirstAsync();
@@ -34,6 +34,6 @@ namespace EventStore.Client.SubscriptionToAll {
 			await _fixture.Client.UpdateToAllAsync(Group,
 					new PersistentSubscriptionSettings(
 						startFrom: new Position(_fixture.LastCommitPosition, _fixture.LastCommitPosition)),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 	}
 }

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/update_existing_with_commit_position_larger_than_last_indexed_position.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/update_existing_with_commit_position_larger_than_last_indexed_position.cs
@@ -21,7 +21,7 @@ namespace EventStore.Client.SubscriptionToAll {
 			protected override async Task When() {
 				await Client.CreateToAllAsync(Group,
 					new PersistentSubscriptionSettings(),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 
 				var lastEvent = await StreamsClient.ReadAllAsync(Direction.Backwards, Position.End, 1,
 					userCredentials: TestCredentials.Root).FirstAsync();
@@ -36,7 +36,7 @@ namespace EventStore.Client.SubscriptionToAll {
 				_fixture.Client.UpdateToAllAsync(Group,
 					new PersistentSubscriptionSettings(
 						startFrom: new Position(_fixture.LastCommitPosition + 1, _fixture.LastCommitPosition)),
-					TestCredentials.Root));
+					userCredentials: TestCredentials.Root));
 			Assert.Equal(StatusCode.Internal, ex.StatusCode);
 		}
 	}

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/update_existing_with_subscribers.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/update_existing_with_subscribers.cs
@@ -33,16 +33,16 @@ namespace EventStore.Client.SubscriptionToAll {
 
 			protected override async Task Given() {
 				await Client.CreateToAllAsync(Group, new PersistentSubscriptionSettings(),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToAllAsync(Group,
 					delegate { return Task.CompletedTask; },
-					(subscription, reason, ex) => _droppedSource.TrySetResult((reason, ex)), TestCredentials.Root);
+					(subscription, reason, ex) => _droppedSource.TrySetResult((reason, ex)), userCredentials: TestCredentials.Root);
 				// todo: investigate why this test is flaky without this delay
 				await Task.Delay(500);
 			}
 
 			protected override Task When() => Client.UpdateToAllAsync(Group,
-				new PersistentSubscriptionSettings(), TestCredentials.Root);
+				new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 
 			public override Task DisposeAsync() {
 				_subscription?.Dispose();

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/update_existing_without_permissions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/update_existing_without_permissions.cs
@@ -22,7 +22,7 @@ namespace EventStore.Client.SubscriptionToAll {
 		public class Fixture : EventStoreClientFixture {
 			protected override async Task Given() {
 				await Client.CreateToAllAsync(Group, new PersistentSubscriptionSettings(),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 			}
 
 			protected override Task When() => Task.CompletedTask;

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/update_non_existent.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/update_non_existent.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -17,7 +16,7 @@ namespace EventStore.Client.SubscriptionToAll {
 		public async Task the_completion_fails_with_not_found() {
 			await Assert.ThrowsAsync<PersistentSubscriptionNotFoundException>(
 				() => _fixture.Client.UpdateToAllAsync(Group,
-					new PersistentSubscriptionSettings(), TestCredentials.Root));
+					new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root));
 		}
 
 		public class Fixture : EventStoreClientFixture {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/update_with_prepare_position_larger_than_commit_position.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/update_with_prepare_position_larger_than_commit_position.cs
@@ -25,6 +25,6 @@ namespace EventStore.Client.SubscriptionToAll {
 				_fixture.Client.UpdateToAllAsync(Group,
 					new PersistentSubscriptionSettings(
 						startFrom: new Position(0, 1)),
-					TestCredentials.Root));
+					userCredentials: TestCredentials.Root));
 	}
 }

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/when_writing_and_filtering_out_events.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/when_writing_and_filtering_out_events.cs
@@ -57,7 +57,7 @@ namespace EventStore.Client.SubscriptionToAll {
 						checkPointLowerBound: 5,
 						checkPointAfter: TimeSpan.FromSeconds(1),
 						startFrom: Position.Start),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 
 				_checkPointSubscription = await StreamsClient.SubscribeToStreamAsync(_checkPointStream,
 					FromStream.Start,

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/when_writing_and_subscribing_to_normal_events_manual_nack.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/when_writing_and_subscribing_to_normal_events_manual_nack.cs
@@ -40,7 +40,7 @@ namespace EventStore.Client.SubscriptionToAll {
 			protected override async Task Given() {
 				await Client.CreateToAllAsync(Group,
 					new PersistentSubscriptionSettings(startFrom: Position.Start, resolveLinkTos: true),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToAllAsync(Group,
 					async (subscription, e, retryCount, ct) => {
 						await subscription.Nack(PersistentSubscriptionNakEventAction.Park, "fail", e);

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/can_create_duplicate_name_on_different_streams.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/can_create_duplicate_name_on_different_streams.cs
@@ -18,12 +18,12 @@ namespace EventStore.Client.SubscriptionToStream {
 
 			protected override Task When() =>
 				Client.CreateAsync(Stream, "group3211",
-					new PersistentSubscriptionSettings(), TestCredentials.Root);
+					new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 		}
 
 		[Fact]
 		public Task the_completion_succeeds() =>
 			_fixture.Client.CreateAsync("someother" + Stream,
-				"group3211", new PersistentSubscriptionSettings(), TestCredentials.Root);
+				"group3211", new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 	}
 }

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_max_one_client.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_max_one_client.cs
@@ -34,7 +34,7 @@ namespace EventStore.Client.SubscriptionToStream {
 					Stream,
 					Group,
 					new PersistentSubscriptionSettings(maxSubscriberCount: 1),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 
 			protected override Task When() => Task.CompletedTask;
 		}

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_permissions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_permissions.cs
@@ -30,7 +30,7 @@ namespace EventStore.Client.SubscriptionToStream {
 					Stream,
 					"agroupname17",
 					new PersistentSubscriptionSettings(),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 
 			protected override Task When() => Task.CompletedTask;
 		}

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_beginning_and_events_in_it.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_beginning_and_events_in_it.cs
@@ -39,7 +39,7 @@ namespace EventStore.Client.SubscriptionToStream {
 			protected override async Task Given() {
 				await StreamsClient.AppendToStreamAsync(Stream, StreamState.NoStream, Events);
 				await Client.CreateAsync(Stream, Group,
-					new PersistentSubscriptionSettings(startFrom: StreamPosition.Start), TestCredentials.Root);
+					new PersistentSubscriptionSettings(startFrom: StreamPosition.Start), userCredentials: TestCredentials.Root);
 			}
 
 			protected override async Task When() {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_beginning_and_no_stream.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_beginning_and_no_stream.cs
@@ -38,7 +38,7 @@ namespace EventStore.Client.SubscriptionToStream {
 
 			protected override async Task Given() {
 				await Client.CreateAsync(Stream, Group,
-					new PersistentSubscriptionSettings(), TestCredentials.Root);
+					new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToStreamAsync(Stream, Group,
 					async (subscription, e, r, ct) => {
 						_firstEventSource.TrySetResult(e);

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_not_set_and_events_in_it.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_not_set_and_events_in_it.cs
@@ -37,7 +37,7 @@ namespace EventStore.Client.SubscriptionToStream {
 			protected override async Task Given() {
 				await StreamsClient.AppendToStreamAsync(Stream, StreamState.NoStream, Events);
 				await Client.CreateAsync(Stream, Group,
-					new PersistentSubscriptionSettings(), TestCredentials.Root);
+					new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 			}
 
 			protected override async Task When() {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_not_set_and_events_in_it_then_event_written.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_not_set_and_events_in_it_then_event_written.cs
@@ -43,7 +43,7 @@ namespace EventStore.Client.SubscriptionToStream {
 			protected override async Task Given() {
 				await StreamsClient.AppendToStreamAsync(Stream, StreamState.NoStream, Events.Take(10));
 				await Client.CreateAsync(Stream, Group,
-					new PersistentSubscriptionSettings(), TestCredentials.Root);
+					new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToStreamAsync(Stream, Group,
 					async (subscription, e, r, ct) => {
 						_firstEventSource.TrySetResult(e);

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_set_to_end_position_and_events_in_it.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_set_to_end_position_and_events_in_it.cs
@@ -5,8 +5,7 @@ using Xunit;
 
 namespace EventStore.Client.SubscriptionToStream {
 	public class connect_to_existing_with_start_from_set_to_end_position_and_events_in_it
-		: IClassFixture<connect_to_existing_with_start_from_set_to_end_position_and_events_in_it.
-			Fixture> {
+		: IClassFixture<connect_to_existing_with_start_from_set_to_end_position_and_events_in_it.Fixture> {
 		private readonly Fixture _fixture;
 		private const string Group = "startinbeginning1";
 
@@ -37,7 +36,7 @@ namespace EventStore.Client.SubscriptionToStream {
 			protected override async Task Given() {
 				await StreamsClient.AppendToStreamAsync(Stream, StreamState.NoStream, Events);
 				await Client.CreateAsync(Stream, Group,
-					new PersistentSubscriptionSettings(startFrom: StreamPosition.End), TestCredentials.Root);
+					new PersistentSubscriptionSettings(startFrom: StreamPosition.End), userCredentials: TestCredentials.Root);
 			}
 
 			protected override async Task When() {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_set_to_end_position_and_events_in_it_then_event_written.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_set_to_end_position_and_events_in_it_then_event_written.cs
@@ -43,7 +43,7 @@ namespace EventStore.Client.SubscriptionToStream {
 			protected override async Task Given() {
 				await StreamsClient.AppendToStreamAsync(Stream, StreamState.NoStream, Events.Take(10));
 				await Client.CreateAsync(Stream, Group,
-					new PersistentSubscriptionSettings(startFrom: StreamPosition.End), TestCredentials.Root);
+					new PersistentSubscriptionSettings(startFrom: StreamPosition.End), userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToStreamAsync(Stream, Group,
 					async (subscription, e, r, ct) => {
 						_firstEventSource.TrySetResult(e);

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_two_and_no_stream.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_two_and_no_stream.cs
@@ -37,7 +37,7 @@ namespace EventStore.Client.SubscriptionToStream {
 
 			protected override async Task Given() {
 				await Client.CreateAsync(Stream, Group,
-					new PersistentSubscriptionSettings(startFrom: new StreamPosition(2)), TestCredentials.Root);
+					new PersistentSubscriptionSettings(startFrom: new StreamPosition(2)), userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToStreamAsync(Stream, Group,
 					async (subscription, e, r, ct) => {
 						_firstEventSource.TrySetResult(e);

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_x_set_and_events_in_it.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_x_set_and_events_in_it.cs
@@ -36,7 +36,7 @@ namespace EventStore.Client.SubscriptionToStream {
 			protected override async Task Given() {
 				await StreamsClient.AppendToStreamAsync(Stream, StreamState.NoStream, Events.Take(10));
 				await Client.CreateAsync(Stream, Group,
-					new PersistentSubscriptionSettings(startFrom: new StreamPosition(4)), TestCredentials.Root);
+					new PersistentSubscriptionSettings(startFrom: new StreamPosition(4)), userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToStreamAsync(Stream, Group,
 					async (subscription, e, r, ct) => {
 						_firstEventSource.TrySetResult(e);

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_x_set_and_events_in_it_then_event_written.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_x_set_and_events_in_it_then_event_written.cs
@@ -41,7 +41,7 @@ namespace EventStore.Client.SubscriptionToStream {
 			protected override async Task Given() {
 				await StreamsClient.AppendToStreamAsync(Stream, StreamState.NoStream, Events.Take(10));
 				await Client.CreateAsync(Stream, Group,
-					new PersistentSubscriptionSettings(startFrom: new StreamPosition(10)), TestCredentials.Root);
+					new PersistentSubscriptionSettings(startFrom: new StreamPosition(10)), userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToStreamAsync(Stream, Group,
 					async (subscription, e, r, ct) => {
 						_firstEventSource.TrySetResult(e);

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_x_set_higher_than_x_and_events_in_it_then_event_written.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_with_start_from_x_set_higher_than_x_and_events_in_it_then_event_written.cs
@@ -44,7 +44,7 @@ namespace EventStore.Client.SubscriptionToStream {
 			protected override async Task Given() {
 				await StreamsClient.AppendToStreamAsync(Stream, StreamState.NoStream, Events.Take(11));
 				await Client.CreateAsync(Stream, Group,
-					new PersistentSubscriptionSettings(startFrom: new StreamPosition(11)), TestCredentials.Root);
+					new PersistentSubscriptionSettings(startFrom: new StreamPosition(11)), userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToStreamAsync(Stream, Group,
 					async (subscription, e, r, ct) => {
 						_firstEventSource.TrySetResult(e);

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_without_permissions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_without_permissions.cs
@@ -21,7 +21,7 @@ namespace EventStore.Client.SubscriptionToStream {
 					Stream,
 					"agroupname55",
 					new PersistentSubscriptionSettings(),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 
 			protected override Task When() => Task.CompletedTask;
 		}

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_with_retries.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_with_retries.cs
@@ -33,7 +33,7 @@ namespace EventStore.Client.SubscriptionToStream {
 			protected override async Task Given() {
 				await StreamsClient.AppendToStreamAsync(Stream, StreamState.NoStream, Events);
 				await Client.CreateAsync(Stream, Group,
-					new PersistentSubscriptionSettings(startFrom: StreamPosition.Start), TestCredentials.Root);
+					new PersistentSubscriptionSettings(startFrom: StreamPosition.Start), userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToStreamAsync(Stream, Group,
 					async (subscription, e, r, ct) => {
 						if (r > 4) {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connecting_to_a_persistent_subscription.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connecting_to_a_persistent_subscription.cs
@@ -44,7 +44,7 @@ namespace EventStore.Client.SubscriptionToStream {
 			protected override async Task Given() {
 				await StreamsClient.AppendToStreamAsync(Stream, StreamState.NoStream, Events.Take(11));
 				await Client.CreateAsync(Stream, Group,
-					new PersistentSubscriptionSettings(startFrom: new StreamPosition(11)), TestCredentials.Root);
+					new PersistentSubscriptionSettings(startFrom: new StreamPosition(11)), userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToStreamAsync(Stream, Group,
 					async (subscription, e, r, ct) => {
 						_firstEventSource.TrySetResult(e);

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/create_after_deleting_the_same.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/create_after_deleting_the_same.cs
@@ -17,16 +17,16 @@ namespace EventStore.Client.SubscriptionToStream {
 			protected override async Task When() {
 				await StreamsClient.AppendToStreamAsync(Stream, StreamState.Any, CreateTestEvents());
 				await Client.CreateAsync(Stream, "existing",
-					new PersistentSubscriptionSettings(), TestCredentials.Root);
+					new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 				await Client.DeleteAsync(Stream, "existing",
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 			}
 		}
 
 		[Fact]
 		public async Task the_completion_succeeds() {
 			await _fixture.Client.CreateAsync(Stream, "existing",
-				new PersistentSubscriptionSettings(), TestCredentials.Root);
+				new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 		}
 	}
 }

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/create_duplicate.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/create_duplicate.cs
@@ -18,7 +18,7 @@ namespace EventStore.Client.SubscriptionToStream {
 
 			protected override Task When() =>
 				Client.CreateAsync(Stream, "group32",
-					new PersistentSubscriptionSettings(), TestCredentials.Root);
+					new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 		}
 
 		[Fact]
@@ -26,7 +26,7 @@ namespace EventStore.Client.SubscriptionToStream {
 			var ex = await Assert.ThrowsAsync<RpcException>(
 				() => _fixture.Client.CreateAsync(Stream, "group32",
 					new PersistentSubscriptionSettings(),
-					TestCredentials.Root));
+					userCredentials: TestCredentials.Root));
 			Assert.Equal(StatusCode.AlreadyExists, ex.StatusCode);
 		}
 	}

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/create_on_existing_stream.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/create_on_existing_stream.cs
@@ -21,6 +21,6 @@ namespace EventStore.Client.SubscriptionToStream {
 		[Fact]
 		public Task the_completion_succeeds()
 			=> _fixture.Client.CreateAsync(
-				Stream, "existing", new PersistentSubscriptionSettings(), TestCredentials.Root);
+				Stream, "existing", new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 	}
 }

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/create_on_non_existing_stream.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/create_on_non_existing_stream.cs
@@ -20,7 +20,7 @@ namespace EventStore.Client.SubscriptionToStream {
 		public async Task the_completion_succeeds() {
 			await _fixture.Client.CreateAsync(Stream, "nonexistinggroup",
 				new PersistentSubscriptionSettings(),
-				TestCredentials.Root);
+				userCredentials: TestCredentials.Root);
 		}
 	}
 }

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/create_persistent_subscription_with_dont_timeout.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/create_persistent_subscription_with_dont_timeout.cs
@@ -21,6 +21,6 @@ namespace EventStore.Client.SubscriptionToStream {
 		public Task the_subscription_is_created_without_error() =>
 			_fixture.Client.CreateAsync(Stream, "dont-timeout",
 				new PersistentSubscriptionSettings(messageTimeout: TimeSpan.Zero),
-				TestCredentials.Root);
+				userCredentials: TestCredentials.Root);
 	}
 }

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/deleting_existing_with_permissions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/deleting_existing_with_permissions.cs
@@ -17,12 +17,12 @@ namespace EventStore.Client.SubscriptionToStream {
 			protected override Task When() =>
 				Client.CreateAsync(Stream, "groupname123",
 					new PersistentSubscriptionSettings(),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 		}
 
 		[Fact]
 		public Task the_delete_of_group_succeeds() =>
 			_fixture.Client.DeleteAsync(Stream, "groupname123",
-				TestCredentials.Root);
+				userCredentials: TestCredentials.Root);
 	}
 }

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/deleting_existing_with_subscriber.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/deleting_existing_with_subscriber.cs
@@ -24,15 +24,15 @@ namespace EventStore.Client.SubscriptionToStream {
 			protected override async Task Given() {
 				await Client.CreateAsync(Stream, "groupname123",
 					new PersistentSubscriptionSettings(),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToStreamAsync(Stream, "groupname123",
-					(s, e, i, ct) => Task.CompletedTask,
-					(s, r, e) => _dropped.TrySetResult((r, e)), TestCredentials.Root);
+					(_, _, _, _) => Task.CompletedTask,
+					(_, r, e) => _dropped.TrySetResult((r, e)), TestCredentials.Root);
 			}
 
 			protected override Task When() =>
 				Client.DeleteAsync(Stream, "groupname123",
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 
 			public override Task DisposeAsync() {
 				_subscription?.Dispose();

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/deleting_nonexistent.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/deleting_nonexistent.cs
@@ -16,7 +16,7 @@ namespace EventStore.Client.SubscriptionToStream {
 		public async Task the_delete_fails_with_argument_exception() {
 			await Assert.ThrowsAsync<PersistentSubscriptionNotFoundException>(
 				() => _fixture.Client.DeleteAsync(Stream,
-					Guid.NewGuid().ToString(), TestCredentials.Root));
+					Guid.NewGuid().ToString(), userCredentials: TestCredentials.Root));
 		}
 
 		public class Fixture : EventStoreClientFixture {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/happy_case_catching_up_to_link_to_events_manual_ack.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/happy_case_catching_up_to_link_to_events_manual_ack.cs
@@ -47,7 +47,7 @@ namespace EventStore.Client.SubscriptionToStream {
 
 				await Client.CreateAsync(Stream, Group,
 					new PersistentSubscriptionSettings(startFrom: StreamPosition.Start, resolveLinkTos: true),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToStreamAsync(Stream, Group,
 					async (subscription, e, retryCount, ct) => {
 						await subscription.Ack(e);

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/happy_case_catching_up_to_normal_events_manual_ack.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/happy_case_catching_up_to_normal_events_manual_ack.cs
@@ -42,7 +42,7 @@ namespace EventStore.Client.SubscriptionToStream {
 
 				await Client.CreateAsync(Stream, Group,
 					new PersistentSubscriptionSettings(startFrom: StreamPosition.Start, resolveLinkTos: true),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToStreamAsync(Stream, Group,
 					async(subscription, e, retryCount, ct) => {
 						await subscription.Ack(e);

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/happy_case_writing_and_subscribing_to_normal_events_manual_ack.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/happy_case_writing_and_subscribing_to_normal_events_manual_ack.cs
@@ -38,7 +38,7 @@ namespace EventStore.Client.SubscriptionToStream {
 			protected override async Task Given() {
 				await Client.CreateAsync(Stream, Group,
 					new PersistentSubscriptionSettings(startFrom: StreamPosition.End, resolveLinkTos: true),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToStreamAsync(Stream, Group,
 					async (subscription, e, retryCount, ct) => {
 						await subscription.Ack(e);

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/update_existing.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/update_existing.cs
@@ -15,14 +15,14 @@ namespace EventStore.Client.SubscriptionToStream {
 		[Fact]
 		public async Task the_completion_succeeds() {
 			await _fixture.Client.UpdateAsync(Stream, Group,
-				new PersistentSubscriptionSettings(), TestCredentials.Root);
+				new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 		}
 
 		public class Fixture : EventStoreClientFixture {
 			protected override async Task Given() {
 				await StreamsClient.AppendToStreamAsync(Stream, StreamState.NoStream, CreateTestEvents());
 				await Client.CreateAsync(Stream, Group, new PersistentSubscriptionSettings(),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 			}
 
 			protected override Task When() => Task.CompletedTask;

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/update_existing_with_subscribers.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/update_existing_with_subscribers.cs
@@ -34,14 +34,14 @@ namespace EventStore.Client.SubscriptionToStream {
 			protected override async Task Given() {
 				await StreamsClient.AppendToStreamAsync(Stream, StreamState.NoStream, CreateTestEvents());
 				await Client.CreateAsync(Stream, Group, new PersistentSubscriptionSettings(),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToStreamAsync(Stream, Group,
 					delegate { return Task.CompletedTask; },
-					(subscription, reason, ex) => _droppedSource.TrySetResult((reason, ex)), TestCredentials.Root);
+					(_, reason, ex) => _droppedSource.TrySetResult((reason, ex)), TestCredentials.Root);
 			}
 
 			protected override Task When() => Client.UpdateAsync(Stream, Group,
-				new PersistentSubscriptionSettings(), TestCredentials.Root);
+				new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root);
 
 			public override Task DisposeAsync() {
 				_subscription?.Dispose();

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/update_existing_without_permissions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/update_existing_without_permissions.cs
@@ -23,7 +23,7 @@ namespace EventStore.Client.SubscriptionToStream {
 			protected override async Task Given() {
 				await StreamsClient.AppendToStreamAsync(Stream, StreamState.NoStream, CreateTestEvents());
 				await Client.CreateAsync(Stream, Group, new PersistentSubscriptionSettings(),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 			}
 
 			protected override Task When() => Task.CompletedTask;

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/update_non_existent.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/update_non_existent.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -17,7 +16,7 @@ namespace EventStore.Client.SubscriptionToStream {
 		public async Task the_completion_fails_with_not_found() {
 			await Assert.ThrowsAsync<PersistentSubscriptionNotFoundException>(
 				() => _fixture.Client.UpdateAsync(Stream, Group,
-					new PersistentSubscriptionSettings(), TestCredentials.Root));
+					new PersistentSubscriptionSettings(), userCredentials: TestCredentials.Root));
 		}
 
 		public class Fixture : EventStoreClientFixture {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/when_writing_and_subscribing_to_normal_events_manual_nack.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/when_writing_and_subscribing_to_normal_events_manual_nack.cs
@@ -39,7 +39,7 @@ namespace EventStore.Client.SubscriptionToStream {
 			protected override async Task Given() {
 				await Client.CreateAsync(Stream, Group,
 					new PersistentSubscriptionSettings(startFrom: StreamPosition.Start, resolveLinkTos: true),
-					TestCredentials.Root);
+					userCredentials: TestCredentials.Root);
 				_subscription = await Client.SubscribeToStreamAsync(Stream, Group,
 					async (subscription, e, retryCount, ct) => {
 						await subscription.Nack(PersistentSubscriptionNakEventAction.Park, "fail", e);

--- a/test/EventStore.Client.ProjectionManagement.Tests/EventStoreClientFixture.cs
+++ b/test/EventStore.Client.ProjectionManagement.Tests/EventStoreClientFixture.cs
@@ -34,7 +34,7 @@ namespace EventStore.Client {
 			if (RunStandardProjections) {
 				await Task
 					.WhenAll(StandardProjections.Names.Select(name =>
-						Client.EnableAsync(name, TestCredentials.Root)))
+						Client.EnableAsync(name, userCredentials: TestCredentials.Root)))
 					.WithTimeout(TimeSpan.FromMinutes(2));
 			}
 		}

--- a/test/EventStore.Client.ProjectionManagement.Tests/EventStoreProjectionManagementClientExtensions.cs
+++ b/test/EventStore.Client.ProjectionManagement.Tests/EventStoreProjectionManagementClientExtensions.cs
@@ -6,7 +6,8 @@ namespace EventStore.Client {
 	public static class EventStoreProjectionManagementClientExtensions {
 		public static async Task WarmUpAsync(this EventStoreProjectionManagementClient self) {
 			await self.WarmUpWith(async cancellationToken => {
-				await self.ListAllAsync(TestCredentials.Root, cancellationToken).ToArrayAsync();
+				await self.ListAllAsync(userCredentials: TestCredentials.Root, cancellationToken: cancellationToken)
+					.ToArrayAsync(cancellationToken);
 			});
 		}
 	}

--- a/test/EventStore.Client.ProjectionManagement.Tests/StandardProjections.cs
+++ b/test/EventStore.Client.ProjectionManagement.Tests/StandardProjections.cs
@@ -16,7 +16,7 @@ namespace EventStore.Client {
 				bool ready = false;
 
 				while (!ready) {
-					var result = await client.GetStatusAsync(name, TestCredentials.Root);
+					var result = await client.GetStatusAsync(name, userCredentials: TestCredentials.Root);
 					if (result.Status.Contains("Running")) {
 						ready = true;
 					} else {

--- a/test/EventStore.Client.ProjectionManagement.Tests/abort.cs
+++ b/test/EventStore.Client.ProjectionManagement.Tests/abort.cs
@@ -13,8 +13,8 @@ namespace EventStore.Client {
 		[Fact]
 		public async Task status_is_aborted() {
 			var name = StandardProjections.Names.First();
-			await _fixture.Client.AbortAsync(name, TestCredentials.Root);
-			var result = await _fixture.Client.GetStatusAsync(name, TestCredentials.Root);
+			await _fixture.Client.AbortAsync(name, userCredentials: TestCredentials.Root);
+			var result = await _fixture.Client.GetStatusAsync(name, userCredentials: TestCredentials.Root);
 			Assert.Equal("Aborted/Stopped", result.Status);
 		}
 

--- a/test/EventStore.Client.ProjectionManagement.Tests/create.cs
+++ b/test/EventStore.Client.ProjectionManagement.Tests/create.cs
@@ -12,7 +12,7 @@ namespace EventStore.Client {
 		[Fact]
 		public async Task one_time() {
 			await _fixture.Client.CreateOneTimeAsync(
-				"fromAll().when({$init: function (state, ev) {return {};}});", TestCredentials.Root);
+				"fromAll().when({$init: function (state, ev) {return {};}});", userCredentials: TestCredentials.Root);
 		}
 
 		[Theory, InlineData(true), InlineData(false)]
@@ -20,14 +20,14 @@ namespace EventStore.Client {
 			await _fixture.Client.CreateContinuousAsync(
 				$"{nameof(continuous)}_{trackEmittedStreams}",
 				"fromAll().when({$init: function (state, ev) {return {};}});", trackEmittedStreams,
-				TestCredentials.Root);
+				userCredentials: TestCredentials.Root);
 		}
 
 		[Fact]
 		public async Task transient() {
 			await _fixture.Client.CreateTransientAsync(
 				nameof(transient),
-				"fromAll().when({$init: function (state, ev) {return {};}});", TestCredentials.Root);
+				"fromAll().when({$init: function (state, ev) {return {};}});", userCredentials: TestCredentials.Root);
 		}
 
 		public class Fixture : EventStoreClientFixture {

--- a/test/EventStore.Client.ProjectionManagement.Tests/disable.cs
+++ b/test/EventStore.Client.ProjectionManagement.Tests/disable.cs
@@ -13,8 +13,8 @@ namespace EventStore.Client {
 		[Fact]
 		public async Task status_is_stopped() {
 			var name = StandardProjections.Names.First();
-			await _fixture.Client.DisableAsync(name, TestCredentials.Root);
-			var result = await _fixture.Client.GetStatusAsync(name, TestCredentials.Root);
+			await _fixture.Client.DisableAsync(name, userCredentials: TestCredentials.Root);
+			var result = await _fixture.Client.GetStatusAsync(name, userCredentials: TestCredentials.Root);
 			Assert.Equal("Stopped", result.Status);
 		}
 

--- a/test/EventStore.Client.ProjectionManagement.Tests/enable.cs
+++ b/test/EventStore.Client.ProjectionManagement.Tests/enable.cs
@@ -13,8 +13,8 @@ namespace EventStore.Client {
 		[Fact]
 		public async Task status_is_running() {
 			var name = StandardProjections.Names.First();
-			await _fixture.Client.EnableAsync(name, TestCredentials.Root);
-			var result = await _fixture.Client.GetStatusAsync(name, TestCredentials.Root);
+			await _fixture.Client.EnableAsync(name, userCredentials: TestCredentials.Root);
+			var result = await _fixture.Client.GetStatusAsync(name, userCredentials: TestCredentials.Root);
 			Assert.Equal("Running", result.Status);
 		}
 

--- a/test/EventStore.Client.ProjectionManagement.Tests/list_all_projections.cs
+++ b/test/EventStore.Client.ProjectionManagement.Tests/list_all_projections.cs
@@ -12,7 +12,7 @@ namespace EventStore.Client {
 
 		[Fact]
 		public async Task returns_expected_result() {
-			var result = await _fixture.Client.ListAllAsync(TestCredentials.Root)
+			var result = await _fixture.Client.ListAllAsync(userCredentials: TestCredentials.Root)
 				.ToArrayAsync();
 
 			Assert.Equal(result.Select(x => x.Name).OrderBy(x => x), StandardProjections.Names.OrderBy(x => x));

--- a/test/EventStore.Client.ProjectionManagement.Tests/list_continuous_projections.cs
+++ b/test/EventStore.Client.ProjectionManagement.Tests/list_continuous_projections.cs
@@ -12,7 +12,7 @@ namespace EventStore.Client {
 
 		[Fact]
 		public async Task returns_expected_result() {
-			var result = await _fixture.Client.ListContinuousAsync(TestCredentials.Root)
+			var result = await _fixture.Client.ListContinuousAsync(userCredentials: TestCredentials.Root)
 				.ToArrayAsync();
 
 			Assert.Equal(result.Select(x => x.Name).OrderBy(x => x),

--- a/test/EventStore.Client.ProjectionManagement.Tests/list_one_time_projections.cs
+++ b/test/EventStore.Client.ProjectionManagement.Tests/list_one_time_projections.cs
@@ -12,7 +12,7 @@ namespace EventStore.Client {
 
 		[Fact]
 		public async Task returns_expected_result() {
-			var result = await _fixture.Client.ListOneTimeAsync(TestCredentials.Root)
+			var result = await _fixture.Client.ListOneTimeAsync(userCredentials: TestCredentials.Root)
 				.ToArrayAsync();
 
 			var details = Assert.Single(result);
@@ -22,7 +22,7 @@ namespace EventStore.Client {
 		public class Fixture : EventStoreClientFixture {
 			protected override Task Given() =>
 				Client.CreateOneTimeAsync(
-					"fromAll().when({$init: function (state, ev) {return {};}});", TestCredentials.Root);
+					"fromAll().when({$init: function (state, ev) {return {};}});", userCredentials: TestCredentials.Root);
 
 			protected override Task When() => Task.CompletedTask;
 		}

--- a/test/EventStore.Client.ProjectionManagement.Tests/reset.cs
+++ b/test/EventStore.Client.ProjectionManagement.Tests/reset.cs
@@ -13,8 +13,8 @@ namespace EventStore.Client {
 		[Fact]
 		public async Task status_is_running() {
 			var name = StandardProjections.Names.First();
-			await _fixture.Client.ResetAsync(name, TestCredentials.Root);
-			var result = await _fixture.Client.GetStatusAsync(name, TestCredentials.Root);
+			await _fixture.Client.ResetAsync(name, userCredentials: TestCredentials.Root);
+			var result = await _fixture.Client.GetStatusAsync(name, userCredentials: TestCredentials.Root);
 			Assert.Equal("Running", result.Status);
 		}
 

--- a/test/EventStore.Client.ProjectionManagement.Tests/restart_subsystem.cs
+++ b/test/EventStore.Client.ProjectionManagement.Tests/restart_subsystem.cs
@@ -1,6 +1,4 @@
-using System.Linq;
 using System.Threading.Tasks;
-using Grpc.Core;
 using Xunit;
 
 namespace EventStore.Client {
@@ -13,7 +11,7 @@ namespace EventStore.Client {
 
 		[Fact]
 		public async Task does_not_throw() {
-			await _fixture.Client.RestartSubsystemAsync(TestCredentials.Root);
+			await _fixture.Client.RestartSubsystemAsync(userCredentials: TestCredentials.Root);
 		}
 
 		[Fact]

--- a/test/EventStore.Client.ProjectionManagement.Tests/update.cs
+++ b/test/EventStore.Client.ProjectionManagement.Tests/update.cs
@@ -12,7 +12,7 @@ namespace EventStore.Client {
 		[Theory, InlineData(true), InlineData(false), InlineData(null)]
 		public async Task returns_expected_result(bool? emitEnabled) {
 			await _fixture.Client.UpdateAsync(nameof(update),
-				"fromAll().when({$init: function (s, e) {return {};}});", emitEnabled, TestCredentials.Root);
+				"fromAll().when({$init: function (s, e) {return {};}});", emitEnabled, userCredentials: TestCredentials.Root);
 		}
 
 		public class Fixture : EventStoreClientFixture {

--- a/test/EventStore.Client.Streams.Tests/Security/SecurityFixture.cs
+++ b/test/EventStore.Client.Streams.Tests/Security/SecurityFixture.cs
@@ -38,7 +38,7 @@ namespace EventStore.Client.Security {
 
 			await UserManagementClient.CreateUserWithRetry(TestCredentials.TestAdmin.Username!,
 				nameof(TestCredentials.TestAdmin), new[] {SystemRoles.Admins}, TestCredentials.TestAdmin.Password!,
-				TestCredentials.Root).WithTimeout(TimeSpan.FromMilliseconds(TimeoutMs));
+				userCredentials: TestCredentials.Root).WithTimeout(TimeSpan.FromMilliseconds(TimeoutMs));
 		}
 
 		protected override async Task Given() {
@@ -190,8 +190,8 @@ namespace EventStore.Client.Security {
 				       }, false, (_, _, ex) => {
 					       if (ex == null) source.TrySetResult(true);
 					       else source.TrySetException(ex);
-				       }, null, null,
-				       userCredentials, default).WithTimeout(TimeSpan.FromMilliseconds(TimeoutMs))) {
+				       },
+				       userCredentials: userCredentials).WithTimeout(TimeSpan.FromMilliseconds(TimeoutMs))) {
 				await source.Task.WithTimeout(TimeSpan.FromMilliseconds(TimeoutMs));
 			}
 		}

--- a/test/EventStore.Client.Streams.Tests/Security/all_stream_with_no_acl_security.cs
+++ b/test/EventStore.Client.Streams.Tests/Security/all_stream_with_no_acl_security.cs
@@ -13,15 +13,15 @@ namespace EventStore.Client.Security {
 		[Fact]
 		public async Task write_to_all_is_never_allowed() {
 			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.AppendStream(SecurityFixture.AllStream));
-			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.AppendStream(SecurityFixture.AllStream, TestCredentials.TestUser1));
-			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.AppendStream(SecurityFixture.AllStream, TestCredentials.TestAdmin));
+			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.AppendStream(SecurityFixture.AllStream, userCredentials: TestCredentials.TestUser1));
+			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.AppendStream(SecurityFixture.AllStream, userCredentials: TestCredentials.TestAdmin));
 		}
 
 		[Fact]
 		public async Task delete_of_all_is_never_allowed() {
 			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.DeleteStream(SecurityFixture.AllStream));
-			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.DeleteStream(SecurityFixture.AllStream, TestCredentials.TestUser1));
-			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.DeleteStream(SecurityFixture.AllStream, TestCredentials.TestAdmin));
+			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.DeleteStream(SecurityFixture.AllStream, userCredentials: TestCredentials.TestUser1));
+			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.DeleteStream(SecurityFixture.AllStream, userCredentials: TestCredentials.TestAdmin));
 		}
 
 
@@ -37,7 +37,7 @@ namespace EventStore.Client.Security {
 		public async Task reading_and_subscribing_is_not_allowed_for_usual_user() {
 			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.ReadAllForward(TestCredentials.TestUser1));
 			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.ReadAllBackward(TestCredentials.TestUser1));
-			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.ReadMeta(SecurityFixture.AllStream, TestCredentials.TestUser1));
+			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.ReadMeta(SecurityFixture.AllStream, userCredentials: TestCredentials.TestUser1));
 			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.SubscribeToAll(TestCredentials.TestUser1));
 		}
 
@@ -45,7 +45,7 @@ namespace EventStore.Client.Security {
 		public async Task reading_and_subscribing_is_allowed_for_admin_user() {
 			await _fixture.ReadAllForward(TestCredentials.TestAdmin);
 			await _fixture.ReadAllBackward(TestCredentials.TestAdmin);
-			await _fixture.ReadMeta(SecurityFixture.AllStream, TestCredentials.TestAdmin);
+			await _fixture.ReadMeta(SecurityFixture.AllStream, userCredentials: TestCredentials.TestAdmin);
 			await _fixture.SubscribeToAll(TestCredentials.TestAdmin);
 		}
 
@@ -56,12 +56,12 @@ namespace EventStore.Client.Security {
 
 		[Fact]
 		public async Task meta_write_is_not_allowed_for_usual_user() {
-			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.WriteMeta(SecurityFixture.AllStream, TestCredentials.TestUser1));
+			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.WriteMeta(SecurityFixture.AllStream, userCredentials: TestCredentials.TestUser1));
 		}
 
 		[Fact]
 		public Task meta_write_is_allowed_for_admin_user() {
-			return _fixture.WriteMeta(SecurityFixture.AllStream, TestCredentials.TestAdmin);
+			return _fixture.WriteMeta(SecurityFixture.AllStream, userCredentials: TestCredentials.TestAdmin);
 		}
 
 		public class Fixture : SecurityFixture {

--- a/test/EventStore.Client.Streams.Tests/Security/delete_stream_security.cs
+++ b/test/EventStore.Client.Streams.Tests/Security/delete_stream_security.cs
@@ -12,8 +12,8 @@ namespace EventStore.Client.Security {
 		[Fact]
 		public async Task delete_of_all_is_never_allowed() {
 			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.DeleteStream(SecurityFixture.AllStream));
-			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.DeleteStream(SecurityFixture.AllStream, TestCredentials.TestUser1));
-			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.DeleteStream(SecurityFixture.AllStream, TestCredentials.TestAdmin));
+			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.DeleteStream(SecurityFixture.AllStream, userCredentials: TestCredentials.TestUser1));
+			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.DeleteStream(SecurityFixture.AllStream, userCredentials: TestCredentials.TestAdmin));
 		}
 
 		[Fact]
@@ -25,13 +25,13 @@ namespace EventStore.Client.Security {
 		[Fact]
 		public async Task deleting_normal_no_acl_stream_with_existing_user_is_allowed() {
 			var streamId = await _fixture.CreateStreamWithMeta(new StreamMetadata());
-			await _fixture.DeleteStream(streamId, TestCredentials.TestUser1);
+			await _fixture.DeleteStream(streamId, userCredentials: TestCredentials.TestUser1);
 		}
 
 		[Fact]
 		public async Task deleting_normal_no_acl_stream_with_admin_user_is_allowed() {
 			var streamId = await _fixture.CreateStreamWithMeta(new StreamMetadata());
-			await _fixture.DeleteStream(streamId, TestCredentials.TestAdmin);
+			await _fixture.DeleteStream(streamId, userCredentials: TestCredentials.TestAdmin);
 		}
 
 
@@ -53,14 +53,14 @@ namespace EventStore.Client.Security {
 		public async Task deleting_normal_user_stream_with_authorized_user_is_allowed() {
 			var streamId =
 				await _fixture.CreateStreamWithMeta(new StreamMetadata(acl: new StreamAcl(deleteRole: TestCredentials.TestUser1.Username)));
-			await _fixture.DeleteStream(streamId, TestCredentials.TestUser1);
+			await _fixture.DeleteStream(streamId, userCredentials: TestCredentials.TestUser1);
 		}
 
 		[Fact]
 		public async Task deleting_normal_user_stream_with_admin_user_is_allowed() {
 			var streamId =
 				await _fixture.CreateStreamWithMeta(new StreamMetadata(acl: new StreamAcl(deleteRole: TestCredentials.TestUser1.Username)));
-			await _fixture.DeleteStream(streamId, TestCredentials.TestAdmin);
+			await _fixture.DeleteStream(streamId, userCredentials: TestCredentials.TestAdmin);
 		}
 
 
@@ -77,7 +77,7 @@ namespace EventStore.Client.Security {
 			var streamId =
 				await _fixture.CreateStreamWithMeta(
 					new StreamMetadata(acl: new StreamAcl(deleteRole: SystemRoles.Admins)));
-			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.DeleteStream(streamId, TestCredentials.TestUser1));
+			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.DeleteStream(streamId, userCredentials: TestCredentials.TestUser1));
 		}
 
 		[Fact]
@@ -85,7 +85,7 @@ namespace EventStore.Client.Security {
 			var streamId =
 				await _fixture.CreateStreamWithMeta(
 					new StreamMetadata(acl: new StreamAcl(deleteRole: SystemRoles.Admins)));
-			await _fixture.DeleteStream(streamId, TestCredentials.TestAdmin);
+			await _fixture.DeleteStream(streamId, userCredentials: TestCredentials.TestAdmin);
 		}
 
 
@@ -102,7 +102,7 @@ namespace EventStore.Client.Security {
 			var streamId =
 				await _fixture.CreateStreamWithMeta(
 					new StreamMetadata(acl: new StreamAcl(deleteRole: SystemRoles.All)));
-			await _fixture.DeleteStream(streamId, TestCredentials.TestUser1);
+			await _fixture.DeleteStream(streamId, userCredentials: TestCredentials.TestUser1);
 		}
 
 		[Fact]
@@ -110,7 +110,7 @@ namespace EventStore.Client.Security {
 			var streamId =
 				await _fixture.CreateStreamWithMeta(
 					new StreamMetadata(acl: new StreamAcl(deleteRole: SystemRoles.All)));
-			await _fixture.DeleteStream(streamId, TestCredentials.TestAdmin);
+			await _fixture.DeleteStream(streamId, userCredentials: TestCredentials.TestAdmin);
 		}
 
 		// $-stream
@@ -126,14 +126,14 @@ namespace EventStore.Client.Security {
 		public async Task deleting_system_no_acl_stream_with_existing_user_is_not_allowed() {
 			var streamId = await _fixture.CreateStreamWithMeta(streamId: $"${_fixture.GetStreamName()}",
 				metadata: new StreamMetadata());
-			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.DeleteStream(streamId, TestCredentials.TestUser1));
+			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.DeleteStream(streamId, userCredentials: TestCredentials.TestUser1));
 		}
 
 		[Fact]
 		public async Task deleting_system_no_acl_stream_with_admin_user_is_allowed() {
 			var streamId = await _fixture.CreateStreamWithMeta(streamId: $"${_fixture.GetStreamName()}",
 				metadata: new StreamMetadata());
-			await _fixture.DeleteStream(streamId, TestCredentials.TestAdmin);
+			await _fixture.DeleteStream(streamId, userCredentials: TestCredentials.TestAdmin);
 		}
 
 
@@ -155,14 +155,14 @@ namespace EventStore.Client.Security {
 		public async Task deleting_system_user_stream_with_authorized_user_is_allowed() {
 			var streamId = await _fixture.CreateStreamWithMeta(streamId: $"${_fixture.GetStreamName()}",
 				metadata: new StreamMetadata(acl: new StreamAcl(deleteRole: TestCredentials.TestUser1.Username)));
-			await _fixture.DeleteStream(streamId, TestCredentials.TestUser1);
+			await _fixture.DeleteStream(streamId, userCredentials: TestCredentials.TestUser1);
 		}
 
 		[Fact]
 		public async Task deleting_system_user_stream_with_admin_user_is_allowed() {
 			var streamId = await _fixture.CreateStreamWithMeta(streamId: $"${_fixture.GetStreamName()}",
 				metadata: new StreamMetadata(acl: new StreamAcl(deleteRole: TestCredentials.TestUser1.Username)));
-			await _fixture.DeleteStream(streamId, TestCredentials.TestAdmin);
+			await _fixture.DeleteStream(streamId, userCredentials: TestCredentials.TestAdmin);
 		}
 
 
@@ -177,14 +177,14 @@ namespace EventStore.Client.Security {
 		public async Task deleting_system_admin_stream_with_existing_user_is_not_allowed() {
 			var streamId = await _fixture.CreateStreamWithMeta(streamId: $"${_fixture.GetStreamName()}",
 				metadata: new StreamMetadata(acl: new StreamAcl(deleteRole: SystemRoles.Admins)));
-			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.DeleteStream(streamId, TestCredentials.TestUser1));
+			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.DeleteStream(streamId, userCredentials: TestCredentials.TestUser1));
 		}
 
 		[Fact]
 		public async Task deleting_system_admin_stream_with_admin_user_is_allowed() {
 			var streamId = await _fixture.CreateStreamWithMeta(streamId: $"${_fixture.GetStreamName()}",
 				metadata: new StreamMetadata(acl: new StreamAcl(deleteRole: SystemRoles.Admins)));
-			await _fixture.DeleteStream(streamId, TestCredentials.TestAdmin);
+			await _fixture.DeleteStream(streamId, userCredentials: TestCredentials.TestAdmin);
 		}
 
 
@@ -199,14 +199,14 @@ namespace EventStore.Client.Security {
 		public async Task deleting_system_all_stream_with_existing_user_is_allowed() {
 			var streamId = await _fixture.CreateStreamWithMeta(streamId: $"${_fixture.GetStreamName()}",
 				metadata: new StreamMetadata(acl: new StreamAcl(deleteRole: SystemRoles.All)));
-			await _fixture.DeleteStream(streamId, TestCredentials.TestUser1);
+			await _fixture.DeleteStream(streamId, userCredentials: TestCredentials.TestUser1);
 		}
 
 		[Fact]
 		public async Task deleting_system_all_stream_with_admin_user_is_allowed() {
 			var streamId = await _fixture.CreateStreamWithMeta(streamId: $"${_fixture.GetStreamName()}",
 				metadata: new StreamMetadata(acl: new StreamAcl(deleteRole: SystemRoles.All)));
-			await _fixture.DeleteStream(streamId, TestCredentials.TestAdmin);
+			await _fixture.DeleteStream(streamId, userCredentials: TestCredentials.TestAdmin);
 		}
 
 

--- a/test/EventStore.Client.Streams.Tests/Security/multiple_role_security.cs
+++ b/test/EventStore.Client.Streams.Tests/Security/multiple_role_security.cs
@@ -12,19 +12,19 @@ namespace EventStore.Client.Security {
 		[Fact]
 		public async Task multiple_roles_are_handled_correctly() {
 			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.ReadEvent("usr-stream"));
-			await Assert.ThrowsAsync<StreamNotFoundException>(() => _fixture.ReadEvent("usr-stream", TestCredentials.TestUser1));
+			await Assert.ThrowsAsync<StreamNotFoundException>(() => _fixture.ReadEvent("usr-stream", userCredentials: TestCredentials.TestUser1));
 			await Assert.ThrowsAsync<StreamNotFoundException>(() => _fixture.ReadEvent("usr-stream", TestCredentials.TestUser2));
-			await Assert.ThrowsAsync<StreamNotFoundException>(() => _fixture.ReadEvent("usr-stream", TestCredentials.TestAdmin));
+			await Assert.ThrowsAsync<StreamNotFoundException>(() => _fixture.ReadEvent("usr-stream", userCredentials: TestCredentials.TestAdmin));
 
 			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.AppendStream("usr-stream"));
-			await _fixture.AppendStream("usr-stream", TestCredentials.TestUser1);
+			await _fixture.AppendStream("usr-stream", userCredentials: TestCredentials.TestUser1);
 			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.AppendStream("usr-stream", TestCredentials.TestUser2));
-			await _fixture.AppendStream("usr-stream", TestCredentials.TestAdmin);
+			await _fixture.AppendStream("usr-stream", userCredentials: TestCredentials.TestAdmin);
 
 			await _fixture.DeleteStream("usr-stream1");
-			await _fixture.DeleteStream("usr-stream2", TestCredentials.TestUser1);
+			await _fixture.DeleteStream("usr-stream2", userCredentials: TestCredentials.TestUser1);
 			await _fixture.DeleteStream("usr-stream3", TestCredentials.TestUser2);
-			await _fixture.DeleteStream("usr-stream4", TestCredentials.TestAdmin);
+			await _fixture.DeleteStream("usr-stream4", userCredentials: TestCredentials.TestAdmin);
 		}
 
 
@@ -33,7 +33,7 @@ namespace EventStore.Client.Security {
 				var settings = new SystemSettings(
 					new StreamAcl(new[] {"user1", "user2"}, new[] {"$admins", "user1"},
 						new[] {"user1", SystemRoles.All}));
-				return Client.SetSystemSettingsAsync(settings, TestCredentials.TestAdmin);
+				return Client.SetSystemSettingsAsync(settings, userCredentials: TestCredentials.TestAdmin);
 			}
 		}
 	}

--- a/test/EventStore.Client.Streams.Tests/Security/overriden_system_stream_security.cs
+++ b/test/EventStore.Client.Streams.Tests/Security/overriden_system_stream_security.cs
@@ -12,18 +12,18 @@ namespace EventStore.Client.Security {
 		[Fact]
 		public async Task operations_on_system_stream_succeed_for_authorized_user() {
 			var stream = $"${_fixture.GetStreamName()}";
-			await _fixture.AppendStream(stream, TestCredentials.TestUser1);
+			await _fixture.AppendStream(stream, userCredentials: TestCredentials.TestUser1);
 
-			await _fixture.ReadEvent(stream, TestCredentials.TestUser1);
-			await _fixture.ReadStreamForward(stream, TestCredentials.TestUser1);
-			await _fixture.ReadStreamBackward(stream, TestCredentials.TestUser1);
+			await _fixture.ReadEvent(stream, userCredentials: TestCredentials.TestUser1);
+			await _fixture.ReadStreamForward(stream, userCredentials: TestCredentials.TestUser1);
+			await _fixture.ReadStreamBackward(stream, userCredentials: TestCredentials.TestUser1);
 
-			await _fixture.ReadMeta(stream, TestCredentials.TestUser1);
-			await _fixture.WriteMeta(stream, TestCredentials.TestUser1, null);
+			await _fixture.ReadMeta(stream, userCredentials: TestCredentials.TestUser1);
+			await _fixture.WriteMeta(stream, userCredentials: TestCredentials.TestUser1, null);
 
-			await _fixture.SubscribeToStream(stream, TestCredentials.TestUser1);
+			await _fixture.SubscribeToStream(stream, userCredentials: TestCredentials.TestUser1);
 
-			await _fixture.DeleteStream(stream, TestCredentials.TestUser1);
+			await _fixture.DeleteStream(stream, userCredentials: TestCredentials.TestUser1);
 		}
 
 		[Fact]
@@ -64,18 +64,18 @@ namespace EventStore.Client.Security {
 		[Fact]
 		public async Task operations_on_system_stream_succeed_for_admin() {
 			var stream = $"${_fixture.GetStreamName()}";
-			await _fixture.AppendStream(stream, TestCredentials.TestAdmin);
+			await _fixture.AppendStream(stream, userCredentials: TestCredentials.TestAdmin);
 
-			await _fixture.ReadEvent(stream, TestCredentials.TestAdmin);
-			await _fixture.ReadStreamForward(stream, TestCredentials.TestAdmin);
-			await _fixture.ReadStreamBackward(stream, TestCredentials.TestAdmin);
+			await _fixture.ReadEvent(stream, userCredentials: TestCredentials.TestAdmin);
+			await _fixture.ReadStreamForward(stream, userCredentials: TestCredentials.TestAdmin);
+			await _fixture.ReadStreamBackward(stream, userCredentials: TestCredentials.TestAdmin);
 
-			await _fixture.ReadMeta(stream, TestCredentials.TestAdmin);
-			await _fixture.WriteMeta(stream, TestCredentials.TestAdmin, null);
+			await _fixture.ReadMeta(stream, userCredentials: TestCredentials.TestAdmin);
+			await _fixture.WriteMeta(stream, userCredentials: TestCredentials.TestAdmin, null);
 
-			await _fixture.SubscribeToStream(stream, TestCredentials.TestAdmin);
+			await _fixture.SubscribeToStream(stream, userCredentials: TestCredentials.TestAdmin);
 
-			await _fixture.DeleteStream(stream, TestCredentials.TestAdmin);
+			await _fixture.DeleteStream(stream, userCredentials: TestCredentials.TestAdmin);
 		}
 
 		public class Fixture : SecurityFixture {
@@ -83,7 +83,7 @@ namespace EventStore.Client.Security {
 				var settings = new SystemSettings(
 					systemStreamAcl: new StreamAcl("user1", "user1", "user1", "user1", "user1"),
 					userStreamAcl: default);
-				return Client.SetSystemSettingsAsync(settings, TestCredentials.TestAdmin);
+				return Client.SetSystemSettingsAsync(settings, userCredentials: TestCredentials.TestAdmin);
 			}
 		}
 	}

--- a/test/EventStore.Client.Streams.Tests/Security/overriden_system_stream_security_for_all.cs
+++ b/test/EventStore.Client.Streams.Tests/Security/overriden_system_stream_security_for_all.cs
@@ -15,24 +15,24 @@ namespace EventStore.Client.Security {
 				var settings = new SystemSettings(
 					systemStreamAcl: new StreamAcl(SystemRoles.All, SystemRoles.All, SystemRoles.All, SystemRoles.All,
 						SystemRoles.All));
-				return Client.SetSystemSettingsAsync(settings, TestCredentials.TestAdmin);
+				return Client.SetSystemSettingsAsync(settings, userCredentials: TestCredentials.TestAdmin);
 			}
 		}
 
 		[Fact]
 		public async Task operations_on_system_stream_succeeds_for_user() {
 			var stream = $"${_fixture.GetStreamName()}";
-			await _fixture.AppendStream(stream, TestCredentials.TestUser1);
-			await _fixture.ReadEvent(stream, TestCredentials.TestUser1);
-			await _fixture.ReadStreamForward(stream, TestCredentials.TestUser1);
-			await _fixture.ReadStreamBackward(stream, TestCredentials.TestUser1);
+			await _fixture.AppendStream(stream, userCredentials: TestCredentials.TestUser1);
+			await _fixture.ReadEvent(stream, userCredentials: TestCredentials.TestUser1);
+			await _fixture.ReadStreamForward(stream, userCredentials: TestCredentials.TestUser1);
+			await _fixture.ReadStreamBackward(stream, userCredentials: TestCredentials.TestUser1);
 
-			await _fixture.ReadMeta(stream, TestCredentials.TestUser1);
-			await _fixture.WriteMeta(stream, TestCredentials.TestUser1, null);
+			await _fixture.ReadMeta(stream, userCredentials: TestCredentials.TestUser1);
+			await _fixture.WriteMeta(stream, userCredentials: TestCredentials.TestUser1, null);
 
-			await _fixture.SubscribeToStream(stream, TestCredentials.TestUser1);
+			await _fixture.SubscribeToStream(stream, userCredentials: TestCredentials.TestUser1);
 
-			await _fixture.DeleteStream(stream, TestCredentials.TestUser1);
+			await _fixture.DeleteStream(stream, userCredentials: TestCredentials.TestUser1);
 		}
 
 		[Fact]
@@ -54,18 +54,18 @@ namespace EventStore.Client.Security {
 		[Fact]
 		public async Task operations_on_system_stream_succeed_for_admin() {
 			var stream = $"${_fixture.GetStreamName()}";
-			await _fixture.AppendStream(stream, TestCredentials.TestAdmin);
+			await _fixture.AppendStream(stream, userCredentials: TestCredentials.TestAdmin);
 
-			await _fixture.ReadEvent(stream, TestCredentials.TestAdmin);
-			await _fixture.ReadStreamForward(stream, TestCredentials.TestAdmin);
-			await _fixture.ReadStreamBackward(stream, TestCredentials.TestAdmin);
+			await _fixture.ReadEvent(stream, userCredentials: TestCredentials.TestAdmin);
+			await _fixture.ReadStreamForward(stream, userCredentials: TestCredentials.TestAdmin);
+			await _fixture.ReadStreamBackward(stream, userCredentials: TestCredentials.TestAdmin);
 
-			await _fixture.ReadMeta(stream, TestCredentials.TestAdmin);
-			await _fixture.WriteMeta(stream, TestCredentials.TestAdmin, null);
+			await _fixture.ReadMeta(stream, userCredentials: TestCredentials.TestAdmin);
+			await _fixture.WriteMeta(stream, userCredentials: TestCredentials.TestAdmin, null);
 
-			await _fixture.SubscribeToStream(stream, TestCredentials.TestAdmin);
+			await _fixture.SubscribeToStream(stream, userCredentials: TestCredentials.TestAdmin);
 
-			await _fixture.DeleteStream(stream, TestCredentials.TestAdmin);
+			await _fixture.DeleteStream(stream, userCredentials: TestCredentials.TestAdmin);
 		}
 	}
 }

--- a/test/EventStore.Client.Streams.Tests/Security/overriden_user_stream_security.cs
+++ b/test/EventStore.Client.Streams.Tests/Security/overriden_user_stream_security.cs
@@ -14,25 +14,25 @@ namespace EventStore.Client.Security
 			protected override Task When() {
 				var settings = new SystemSettings(
 					new StreamAcl("user1", "user1", "user1", "user1", "user1"));
-				return Client.SetSystemSettingsAsync(settings, TestCredentials.TestAdmin);
+				return Client.SetSystemSettingsAsync(settings, userCredentials: TestCredentials.TestAdmin);
 			}
 		}
 
 		[Fact]
 		public async Task operations_on_user_stream_succeeds_for_authorized_user() {
 			var stream = _fixture.GetStreamName();
-			await _fixture.AppendStream(stream, TestCredentials.TestUser1);
+			await _fixture.AppendStream(stream, userCredentials: TestCredentials.TestUser1);
 
-			await _fixture.ReadEvent(stream, TestCredentials.TestUser1);
-			await _fixture.ReadStreamForward(stream, TestCredentials.TestUser1);
-			await _fixture.ReadStreamBackward(stream, TestCredentials.TestUser1);
+			await _fixture.ReadEvent(stream, userCredentials: TestCredentials.TestUser1);
+			await _fixture.ReadStreamForward(stream, userCredentials: TestCredentials.TestUser1);
+			await _fixture.ReadStreamBackward(stream, userCredentials: TestCredentials.TestUser1);
 
-			await _fixture.ReadMeta(stream, TestCredentials.TestUser1);
-			await _fixture.WriteMeta(stream, TestCredentials.TestUser1, null);
+			await _fixture.ReadMeta(stream, userCredentials: TestCredentials.TestUser1);
+			await _fixture.WriteMeta(stream, userCredentials: TestCredentials.TestUser1, null);
 
-			await _fixture.SubscribeToStream(stream, TestCredentials.TestUser1);
+			await _fixture.SubscribeToStream(stream, userCredentials: TestCredentials.TestUser1);
 
-			await _fixture.DeleteStream(stream, TestCredentials.TestUser1);
+			await _fixture.DeleteStream(stream, userCredentials: TestCredentials.TestUser1);
 		}
 
 		[Fact]
@@ -70,18 +70,18 @@ namespace EventStore.Client.Security
 		[Fact]
 		public async Task operations_on_user_stream_succeed_for_admin() {
 			var stream = _fixture.GetStreamName();
-			await _fixture.AppendStream(stream, TestCredentials.TestAdmin);
+			await _fixture.AppendStream(stream, userCredentials: TestCredentials.TestAdmin);
 
-			await _fixture.ReadEvent(stream, TestCredentials.TestAdmin);
-			await _fixture.ReadStreamForward(stream, TestCredentials.TestAdmin);
-			await _fixture.ReadStreamBackward(stream, TestCredentials.TestAdmin);
+			await _fixture.ReadEvent(stream, userCredentials: TestCredentials.TestAdmin);
+			await _fixture.ReadStreamForward(stream, userCredentials: TestCredentials.TestAdmin);
+			await _fixture.ReadStreamBackward(stream, userCredentials: TestCredentials.TestAdmin);
 
-			await _fixture.ReadMeta(stream, TestCredentials.TestAdmin);
-			await _fixture.WriteMeta(stream, TestCredentials.TestAdmin, null);
+			await _fixture.ReadMeta(stream, userCredentials: TestCredentials.TestAdmin);
+			await _fixture.WriteMeta(stream, userCredentials: TestCredentials.TestAdmin, null);
 
-			await _fixture.SubscribeToStream(stream, TestCredentials.TestAdmin);
+			await _fixture.SubscribeToStream(stream, userCredentials: TestCredentials.TestAdmin);
 
-			await _fixture.DeleteStream(stream, TestCredentials.TestAdmin);
+			await _fixture.DeleteStream(stream, userCredentials: TestCredentials.TestAdmin);
 		}
 	}
 }

--- a/test/EventStore.Client.Streams.Tests/Security/read_stream_meta_security.cs
+++ b/test/EventStore.Client.Streams.Tests/Security/read_stream_meta_security.cs
@@ -32,12 +32,12 @@ namespace EventStore.Client.Security {
 
 		[Fact]
 		public async Task reading_stream_meta_with_authorized_user_credentials_succeeds() {
-			await _fixture.ReadMeta(SecurityFixture.MetaReadStream, TestCredentials.TestUser1);
+			await _fixture.ReadMeta(SecurityFixture.MetaReadStream, userCredentials: TestCredentials.TestUser1);
 		}
 
 		[Fact]
 		public async Task reading_stream_meta_with_admin_user_credentials_succeeds() {
-			await _fixture.ReadMeta(SecurityFixture.MetaReadStream, TestCredentials.TestAdmin);
+			await _fixture.ReadMeta(SecurityFixture.MetaReadStream, userCredentials: TestCredentials.TestAdmin);
 		}
 
 
@@ -54,13 +54,13 @@ namespace EventStore.Client.Security {
 
 		[Fact]
 		public async Task reading_no_acl_stream_meta_succeeds_when_any_existing_user_credentials_are_passed() {
-			await _fixture.ReadMeta(SecurityFixture.NoAclStream, TestCredentials.TestUser1);
+			await _fixture.ReadMeta(SecurityFixture.NoAclStream, userCredentials: TestCredentials.TestUser1);
 			await _fixture.ReadMeta(SecurityFixture.NoAclStream, TestCredentials.TestUser2);
 		}
 
 		[Fact]
 		public async Task reading_no_acl_stream_meta_succeeds_when_admin_user_credentials_are_passed() {
-			await _fixture.ReadMeta(SecurityFixture.NoAclStream, TestCredentials.TestAdmin);
+			await _fixture.ReadMeta(SecurityFixture.NoAclStream, userCredentials: TestCredentials.TestAdmin);
 		}
 
 
@@ -79,13 +79,13 @@ namespace EventStore.Client.Security {
 		[Fact]
 		public async Task
 			reading_all_access_normal_stream_meta_succeeds_when_any_existing_user_credentials_are_passed() {
-			await _fixture.ReadMeta(SecurityFixture.NormalAllStream, TestCredentials.TestUser1);
+			await _fixture.ReadMeta(SecurityFixture.NormalAllStream, userCredentials: TestCredentials.TestUser1);
 			await _fixture.ReadMeta(SecurityFixture.NormalAllStream, TestCredentials.TestUser2);
 		}
 
 		[Fact]
 		public async Task reading_all_access_normal_stream_meta_succeeds_when_admin_user_credentials_are_passed() {
-			await _fixture.ReadMeta(SecurityFixture.NormalAllStream, TestCredentials.TestAdmin);
+			await _fixture.ReadMeta(SecurityFixture.NormalAllStream, userCredentials: TestCredentials.TestAdmin);
 		}
 	}
 }

--- a/test/EventStore.Client.Streams.Tests/Security/read_stream_security.cs
+++ b/test/EventStore.Client.Streams.Tests/Security/read_stream_security.cs
@@ -44,20 +44,20 @@ namespace EventStore.Client.Security {
 
 		[Fact]
 		public async Task reading_stream_with_authorized_user_credentials_succeeds() {
-			await _fixture.AppendStream(SecurityFixture.ReadStream, TestCredentials.TestUser1);
+			await _fixture.AppendStream(SecurityFixture.ReadStream, userCredentials: TestCredentials.TestUser1);
 
-			await _fixture.ReadEvent(SecurityFixture.ReadStream, TestCredentials.TestUser1);
-			await _fixture.ReadStreamForward(SecurityFixture.ReadStream, TestCredentials.TestUser1);
-			await _fixture.ReadStreamBackward(SecurityFixture.ReadStream, TestCredentials.TestUser1);
+			await _fixture.ReadEvent(SecurityFixture.ReadStream, userCredentials: TestCredentials.TestUser1);
+			await _fixture.ReadStreamForward(SecurityFixture.ReadStream, userCredentials: TestCredentials.TestUser1);
+			await _fixture.ReadStreamBackward(SecurityFixture.ReadStream, userCredentials: TestCredentials.TestUser1);
 		}
 
 		[Fact]
 		public async Task reading_stream_with_admin_user_credentials_succeeds() {
-			await _fixture.AppendStream(SecurityFixture.ReadStream, TestCredentials.TestAdmin);
+			await _fixture.AppendStream(SecurityFixture.ReadStream, userCredentials: TestCredentials.TestAdmin);
 
-			await _fixture.ReadEvent(SecurityFixture.ReadStream, TestCredentials.TestAdmin);
-			await _fixture.ReadStreamForward(SecurityFixture.ReadStream, TestCredentials.TestAdmin);
-			await _fixture.ReadStreamBackward(SecurityFixture.ReadStream, TestCredentials.TestAdmin);
+			await _fixture.ReadEvent(SecurityFixture.ReadStream, userCredentials: TestCredentials.TestAdmin);
+			await _fixture.ReadStreamForward(SecurityFixture.ReadStream, userCredentials: TestCredentials.TestAdmin);
+			await _fixture.ReadStreamBackward(SecurityFixture.ReadStream, userCredentials: TestCredentials.TestAdmin);
 		}
 
 
@@ -82,11 +82,11 @@ namespace EventStore.Client.Security {
 
 		[Fact]
 		public async Task reading_no_acl_stream_succeeds_when_any_existing_user_credentials_are_passed() {
-			await _fixture.AppendStream(SecurityFixture.NoAclStream, TestCredentials.TestUser1);
+			await _fixture.AppendStream(SecurityFixture.NoAclStream, userCredentials: TestCredentials.TestUser1);
 
-			await _fixture.ReadEvent(SecurityFixture.NoAclStream, TestCredentials.TestUser1);
-			await _fixture.ReadStreamForward(SecurityFixture.NoAclStream, TestCredentials.TestUser1);
-			await _fixture.ReadStreamBackward(SecurityFixture.NoAclStream, TestCredentials.TestUser1);
+			await _fixture.ReadEvent(SecurityFixture.NoAclStream, userCredentials: TestCredentials.TestUser1);
+			await _fixture.ReadStreamForward(SecurityFixture.NoAclStream, userCredentials: TestCredentials.TestUser1);
+			await _fixture.ReadStreamBackward(SecurityFixture.NoAclStream, userCredentials: TestCredentials.TestUser1);
 			await _fixture.ReadEvent(SecurityFixture.NoAclStream, TestCredentials.TestUser2);
 			await _fixture.ReadStreamForward(SecurityFixture.NoAclStream, TestCredentials.TestUser2);
 			await _fixture.ReadStreamBackward(SecurityFixture.NoAclStream, TestCredentials.TestUser2);
@@ -94,10 +94,10 @@ namespace EventStore.Client.Security {
 
 		[Fact]
 		public async Task reading_no_acl_stream_succeeds_when_admin_user_credentials_are_passed() {
-			await _fixture.AppendStream(SecurityFixture.NoAclStream, TestCredentials.TestAdmin);
-			await _fixture.ReadEvent(SecurityFixture.NoAclStream, TestCredentials.TestAdmin);
-			await _fixture.ReadStreamForward(SecurityFixture.NoAclStream, TestCredentials.TestAdmin);
-			await _fixture.ReadStreamBackward(SecurityFixture.NoAclStream, TestCredentials.TestAdmin);
+			await _fixture.AppendStream(SecurityFixture.NoAclStream, userCredentials: TestCredentials.TestAdmin);
+			await _fixture.ReadEvent(SecurityFixture.NoAclStream, userCredentials: TestCredentials.TestAdmin);
+			await _fixture.ReadStreamForward(SecurityFixture.NoAclStream, userCredentials: TestCredentials.TestAdmin);
+			await _fixture.ReadStreamBackward(SecurityFixture.NoAclStream, userCredentials: TestCredentials.TestAdmin);
 		}
 
 
@@ -122,10 +122,10 @@ namespace EventStore.Client.Security {
 
 		[Fact]
 		public async Task reading_all_access_normal_stream_succeeds_when_any_existing_user_credentials_are_passed() {
-			await _fixture.AppendStream(SecurityFixture.NormalAllStream, TestCredentials.TestUser1);
-			await _fixture.ReadEvent(SecurityFixture.NormalAllStream, TestCredentials.TestUser1);
-			await _fixture.ReadStreamForward(SecurityFixture.NormalAllStream, TestCredentials.TestUser1);
-			await _fixture.ReadStreamBackward(SecurityFixture.NormalAllStream, TestCredentials.TestUser1);
+			await _fixture.AppendStream(SecurityFixture.NormalAllStream, userCredentials: TestCredentials.TestUser1);
+			await _fixture.ReadEvent(SecurityFixture.NormalAllStream, userCredentials: TestCredentials.TestUser1);
+			await _fixture.ReadStreamForward(SecurityFixture.NormalAllStream, userCredentials: TestCredentials.TestUser1);
+			await _fixture.ReadStreamBackward(SecurityFixture.NormalAllStream, userCredentials: TestCredentials.TestUser1);
 			await _fixture.ReadEvent(SecurityFixture.NormalAllStream, TestCredentials.TestUser2);
 			await _fixture.ReadStreamForward(SecurityFixture.NormalAllStream, TestCredentials.TestUser2);
 			await _fixture.ReadStreamBackward(SecurityFixture.NormalAllStream, TestCredentials.TestUser2);
@@ -133,10 +133,10 @@ namespace EventStore.Client.Security {
 
 		[Fact]
 		public async Task reading_all_access_normal_stream_succeeds_when_admin_user_credentials_are_passed() {
-			await _fixture.AppendStream(SecurityFixture.NormalAllStream, TestCredentials.TestAdmin);
-			await _fixture.ReadEvent(SecurityFixture.NormalAllStream, TestCredentials.TestAdmin);
-			await _fixture.ReadStreamForward(SecurityFixture.NormalAllStream, TestCredentials.TestAdmin);
-			await _fixture.ReadStreamBackward(SecurityFixture.NormalAllStream, TestCredentials.TestAdmin);
+			await _fixture.AppendStream(SecurityFixture.NormalAllStream, userCredentials: TestCredentials.TestAdmin);
+			await _fixture.ReadEvent(SecurityFixture.NormalAllStream, userCredentials: TestCredentials.TestAdmin);
+			await _fixture.ReadStreamForward(SecurityFixture.NormalAllStream, userCredentials: TestCredentials.TestAdmin);
+			await _fixture.ReadStreamBackward(SecurityFixture.NormalAllStream, userCredentials: TestCredentials.TestAdmin);
 		}
 	}
 }

--- a/test/EventStore.Client.Streams.Tests/Security/stream_security_inheritance.cs
+++ b/test/EventStore.Client.Streams.Tests/Security/stream_security_inheritance.cs
@@ -13,7 +13,7 @@ namespace EventStore.Client.Security {
 			protected override async Task When() {
 				var settings = new SystemSettings(userStreamAcl: new StreamAcl(writeRole: "user1"),
 					systemStreamAcl: new StreamAcl(writeRole: "user1"));
-				await Client.SetSystemSettingsAsync(settings, TestCredentials.TestAdmin);
+				await Client.SetSystemSettingsAsync(settings, userCredentials: TestCredentials.TestAdmin);
 
 				await Client.SetStreamMetadataAsync("user-no-acl", StreamState.NoStream,
 					new StreamMetadata(), userCredentials: TestCredentials.TestAdmin);
@@ -55,87 +55,87 @@ namespace EventStore.Client.Security {
 		[Fact]
 		public async Task acl_inheritance_is_working_properly_on_user_streams() {
 			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.AppendStream("user-no-acl"));
-			await _fixture.AppendStream("user-no-acl", TestCredentials.TestUser1);
+			await _fixture.AppendStream("user-no-acl", userCredentials: TestCredentials.TestUser1);
 			await Assert.ThrowsAsync<AccessDeniedException>(() =>
 				_fixture.AppendStream("user-no-acl", TestCredentials.TestUser2));
-			await _fixture.AppendStream("user-no-acl", TestCredentials.TestAdmin);
+			await _fixture.AppendStream("user-no-acl", userCredentials: TestCredentials.TestAdmin);
 
 			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.AppendStream("user-w-diff"));
 			await Assert.ThrowsAsync<AccessDeniedException>(() =>
-				_fixture.AppendStream("user-w-diff", TestCredentials.TestUser1));
+				_fixture.AppendStream("user-w-diff", userCredentials: TestCredentials.TestUser1));
 			await _fixture.AppendStream("user-w-diff", TestCredentials.TestUser2);
-			await _fixture.AppendStream("user-w-diff", TestCredentials.TestAdmin);
+			await _fixture.AppendStream("user-w-diff", userCredentials: TestCredentials.TestAdmin);
 
 			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.AppendStream("user-w-multiple"));
-			await _fixture.AppendStream("user-w-multiple", TestCredentials.TestUser1);
+			await _fixture.AppendStream("user-w-multiple", userCredentials: TestCredentials.TestUser1);
 			await _fixture.AppendStream("user-w-multiple", TestCredentials.TestUser2);
-			await _fixture.AppendStream("user-w-multiple", TestCredentials.TestAdmin);
+			await _fixture.AppendStream("user-w-multiple", userCredentials: TestCredentials.TestAdmin);
 
 			await Assert.ThrowsAsync<AccessDeniedException>(() =>
 				_fixture.AppendStream("user-w-restricted"));
 			await Assert.ThrowsAsync<AccessDeniedException>(() =>
-				_fixture.AppendStream("user-w-restricted", TestCredentials.TestUser1));
+				_fixture.AppendStream("user-w-restricted", userCredentials: TestCredentials.TestUser1));
 			await Assert.ThrowsAsync<AccessDeniedException>(() =>
 				_fixture.AppendStream("user-w-restricted", TestCredentials.TestUser2));
-			await _fixture.AppendStream("user-w-restricted", TestCredentials.TestAdmin);
+			await _fixture.AppendStream("user-w-restricted", userCredentials: TestCredentials.TestAdmin);
 
 			await _fixture.AppendStream("user-w-all");
-			await _fixture.AppendStream("user-w-all", TestCredentials.TestUser1);
+			await _fixture.AppendStream("user-w-all", userCredentials: TestCredentials.TestUser1);
 			await _fixture.AppendStream("user-w-all", TestCredentials.TestUser2);
-			await _fixture.AppendStream("user-w-all", TestCredentials.TestAdmin);
+			await _fixture.AppendStream("user-w-all", userCredentials: TestCredentials.TestAdmin);
 
 
 			await _fixture.ReadEvent("user-no-acl");
-			await _fixture.ReadEvent("user-no-acl", TestCredentials.TestUser1);
+			await _fixture.ReadEvent("user-no-acl", userCredentials: TestCredentials.TestUser1);
 			await _fixture.ReadEvent("user-no-acl", TestCredentials.TestUser2);
-			await _fixture.ReadEvent("user-no-acl", TestCredentials.TestAdmin);
+			await _fixture.ReadEvent("user-no-acl", userCredentials: TestCredentials.TestAdmin);
 
 			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.ReadEvent("user-r-restricted"));
-			await _fixture.AppendStream("user-r-restricted", TestCredentials.TestUser1);
-			await _fixture.ReadEvent("user-r-restricted", TestCredentials.TestUser1);
+			await _fixture.AppendStream("user-r-restricted", userCredentials: TestCredentials.TestUser1);
+			await _fixture.ReadEvent("user-r-restricted", userCredentials: TestCredentials.TestUser1);
 			await Assert.ThrowsAsync<AccessDeniedException>(() =>
 				_fixture.ReadEvent("user-r-restricted", TestCredentials.TestUser2));
-			await _fixture.ReadEvent("user-r-restricted", TestCredentials.TestAdmin);
+			await _fixture.ReadEvent("user-r-restricted", userCredentials: TestCredentials.TestAdmin);
 		}
 
 		[Fact]
 		public async Task acl_inheritance_is_working_properly_on_system_streams() {
 			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.AppendStream("$sys-no-acl"));
-			await _fixture.AppendStream("$sys-no-acl", TestCredentials.TestUser1);
+			await _fixture.AppendStream("$sys-no-acl", userCredentials: TestCredentials.TestUser1);
 			await Assert.ThrowsAsync<AccessDeniedException>(() =>
 				_fixture.AppendStream("$sys-no-acl", TestCredentials.TestUser2));
-			await _fixture.AppendStream("$sys-no-acl", TestCredentials.TestAdmin);
+			await _fixture.AppendStream("$sys-no-acl", userCredentials: TestCredentials.TestAdmin);
 
 			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.AppendStream("$sys-w-diff"));
 			await Assert.ThrowsAsync<AccessDeniedException>(() =>
-				_fixture.AppendStream("$sys-w-diff", TestCredentials.TestUser1));
+				_fixture.AppendStream("$sys-w-diff", userCredentials: TestCredentials.TestUser1));
 			await _fixture.AppendStream("$sys-w-diff", TestCredentials.TestUser2);
-			await _fixture.AppendStream("$sys-w-diff", TestCredentials.TestAdmin);
+			await _fixture.AppendStream("$sys-w-diff", userCredentials: TestCredentials.TestAdmin);
 
 			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.AppendStream("$sys-w-multiple"));
-			await _fixture.AppendStream("$sys-w-multiple", TestCredentials.TestUser1);
+			await _fixture.AppendStream("$sys-w-multiple", userCredentials: TestCredentials.TestUser1);
 			await _fixture.AppendStream("$sys-w-multiple", TestCredentials.TestUser2);
-			await _fixture.AppendStream("$sys-w-multiple", TestCredentials.TestAdmin);
+			await _fixture.AppendStream("$sys-w-multiple", userCredentials: TestCredentials.TestAdmin);
 
 			await Assert.ThrowsAsync<AccessDeniedException>(() =>
 				_fixture.AppendStream("$sys-w-restricted"));
 			await Assert.ThrowsAsync<AccessDeniedException>(() =>
-				_fixture.AppendStream("$sys-w-restricted", TestCredentials.TestUser1));
+				_fixture.AppendStream("$sys-w-restricted", userCredentials: TestCredentials.TestUser1));
 			await Assert.ThrowsAsync<AccessDeniedException>(() =>
 				_fixture.AppendStream("$sys-w-restricted", TestCredentials.TestUser2));
-			await _fixture.AppendStream("$sys-w-restricted", TestCredentials.TestAdmin);
+			await _fixture.AppendStream("$sys-w-restricted", userCredentials: TestCredentials.TestAdmin);
 
 			await _fixture.AppendStream("$sys-w-all");
-			await _fixture.AppendStream("$sys-w-all", TestCredentials.TestUser1);
+			await _fixture.AppendStream("$sys-w-all", userCredentials: TestCredentials.TestUser1);
 			await _fixture.AppendStream("$sys-w-all", TestCredentials.TestUser2);
-			await _fixture.AppendStream("$sys-w-all", TestCredentials.TestAdmin);
+			await _fixture.AppendStream("$sys-w-all", userCredentials: TestCredentials.TestAdmin);
 
 			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.ReadEvent("$sys-no-acl"));
 			await Assert.ThrowsAsync<AccessDeniedException>(() =>
-				_fixture.ReadEvent("$sys-no-acl", TestCredentials.TestUser1));
+				_fixture.ReadEvent("$sys-no-acl", userCredentials: TestCredentials.TestUser1));
 			await Assert.ThrowsAsync<AccessDeniedException>(() =>
 				_fixture.ReadEvent("$sys-no-acl", TestCredentials.TestUser2));
-			await _fixture.ReadEvent("$sys-no-acl", TestCredentials.TestAdmin);
+			await _fixture.ReadEvent("$sys-no-acl", userCredentials: TestCredentials.TestAdmin);
 		}
 	}
 }

--- a/test/EventStore.Client.Streams.Tests/Security/subscribe_to_stream_security.cs
+++ b/test/EventStore.Client.Streams.Tests/Security/subscribe_to_stream_security.cs
@@ -33,14 +33,14 @@ namespace EventStore.Client.Security {
 
 		[Fact]
 		public async Task reading_stream_with_authorized_user_credentials_succeeds() {
-			await _fixture.AppendStream(SecurityFixture.ReadStream, TestCredentials.TestUser1);
-			await _fixture.SubscribeToStream(SecurityFixture.ReadStream, TestCredentials.TestUser1);
+			await _fixture.AppendStream(SecurityFixture.ReadStream, userCredentials: TestCredentials.TestUser1);
+			await _fixture.SubscribeToStream(SecurityFixture.ReadStream, userCredentials: TestCredentials.TestUser1);
 		}
 
 		[Fact]
 		public async Task reading_stream_with_admin_user_credentials_succeeds() {
-			await _fixture.AppendStream(SecurityFixture.ReadStream, TestCredentials.TestAdmin);
-			await _fixture.SubscribeToStream(SecurityFixture.ReadStream, TestCredentials.TestAdmin);
+			await _fixture.AppendStream(SecurityFixture.ReadStream, userCredentials: TestCredentials.TestAdmin);
+			await _fixture.SubscribeToStream(SecurityFixture.ReadStream, userCredentials: TestCredentials.TestAdmin);
 		}
 
 		[Fact]
@@ -57,15 +57,15 @@ namespace EventStore.Client.Security {
 
 		[Fact]
 		public async Task subscribing_to_no_acl_stream_succeeds_when_any_existing_user_credentials_are_passed() {
-			await _fixture.AppendStream(SecurityFixture.NoAclStream, TestCredentials.TestUser1);
-			await _fixture.SubscribeToStream(SecurityFixture.NoAclStream, TestCredentials.TestUser1);
+			await _fixture.AppendStream(SecurityFixture.NoAclStream, userCredentials: TestCredentials.TestUser1);
+			await _fixture.SubscribeToStream(SecurityFixture.NoAclStream, userCredentials: TestCredentials.TestUser1);
 			await _fixture.SubscribeToStream(SecurityFixture.NoAclStream, TestCredentials.TestUser2);
 		}
 
 		[Fact]
 		public async Task subscribing_to_no_acl_stream_succeeds_when_admin_user_credentials_are_passed() {
-			await _fixture.AppendStream(SecurityFixture.NoAclStream, TestCredentials.TestAdmin);
-			await _fixture.SubscribeToStream(SecurityFixture.NoAclStream, TestCredentials.TestAdmin);
+			await _fixture.AppendStream(SecurityFixture.NoAclStream, userCredentials: TestCredentials.TestAdmin);
+			await _fixture.SubscribeToStream(SecurityFixture.NoAclStream, userCredentials: TestCredentials.TestAdmin);
 		}
 
 
@@ -85,15 +85,15 @@ namespace EventStore.Client.Security {
 		[Fact]
 		public async Task
 			subscribing_to_all_access_normal_stream_succeeds_when_any_existing_user_credentials_are_passed() {
-			await _fixture.AppendStream(SecurityFixture.NormalAllStream, TestCredentials.TestUser1);
-			await _fixture.SubscribeToStream(SecurityFixture.NormalAllStream, TestCredentials.TestUser1);
+			await _fixture.AppendStream(SecurityFixture.NormalAllStream, userCredentials: TestCredentials.TestUser1);
+			await _fixture.SubscribeToStream(SecurityFixture.NormalAllStream, userCredentials: TestCredentials.TestUser1);
 			await _fixture.SubscribeToStream(SecurityFixture.NormalAllStream, TestCredentials.TestUser2);
 		}
 
 		[Fact]
 		public async Task subscribing_to_all_access_normal_streamm_succeeds_when_admin_user_credentials_are_passed() {
-			await _fixture.AppendStream(SecurityFixture.NormalAllStream, TestCredentials.TestAdmin);
-			await _fixture.SubscribeToStream(SecurityFixture.NormalAllStream, TestCredentials.TestAdmin);
+			await _fixture.AppendStream(SecurityFixture.NormalAllStream, userCredentials: TestCredentials.TestAdmin);
+			await _fixture.SubscribeToStream(SecurityFixture.NormalAllStream, userCredentials: TestCredentials.TestAdmin);
 		}
 	}
 }

--- a/test/EventStore.Client.Streams.Tests/Security/write_stream_meta_security.cs
+++ b/test/EventStore.Client.Streams.Tests/Security/write_stream_meta_security.cs
@@ -16,7 +16,8 @@ namespace EventStore.Client.Security {
 		[Fact]
 		public async Task writing_meta_with_not_existing_credentials_is_not_authenticated() {
 			await Assert.ThrowsAsync<NotAuthenticatedException>(() =>
-				_fixture.WriteMeta(SecurityFixture.MetaWriteStream, TestCredentials.TestBadUser, TestCredentials.TestUser1.Username));
+				_fixture.WriteMeta(SecurityFixture.MetaWriteStream, TestCredentials.TestBadUser,
+					TestCredentials.TestUser1.Username));
 		}
 
 		[Fact]
@@ -28,17 +29,20 @@ namespace EventStore.Client.Security {
 		[Fact]
 		public async Task writing_meta_to_stream_with_not_authorized_user_credentials_is_denied() {
 			await Assert.ThrowsAsync<AccessDeniedException>(() =>
-				_fixture.WriteMeta(SecurityFixture.MetaWriteStream, TestCredentials.TestUser2, TestCredentials.TestUser1.Username));
+				_fixture.WriteMeta(SecurityFixture.MetaWriteStream, TestCredentials.TestUser2,
+					TestCredentials.TestUser1.Username));
 		}
 
 		[Fact]
 		public async Task writing_meta_to_stream_with_authorized_user_credentials_succeeds() {
-			await _fixture.WriteMeta(SecurityFixture.MetaWriteStream, TestCredentials.TestUser1, TestCredentials.TestUser1.Username);
+			await _fixture.WriteMeta(SecurityFixture.MetaWriteStream, TestCredentials.TestUser1,
+				TestCredentials.TestUser1.Username);
 		}
 
 		[Fact]
 		public async Task writing_meta_to_stream_with_admin_user_credentials_succeeds() {
-			await _fixture.WriteMeta(SecurityFixture.MetaWriteStream, TestCredentials.TestAdmin, TestCredentials.TestUser1.Username);
+			await _fixture.WriteMeta(SecurityFixture.MetaWriteStream, TestCredentials.TestAdmin,
+				TestCredentials.TestUser1.Username);
 		}
 
 

--- a/test/EventStore.Client.Streams.Tests/Security/write_stream_security.cs
+++ b/test/EventStore.Client.Streams.Tests/Security/write_stream_security.cs
@@ -19,9 +19,9 @@ namespace EventStore.Client.Security {
 		public async Task writing_to_all_is_never_allowed() {
 			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.AppendStream(SecurityFixture.AllStream));
 			await Assert.ThrowsAsync<AccessDeniedException>(() =>
-				_fixture.AppendStream(SecurityFixture.AllStream, TestCredentials.TestUser1));
+				_fixture.AppendStream(SecurityFixture.AllStream, userCredentials: TestCredentials.TestUser1));
 			await Assert.ThrowsAsync<AccessDeniedException>(() =>
-				_fixture.AppendStream(SecurityFixture.AllStream, TestCredentials.TestAdmin));
+				_fixture.AppendStream(SecurityFixture.AllStream, userCredentials: TestCredentials.TestAdmin));
 		}
 
 		[Fact]
@@ -43,12 +43,12 @@ namespace EventStore.Client.Security {
 
 		[Fact]
 		public async Task writing_to_stream_with_authorized_user_credentials_succeeds() {
-			await _fixture.AppendStream(SecurityFixture.WriteStream, TestCredentials.TestUser1);
+			await _fixture.AppendStream(SecurityFixture.WriteStream, userCredentials: TestCredentials.TestUser1);
 		}
 
 		[Fact]
 		public async Task writing_to_stream_with_admin_user_credentials_succeeds() {
-			await _fixture.AppendStream(SecurityFixture.WriteStream, TestCredentials.TestAdmin);
+			await _fixture.AppendStream(SecurityFixture.WriteStream, userCredentials: TestCredentials.TestAdmin);
 		}
 
 
@@ -65,13 +65,13 @@ namespace EventStore.Client.Security {
 
 		[Fact]
 		public async Task writing_to_no_acl_stream_succeeds_when_any_existing_user_credentials_are_passed() {
-			await _fixture.AppendStream(SecurityFixture.NoAclStream, TestCredentials.TestUser1);
+			await _fixture.AppendStream(SecurityFixture.NoAclStream, userCredentials: TestCredentials.TestUser1);
 			await _fixture.AppendStream(SecurityFixture.NoAclStream, TestCredentials.TestUser2);
 		}
 
 		[Fact]
 		public async Task writing_to_no_acl_stream_succeeds_when_any_admin_user_credentials_are_passed() {
-			await _fixture.AppendStream(SecurityFixture.NoAclStream, TestCredentials.TestAdmin);
+			await _fixture.AppendStream(SecurityFixture.NoAclStream, userCredentials: TestCredentials.TestAdmin);
 		}
 
 
@@ -89,13 +89,13 @@ namespace EventStore.Client.Security {
 
 		[Fact]
 		public async Task writing_to_all_access_normal_stream_succeeds_when_any_existing_user_credentials_are_passed() {
-			await _fixture.AppendStream(SecurityFixture.NormalAllStream, TestCredentials.TestUser1);
+			await _fixture.AppendStream(SecurityFixture.NormalAllStream, userCredentials: TestCredentials.TestUser1);
 			await _fixture.AppendStream(SecurityFixture.NormalAllStream, TestCredentials.TestUser2);
 		}
 
 		[Fact]
 		public async Task writing_to_all_access_normal_stream_succeeds_when_any_admin_user_credentials_are_passed() {
-			await _fixture.AppendStream(SecurityFixture.NormalAllStream, TestCredentials.TestAdmin);
+			await _fixture.AppendStream(SecurityFixture.NormalAllStream, userCredentials: TestCredentials.TestAdmin);
 		}
 	}
 }

--- a/test/EventStore.Client.Streams.Tests/delete_stream_with_timeout.cs
+++ b/test/EventStore.Client.Streams.Tests/delete_stream_with_timeout.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Grpc.Core;
 using Xunit;
@@ -17,8 +16,7 @@ namespace EventStore.Client {
 		public async Task any_stream_revision_delete_fails_when_operation_expired() {
 			var stream = _fixture.GetStreamName();
 			var rpcException = await Assert.ThrowsAsync<RpcException>(() =>
-				_fixture.Client.DeleteAsync(stream, StreamState.Any,
-					options => options.TimeoutAfter = TimeSpan.Zero));
+				_fixture.Client.DeleteAsync(stream, StreamState.Any, TimeSpan.Zero));
 
 			Assert.Equal(StatusCode.DeadlineExceeded, rpcException.StatusCode);
 		}
@@ -28,8 +26,7 @@ namespace EventStore.Client {
 			var stream = _fixture.GetStreamName();
 
 			var rpcException = await Assert.ThrowsAsync<RpcException>(() =>
-				_fixture.Client.DeleteAsync(stream, new StreamRevision(0),
-					options => options.TimeoutAfter = TimeSpan.Zero));
+				_fixture.Client.DeleteAsync(stream, new StreamRevision(0), TimeSpan.Zero));
 
 			Assert.Equal(StatusCode.DeadlineExceeded, rpcException.StatusCode);
 		}
@@ -38,8 +35,7 @@ namespace EventStore.Client {
 		public async Task any_stream_revision_tombstoning_fails_when_operation_expired() {
 			var stream = _fixture.GetStreamName();
 			var rpcException = await Assert.ThrowsAsync<RpcException>(() =>
-				_fixture.Client.TombstoneAsync(stream, StreamState.Any,
-					options => options.TimeoutAfter = TimeSpan.Zero));
+				_fixture.Client.TombstoneAsync(stream, StreamState.Any, TimeSpan.Zero));
 
 			Assert.Equal(StatusCode.DeadlineExceeded, rpcException.StatusCode);
 		}
@@ -49,8 +45,7 @@ namespace EventStore.Client {
 			var stream = _fixture.GetStreamName();
 
 			var rpcException = await Assert.ThrowsAsync<RpcException>(() =>
-				_fixture.Client.TombstoneAsync(stream, new StreamRevision(0),
-					options => options.TimeoutAfter = TimeSpan.Zero));
+				_fixture.Client.TombstoneAsync(stream, new StreamRevision(0), TimeSpan.Zero));
 
 			Assert.Equal(StatusCode.DeadlineExceeded, rpcException.StatusCode);
 		}

--- a/test/EventStore.Client.Streams.Tests/read_all_with_timeout.cs
+++ b/test/EventStore.Client.Streams.Tests/read_all_with_timeout.cs
@@ -16,8 +16,8 @@ namespace EventStore.Client {
 		[Fact]
 		public async Task fails_when_operation_expired() {
 			var rpcException = await Assert.ThrowsAsync<RpcException>(() => _fixture.Client
-				.ReadAllAsync(Direction.Backwards, Position.Start, 1,
-					options => options.TimeoutAfter = TimeSpan.Zero)
+				.ReadAllAsync(Direction.Backwards, Position.Start,
+					maxCount: 1, resolveLinkTos: false, deadline: TimeSpan.Zero)
 				.ToArrayAsync().AsTask());
 
 			Assert.Equal(StatusCode.DeadlineExceeded, rpcException.StatusCode);

--- a/test/EventStore.Client.Streams.Tests/read_stream_with_timeout.cs
+++ b/test/EventStore.Client.Streams.Tests/read_stream_with_timeout.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Grpc.Core;
 using Xunit;
@@ -18,9 +17,11 @@ namespace EventStore.Client {
 		public async Task fails_when_operation_expired() {
 			var stream = _fixture.GetStreamName();
 
+			await _fixture.Client.AppendToStreamAsync(stream, StreamRevision.None, _fixture.CreateTestEvents());
+
 			var rpcException = await Assert.ThrowsAsync<RpcException>(() => _fixture.Client
-				.ReadStreamAsync(Direction.Backwards, stream, StreamPosition.End, 1,
-					options => options.TimeoutAfter = TimeSpan.Zero)
+				.ReadStreamAsync(Direction.Backwards, stream, StreamPosition.End,
+					maxCount: 1, resolveLinkTos: false, deadline: TimeSpan.Zero)
 				.ToArrayAsync().AsTask());
 			
 			Assert.Equal(StatusCode.DeadlineExceeded, rpcException.StatusCode);

--- a/test/EventStore.Client.Streams.Tests/stream_metadata_with_timeout.cs
+++ b/test/EventStore.Client.Streams.Tests/stream_metadata_with_timeout.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Grpc.Core;
 using Xunit;
@@ -18,7 +17,7 @@ namespace EventStore.Client {
 			var stream = _fixture.GetStreamName();
 			var rpcException = await Assert.ThrowsAsync<RpcException>(() =>
 				_fixture.Client.SetStreamMetadataAsync(stream, StreamState.Any, new StreamMetadata(),
-					options => options.TimeoutAfter = TimeSpan.Zero));
+					deadline: TimeSpan.Zero));
 
 			Assert.Equal(StatusCode.DeadlineExceeded, rpcException.StatusCode);
 		}
@@ -29,7 +28,7 @@ namespace EventStore.Client {
 
 			var rpcException = await Assert.ThrowsAsync<RpcException>(() =>
 				_fixture.Client.SetStreamMetadataAsync(stream, new StreamRevision(0), new StreamMetadata(),
-					options => options.TimeoutAfter = TimeSpan.Zero));
+					deadline: TimeSpan.Zero));
 
 			Assert.Equal(StatusCode.DeadlineExceeded, rpcException.StatusCode);
 		}
@@ -38,10 +37,7 @@ namespace EventStore.Client {
 		public async Task get_fails_when_operation_expired() {
 			var stream = _fixture.GetStreamName();
 			var rpcException = await Assert.ThrowsAsync<RpcException>(() =>
-				_fixture.Client.GetStreamMetadataAsync(stream,
-					options => options.TimeoutAfter = TimeSpan.Zero));
-
-			Assert.Equal(StatusCode.DeadlineExceeded, rpcException.StatusCode);
+				_fixture.Client.GetStreamMetadataAsync(stream, TimeSpan.Zero));
 		}
 
 		public class Fixture : EventStoreClientFixture {

--- a/test/EventStore.Client.Tests.Common/EventStoreClientExtensions.cs
+++ b/test/EventStore.Client.Tests.Common/EventStoreClientExtensions.cs
@@ -20,19 +20,21 @@ namespace EventStore.Client {
 						StreamPosition.Start,
 						userCredentials: TestCredentials.Root,
 						cancellationToken: cancellationToken)
-					.ToArrayAsync();
+					.ToArrayAsync(cancellationToken);
 
 				if (users.Length == 0)
 					throw new Exception("no users yet");
 
 				// the read from leader above is not enough to guarantee the next write goes to leader
-				await self.AppendToStreamAsync($"warmup", StreamState.Any, Enumerable.Empty<EventData>());
+				await self.AppendToStreamAsync($"warmup", StreamState.Any, Enumerable.Empty<EventData>(),
+					cancellationToken: cancellationToken);
 			});
 		}
 
 		public static async Task WarmUpAsync(this EventStoreUserManagementClient self) {
 			await self.WarmUpWith(async cancellationToken => {
-				await self.ListAllAsync(TestCredentials.Root, cancellationToken).ToArrayAsync();
+				await self.ListAllAsync(userCredentials: TestCredentials.Root, cancellationToken: cancellationToken)
+					.ToArrayAsync(cancellationToken);
 			});
 		}
 

--- a/test/EventStore.Client.Tests.Common/EventStoreClientFixtureBase.cs
+++ b/test/EventStore.Client.Tests.Common/EventStoreClientFixtureBase.cs
@@ -61,7 +61,7 @@ namespace EventStore.Client {
 			var connectionString = GlobalEnvironment.UseCluster ? ConnectionStringCluster : ConnectionStringSingle;
 			Settings = clientSettings ?? EventStoreClientSettings.Create(connectionString);
 
-			Settings.OperationOptions.TimeoutAfter = Debugger.IsAttached
+			Settings.DefaultDeadline = Debugger.IsAttached
 				? new TimeSpan?()
 				: TimeSpan.FromSeconds(30);
 

--- a/test/EventStore.Client.Tests.Common/EventStoreTestServer.cs
+++ b/test/EventStore.Client.Tests.Common/EventStoreTestServer.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Ductus.FluentDocker.Builders;

--- a/test/EventStore.Client.Tests.Common/EventStoreUserManagementClientExtensions.cs
+++ b/test/EventStore.Client.Tests.Common/EventStoreUserManagementClientExtensions.cs
@@ -12,7 +12,8 @@ namespace EventStore.Client {
 			CancellationToken cancellationToken = default) =>
 			Policy.Handle<NotAuthenticatedException>()
 				.WaitAndRetryAsync(200, retryCount => TimeSpan.FromMilliseconds(100))
-				.ExecuteAsync(ct => client.CreateUserAsync(loginName, fullName, groups, password, userCredentials, ct),
-					cancellationToken);
+				.ExecuteAsync(
+					ct => client.CreateUserAsync(loginName, fullName, groups, password,
+						userCredentials: userCredentials, cancellationToken: ct), cancellationToken);
 	}
 }

--- a/test/EventStore.Client.Tests/Assertions/StringConversionAssertion.cs
+++ b/test/EventStore.Client.Tests/Assertions/StringConversionAssertion.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using AutoFixture.Idioms;
 using AutoFixture.Kernel;
 using Xunit;

--- a/test/EventStore.Client.Tests/EventStoreClientOperationOptionsTests.cs
+++ b/test/EventStore.Client.Tests/EventStoreClientOperationOptionsTests.cs
@@ -1,19 +1,16 @@
-﻿using System;
-using Xunit;
+﻿using Xunit;
 
 namespace EventStore.Client {
 	public class EventStoreClientOperationOptionsTests {
 		[Fact]
 		public void setting_options_on_clone_should_not_modify_original() {
-			EventStoreClientOperationOptions options = new EventStoreClientOperationOptions {
-				TimeoutAfter = TimeSpan.FromDays(5),
-			};
+			EventStoreClientOperationOptions options = EventStoreClientOperationOptions.Default;
 			
 			var clonedOptions = options.Clone();
-			clonedOptions.TimeoutAfter = TimeSpan.FromSeconds(1);
+			clonedOptions.BatchAppendSize = int.MaxValue;
 			
-			Assert.Equal(options.TimeoutAfter, TimeSpan.FromDays(5));
-			Assert.Equal(clonedOptions.TimeoutAfter, TimeSpan.FromSeconds(1));
+			Assert.Equal(options.BatchAppendSize, EventStoreClientOperationOptions.Default.BatchAppendSize);
+			Assert.Equal(clonedOptions.BatchAppendSize, int.MaxValue);
 		}
 	}
 }

--- a/test/EventStore.Client.Tests/PositionTests.cs
+++ b/test/EventStore.Client.Tests/PositionTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using AutoFixture;
 using Xunit;
 

--- a/test/EventStore.Client.Tests/StreamStateTests.cs
+++ b/test/EventStore.Client.Tests/StreamStateTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using System.Threading;
 using AutoFixture;

--- a/test/EventStore.Client.UserManagement.Tests/changing_user_password.cs
+++ b/test/EventStore.Client.UserManagement.Tests/changing_user_password.cs
@@ -26,7 +26,7 @@ namespace EventStore.Client {
 			string paramName) {
 			var ex = await Assert.ThrowsAsync<ArgumentNullException>(
 				() => _fixture.Client.ChangePasswordAsync(loginName, currentPassword, newPassword,
-					TestCredentials.Root));
+					userCredentials: TestCredentials.Root));
 			Assert.Equal(paramName, ex.ParamName);
 		}
 
@@ -45,7 +45,7 @@ namespace EventStore.Client {
 			string paramName) {
 			var ex = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
 				() => _fixture.Client.ChangePasswordAsync(loginName, currentPassword, newPassword,
-					TestCredentials.Root));
+					userCredentials: TestCredentials.Root));
 			Assert.Equal(paramName, ex.ParamName);
 		}
 
@@ -53,40 +53,40 @@ namespace EventStore.Client {
 		public async Task with_user_with_insufficient_credentials_throws(string loginName,
 			UserCredentials userCredentials) {
 			await _fixture.Client.CreateUserAsync(loginName, "Full Name", Array.Empty<string>(),
-				"password", TestCredentials.Root);
+				"password", userCredentials: TestCredentials.Root);
 			await Assert.ThrowsAsync<AccessDeniedException>(
 				() => _fixture.Client.ChangePasswordAsync(loginName, "password", "newPassword",
-					userCredentials));
+					userCredentials: userCredentials));
 		}
 
 		[Fact]
 		public async Task when_the_current_password_is_wrong_throws() {
 			var loginName = Guid.NewGuid().ToString();
 			await _fixture.Client.CreateUserAsync(loginName, "Full Name", Array.Empty<string>(),
-				"password", TestCredentials.Root);
+				"password", userCredentials: TestCredentials.Root);
 			await Assert.ThrowsAsync<AccessDeniedException>(
 				() => _fixture.Client.ChangePasswordAsync(loginName, "wrong-password", "newPassword",
-					TestCredentials.Root));
+					userCredentials: TestCredentials.Root));
 		}
 
 		[Fact]
 		public async Task with_correct_credentials() {
 			var loginName = Guid.NewGuid().ToString();
 			await _fixture.Client.CreateUserAsync(loginName, "Full Name", Array.Empty<string>(),
-				"password", TestCredentials.Root);
+				"password", userCredentials: TestCredentials.Root);
 
 			await _fixture.Client.ChangePasswordAsync(loginName, "password", "newPassword",
-				TestCredentials.Root);
+				userCredentials: TestCredentials.Root);
 		}
 
 		[Fact]
 		public async Task with_own_credentials() {
 			var loginName = Guid.NewGuid().ToString();
 			await _fixture.Client.CreateUserAsync(loginName, "Full Name", Array.Empty<string>(),
-				"password", TestCredentials.Root);
+				"password", userCredentials: TestCredentials.Root);
 
 			await _fixture.Client.ChangePasswordAsync(loginName, "password", "newPassword",
-				new UserCredentials(loginName, "password"));
+				userCredentials: new UserCredentials(loginName, "password"));
 		}
 
 		public class Fixture : EventStoreClientFixture {

--- a/test/EventStore.Client.UserManagement.Tests/creating_a_user.cs
+++ b/test/EventStore.Client.UserManagement.Tests/creating_a_user.cs
@@ -28,7 +28,7 @@ namespace EventStore.Client {
 			string paramName) {
 			var ex = await Assert.ThrowsAsync<ArgumentNullException>(
 				() => _fixture.Client.CreateUserAsync(loginName, fullName, groups, password,
-					TestCredentials.Root));
+					userCredentials: TestCredentials.Root));
 			Assert.Equal(paramName, ex.ParamName);
 		}
 
@@ -48,7 +48,7 @@ namespace EventStore.Client {
 			string paramName) {
 			var ex = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
 				() => _fixture.Client.CreateUserAsync(loginName, fullName, groups, password,
-					TestCredentials.Root));
+					userCredentials: TestCredentials.Root));
 			Assert.Equal(paramName, ex.ParamName);
 		}
 
@@ -58,20 +58,20 @@ namespace EventStore.Client {
 			if (userCredentials == null)
 				await Assert.ThrowsAsync<AccessDeniedException>(
 					() => _fixture.Client.CreateUserAsync(loginName, "Full Name", new[] { "foo", "bar" },
-						"password", userCredentials));
+						"password"));
 			else
 				await Assert.ThrowsAsync<NotAuthenticatedException>(
 					() => _fixture.Client.CreateUserAsync(loginName, "Full Name", new[] { "foo", "bar" },
-						"password", userCredentials));
+						"password", userCredentials: userCredentials));
 		}
 
 		[Fact]
 		public async Task can_be_read() {
 			var loginName = Guid.NewGuid().ToString();
 			await _fixture.Client.CreateUserAsync(loginName, "Full Name", new[] { "foo", "bar" }, "password",
-				TestCredentials.Root);
+				userCredentials: TestCredentials.Root);
 
-			var details = await _fixture.Client.GetUserAsync(loginName, TestCredentials.Root);
+			var details = await _fixture.Client.GetUserAsync(loginName, userCredentials: TestCredentials.Root);
 
 			Assert.Equal(new UserDetails(loginName, "Full Name", new[] { "foo", "bar" }, false, details.DateLastUpdated),
 				details);

--- a/test/EventStore.Client.UserManagement.Tests/deleting_a_user.cs
+++ b/test/EventStore.Client.UserManagement.Tests/deleting_a_user.cs
@@ -13,14 +13,14 @@ namespace EventStore.Client {
 		[Fact]
 		public async Task with_null_input_throws() {
 			var ex = await Assert.ThrowsAsync<ArgumentNullException>(
-				() => _fixture.Client.DeleteUserAsync(null!, TestCredentials.Root));
+				() => _fixture.Client.DeleteUserAsync(null!, userCredentials: TestCredentials.Root));
 			Assert.Equal("loginName", ex.ParamName);
 		}
 
 		[Fact]
 		public async Task with_empty_input_throws() {
 			var ex = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
-				() => _fixture.Client.DeleteUserAsync(string.Empty, TestCredentials.Root));
+				() => _fixture.Client.DeleteUserAsync(string.Empty, userCredentials: TestCredentials.Root));
 			Assert.Equal("loginName", ex.ParamName);
 		}
 
@@ -28,25 +28,25 @@ namespace EventStore.Client {
 		public async Task with_user_with_insufficient_credentials_throws(string loginName,
 			UserCredentials userCredentials) {
 			await _fixture.Client.CreateUserAsync(loginName, "Full Name", new[] {"foo", "bar"},
-				"password", TestCredentials.Root);
+				"password", userCredentials: TestCredentials.Root);
 			if(userCredentials == null)
 				await Assert.ThrowsAsync<AccessDeniedException>(
-				() => _fixture.Client.DeleteUserAsync(loginName, userCredentials));
+				() => _fixture.Client.DeleteUserAsync(loginName));
 			else
 				await Assert.ThrowsAsync<NotAuthenticatedException>(
-				() => _fixture.Client.DeleteUserAsync(loginName, userCredentials));
+				() => _fixture.Client.DeleteUserAsync(loginName, userCredentials: userCredentials));
 		}
 
 		[Fact]
 		public async Task cannot_be_read() {
 			var loginName = Guid.NewGuid().ToString();
 			await _fixture.Client.CreateUserAsync(loginName, "Full Name", new[] {"foo", "bar"}, "password",
-				TestCredentials.Root);
+				userCredentials: TestCredentials.Root);
 
-			await _fixture.Client.DeleteUserAsync(loginName, TestCredentials.Root);
+			await _fixture.Client.DeleteUserAsync(loginName, userCredentials: TestCredentials.Root);
 
 			var ex = await Assert.ThrowsAsync<UserNotFoundException>(
-				() => _fixture.Client.GetUserAsync(loginName, TestCredentials.Root));
+				() => _fixture.Client.GetUserAsync(loginName, userCredentials: TestCredentials.Root));
 
 			Assert.Equal(loginName, ex.LoginName);
 		}
@@ -55,12 +55,12 @@ namespace EventStore.Client {
 		public async Task a_second_time_throws() {
 			var loginName = Guid.NewGuid().ToString();
 			await _fixture.Client.CreateUserAsync(loginName, "Full Name", new[] {"foo", "bar"}, "password",
-				TestCredentials.Root);
+				userCredentials: TestCredentials.Root);
 
-			await _fixture.Client.DeleteUserAsync(loginName, TestCredentials.Root);
+			await _fixture.Client.DeleteUserAsync(loginName, userCredentials: TestCredentials.Root);
 
 			var ex = await Assert.ThrowsAsync<UserNotFoundException>(
-				() => _fixture.Client.DeleteUserAsync(loginName, TestCredentials.Root));
+				() => _fixture.Client.DeleteUserAsync(loginName, userCredentials: TestCredentials.Root));
 
 			Assert.Equal(loginName, ex.LoginName);
 		}

--- a/test/EventStore.Client.UserManagement.Tests/disabling_a_user.cs
+++ b/test/EventStore.Client.UserManagement.Tests/disabling_a_user.cs
@@ -14,7 +14,7 @@ namespace EventStore.Client {
 		public async Task with_null_input_throws() {
 			var ex = await Assert.ThrowsAsync<ArgumentNullException>(
 				() => _fixture.Client.EnableUserAsync(null!,
-					TestCredentials.Root));
+					userCredentials: TestCredentials.Root));
 			Assert.Equal("loginName", ex.ParamName);
 		}
 
@@ -22,7 +22,7 @@ namespace EventStore.Client {
 		public async Task with_empty_input_throws() {
 			var ex = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
 				() => _fixture.Client.EnableUserAsync(string.Empty,
-					TestCredentials.Root));
+					userCredentials: TestCredentials.Root));
 			Assert.Equal("loginName", ex.ParamName);
 		}
 
@@ -30,31 +30,31 @@ namespace EventStore.Client {
 		public async Task with_user_with_insufficient_credentials_throws(string loginName,
 			UserCredentials userCredentials) {
 			await _fixture.Client.CreateUserAsync(loginName, "Full Name", new[] {"foo", "bar"},
-				"password", TestCredentials.Root);
+				"password", userCredentials: TestCredentials.Root);
 			if (userCredentials == null)
-				await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.Client.DisableUserAsync(loginName, userCredentials));
+				await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.Client.DisableUserAsync(loginName));
 			else
 				await Assert.ThrowsAsync<NotAuthenticatedException>(
-					() => _fixture.Client.DisableUserAsync(loginName, userCredentials));
+					() => _fixture.Client.DisableUserAsync(loginName, userCredentials: userCredentials));
 		}
 
 		[Fact]
 		public async Task that_was_disabled() {
 			var loginName = Guid.NewGuid().ToString();
 			await _fixture.Client.CreateUserAsync(loginName, "Full Name", new[] {"foo", "bar"},
-				"password", TestCredentials.Root);
+				"password", userCredentials: TestCredentials.Root);
 
-			await _fixture.Client.DisableUserAsync(loginName, TestCredentials.Root);
-			await _fixture.Client.DisableUserAsync(loginName, TestCredentials.Root);
+			await _fixture.Client.DisableUserAsync(loginName, userCredentials: TestCredentials.Root);
+			await _fixture.Client.DisableUserAsync(loginName, userCredentials: TestCredentials.Root);
 		}
 
 		[Fact]
 		public async Task that_is_enabled() {
 			var loginName = Guid.NewGuid().ToString();
 			await _fixture.Client.CreateUserAsync(loginName, "Full Name", new[] {"foo", "bar"},
-				"password", TestCredentials.Root);
+				"password", userCredentials: TestCredentials.Root);
 
-			await _fixture.Client.DisableUserAsync(loginName, TestCredentials.Root);
+			await _fixture.Client.DisableUserAsync(loginName, userCredentials: TestCredentials.Root);
 		}
 
 		public class Fixture : EventStoreClientFixture {

--- a/test/EventStore.Client.UserManagement.Tests/enabling_a_user.cs
+++ b/test/EventStore.Client.UserManagement.Tests/enabling_a_user.cs
@@ -13,7 +13,7 @@ namespace EventStore.Client {
 		[Fact]
 		public async Task with_null_input_throws() {
 			var ex = await Assert.ThrowsAsync<ArgumentNullException>(
-				() => _fixture.Client.EnableUserAsync(null!, TestCredentials.Root));
+				() => _fixture.Client.EnableUserAsync(null!, userCredentials: TestCredentials.Root));
 			Assert.Equal("loginName", ex.ParamName);
 		}
 
@@ -21,7 +21,7 @@ namespace EventStore.Client {
 		public async Task with_empty_input_throws() {
 			var ex = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
 				() => _fixture.Client.EnableUserAsync(string.Empty,
-					TestCredentials.Root));
+					userCredentials: TestCredentials.Root));
 			Assert.Equal("loginName", ex.ParamName);
 		}
 
@@ -29,32 +29,32 @@ namespace EventStore.Client {
 		public async Task with_user_with_insufficient_credentials_throws(string loginName,
 			UserCredentials userCredentials) {
 			await _fixture.Client.CreateUserAsync(loginName, "Full Name", new[] {"foo", "bar"},
-				"password", TestCredentials.Root);
+				"password", userCredentials: TestCredentials.Root);
 			if (userCredentials == null) 
 				await Assert.ThrowsAsync<AccessDeniedException>(
-					() => _fixture.Client.EnableUserAsync(loginName, userCredentials));
+					() => _fixture.Client.EnableUserAsync(loginName));
 			 else 
 				await Assert.ThrowsAsync<NotAuthenticatedException>(
-					() => _fixture.Client.EnableUserAsync(loginName, userCredentials));
+					() => _fixture.Client.EnableUserAsync(loginName, userCredentials: userCredentials));
 		}
 
 		[Fact]
 		public async Task that_was_disabled() {
 			var loginName = Guid.NewGuid().ToString();
 			await _fixture.Client.CreateUserAsync(loginName, "Full Name", new[] {"foo", "bar"},
-				"password", TestCredentials.Root);
+				"password", userCredentials: TestCredentials.Root);
 
-			await _fixture.Client.DisableUserAsync(loginName, TestCredentials.Root);
-			await _fixture.Client.EnableUserAsync(loginName, TestCredentials.Root);
+			await _fixture.Client.DisableUserAsync(loginName, userCredentials: TestCredentials.Root);
+			await _fixture.Client.EnableUserAsync(loginName, userCredentials: TestCredentials.Root);
 		}
 
 		[Fact]
 		public async Task that_is_enabled() {
 			var loginName = Guid.NewGuid().ToString();
 			await _fixture.Client.CreateUserAsync(loginName, "Full Name", new[] {"foo", "bar"},
-				"password", TestCredentials.Root);
+				"password", userCredentials: TestCredentials.Root);
 
-			await _fixture.Client.EnableUserAsync(loginName, TestCredentials.Root);
+			await _fixture.Client.EnableUserAsync(loginName, userCredentials: TestCredentials.Root);
 		}
 
 		public class Fixture : EventStoreClientFixture {

--- a/test/EventStore.Client.UserManagement.Tests/listing_users.cs
+++ b/test/EventStore.Client.UserManagement.Tests/listing_users.cs
@@ -13,7 +13,7 @@ namespace EventStore.Client {
 
 		[Fact]
 		public async Task returns_all_users() {
-			var users = await _fixture.Client.ListAllAsync(TestCredentials.Root)
+			var users = await _fixture.Client.ListAllAsync(userCredentials: TestCredentials.Root)
 				.ToArrayAsync();
 
 			var expected = new[] {
@@ -55,7 +55,7 @@ namespace EventStore.Client {
 			protected override async Task Given() {
 				foreach (var user in Users) {
 					await Client.CreateUserAsync(user.LoginName, user.FullName,
-						user.Groups, Guid.NewGuid().ToString(), TestCredentials.Root);
+						user.Groups, Guid.NewGuid().ToString(), userCredentials: TestCredentials.Root);
 				}
 			}
 

--- a/test/EventStore.Client.UserManagement.Tests/reset_user_password.cs
+++ b/test/EventStore.Client.UserManagement.Tests/reset_user_password.cs
@@ -24,7 +24,7 @@ namespace EventStore.Client {
 			string paramName) {
 			var ex = await Assert.ThrowsAsync<ArgumentNullException>(
 				() => _fixture.Client.ResetPasswordAsync(loginName, newPassword,
-					TestCredentials.Root));
+					userCredentials: TestCredentials.Root));
 			Assert.Equal(paramName, ex.ParamName);
 		}
 
@@ -41,7 +41,7 @@ namespace EventStore.Client {
 			string paramName) {
 			var ex = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
 				() => _fixture.Client.ResetPasswordAsync(loginName, newPassword,
-					TestCredentials.Root));
+					userCredentials: TestCredentials.Root));
 			Assert.Equal(paramName, ex.ParamName);
 		}
 
@@ -49,36 +49,35 @@ namespace EventStore.Client {
 		public async Task with_user_with_insufficient_credentials_throws(string loginName,
 			UserCredentials userCredentials) {
 			await _fixture.Client.CreateUserAsync(loginName, "Full Name", Array.Empty<string>(),
-				"password", TestCredentials.Root);
+				"password", userCredentials: TestCredentials.Root);
 			if (userCredentials == null)
 				await Assert.ThrowsAsync<AccessDeniedException>(
-					() => _fixture.Client.ResetPasswordAsync(loginName, "newPassword",
-						userCredentials));
+					() => _fixture.Client.ResetPasswordAsync(loginName, "newPassword"));
 			else
 				await Assert.ThrowsAsync<NotAuthenticatedException>(
 					() => _fixture.Client.ResetPasswordAsync(loginName, "newPassword",
-						userCredentials));
+						userCredentials: userCredentials));
 		}
 
 		[Fact]
 		public async Task with_correct_credentials() {
 			var loginName = Guid.NewGuid().ToString();
 			await _fixture.Client.CreateUserAsync(loginName, "Full Name", Array.Empty<string>(),
-				"password", TestCredentials.Root);
+				"password", userCredentials: TestCredentials.Root);
 
 			await _fixture.Client.ResetPasswordAsync(loginName, "newPassword",
-				TestCredentials.Root);
+				userCredentials: TestCredentials.Root);
 		}
 
 		[Fact]
 		public async Task with_own_credentials_throws() {
 			var loginName = Guid.NewGuid().ToString();
 			await _fixture.Client.CreateUserAsync(loginName, "Full Name", Array.Empty<string>(),
-				"password", TestCredentials.Root);
+				"password", userCredentials: TestCredentials.Root);
 
 			await Assert.ThrowsAsync<AccessDeniedException>(
 				() => _fixture.Client.ResetPasswordAsync(loginName, "newPassword",
-					new UserCredentials(loginName, "password")));
+					userCredentials: new UserCredentials(loginName, "password")));
 		}
 
 		public class Fixture : EventStoreClientFixture {


### PR DESCRIPTION
Changed: Default deadlines for reading operations set to `Inifinity`
Changed: Deadlines for all other operations defaults to `10s`
Changed: Removed `Timeout` from `EventStoreOperationOptions` and moved it to an explicit `deadline` parameter on all operations except for subscriptions. Consequently, `configureOperationOptions` callback has been removed for most operations.

This PR configures default deadlines for each operation according to the following table:

| Operation | Default Timeout | Overridden by `defaultDeadline` | Overridden by `deadline` |
|-----------|-----------------|---------------------------------|------------|
| Stream and $all Reads | `infinity` | N | Y |
| Stream and $all Subscriptions (Including Persistent Subscriptions) | `infinity` | N | N |
| Writes | `10 seconds` | Y | Y |
| Management operations | `10 seconds` | Y | Y |
| Batch Append | `10 seconds` | Y | Y |

This aligns with the other clients.

Fixes  #184 