### PR TITLE
Implement RFC 574

### DIFF
--- a/samples/projection-management/Program.cs
+++ b/samples/projection-management/Program.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using EventStore.Client;
+using Grpc.Core;
 
 namespace projection_management {
 	public static class Program {
@@ -100,7 +101,9 @@ namespace projection_management {
 			#region DisableNotFound
 			try {
 				await managementClient.DisableAsync("projection that does not exists");
-			} catch (InvalidOperationException e) when (e.Message.Contains("NotFound")) {
+			} catch (RpcException e) when (e.StatusCode is StatusCode.NotFound) {
+				Console.WriteLine(e.Message);
+			} catch (RpcException e) when (e.Message.Contains("NotFound")) {  // will be removed in a future release
 				Console.WriteLine(e.Message);
 			}
 			#endregion DisableNotFound
@@ -116,7 +119,9 @@ namespace projection_management {
 			#region EnableNotFound
 			try {
 				await managementClient.EnableAsync("projection that does not exists");
-			} catch (InvalidOperationException e) when (e.Message.Contains("NotFound")) {
+			} catch (RpcException e) when (e.StatusCode is StatusCode.NotFound) {
+				Console.WriteLine(e.Message);
+			} catch (RpcException e) when (e.Message.Contains("NotFound")) {  // will be removed in a future release
 				Console.WriteLine(e.Message);
 			}
 			#endregion EnableNotFound
@@ -135,7 +140,9 @@ namespace projection_management {
 				var js =
 					"fromAll() .when({$init:function(){return {count:0};},$any:function(s, e){s.count += 1;}}).outputState();";
 				await managementClient.CreateContinuousAsync("countEvents_Abort", js);
-			} catch (InvalidOperationException e) when (e.Message.Contains("Conflict")) {
+			} catch (RpcException e) when (e.StatusCode is StatusCode.Aborted) {
+				// ignore was already created in a previous run
+			} catch (RpcException e) when (e.Message.Contains("Conflict")) {  // will be removed in a future release
 				// ignore was already created in a previous run
 			}
 
@@ -149,7 +156,9 @@ namespace projection_management {
 			#region Abort_NotFound
 			try {
 				await managementClient.AbortAsync("projection that does not exists");
-			} catch (InvalidOperationException e) when (e.Message.Contains("NotFound")) {
+			} catch (RpcException e) when (e.StatusCode is StatusCode.NotFound) {
+				Console.WriteLine(e.Message);
+			} catch (RpcException e) when (e.Message.Contains("NotFound")) {  // will be removed in a future release
 				Console.WriteLine(e.Message);
 			}
 			#endregion Abort_NotFound
@@ -160,7 +169,9 @@ namespace projection_management {
 				var js =
 					"fromAll() .when({$init:function(){return {count:0};},$any:function(s, e){s.count += 1;}}).outputState();";
 				await managementClient.CreateContinuousAsync("countEvents_Reset", js);
-			} catch (InvalidOperationException e) when (e.Message.Contains("Conflict")) {
+			} catch (RpcException e) when (e.StatusCode is StatusCode.Internal) {
+				// ignore was already created in a previous run
+			} catch (RpcException e) when (e.Message.Contains("Conflict")) {  // will be removed in a future release
 				// ignore was already created in a previous run
 			}
 
@@ -175,7 +186,9 @@ namespace projection_management {
 			#region Reset_NotFound
 			try {
 				await managementClient.ResetAsync("projection that does not exists");
-			} catch (InvalidOperationException e) when (e.Message.Contains("NotFound")) {
+			} catch (RpcException e) when (e.StatusCode is StatusCode.NotFound) {
+				Console.WriteLine(e.Message);
+			} catch (RpcException e) when (e.Message.Contains("NotFound")) {  // will be removed in a future release
 				Console.WriteLine(e.Message);
 			}
 			#endregion Reset_NotFound
@@ -227,7 +240,9 @@ namespace projection_management {
 			try {
 
 				await managementClient.CreateContinuousAsync(name, js);
-			} catch (InvalidOperationException e) when (e.Message.Contains("Conflict")) {
+			} catch (RpcException e) when (e.StatusCode is StatusCode.AlreadyExists) {
+				Console.WriteLine(e.Message);
+			} catch (RpcException e) when (e.Message.Contains("Conflict")) {  // will be removed in a future release
 				var format = $"{name} already exists";
 				Console.WriteLine(format);
 			}
@@ -259,7 +274,9 @@ namespace projection_management {
 			#region Update_NotFound
 			try {
 				await managementClient.UpdateAsync("Update Not existing projection", "fromAll().when()");
-			} catch (InvalidOperationException e) when (e.Message.Contains("NotFound")) {
+			} catch (RpcException e) when (e.StatusCode is StatusCode.NotFound) {
+				Console.WriteLine(e.Message);
+			} catch (RpcException e) when (e.Message.Contains("NotFound")) {  // will be removed in a future release
 				Console.WriteLine("'Update Not existing projection' does not exists and can not be updated");
 			}
 			#endregion Update_NotFound

--- a/src/EventStore.Client/ChannelFactory.cs
+++ b/src/EventStore.Client/ChannelFactory.cs
@@ -13,6 +13,8 @@ using TChannel = Grpc.Core.ChannelBase;
 #nullable enable
 namespace EventStore.Client {
 	internal static class ChannelFactory {
+		private const int MaxReceiveMessageLength = 17 * 1024 * 1024;
+
 		public static TChannel CreateChannel(EventStoreClientSettings settings, EndPoint endPoint, bool https) =>
 			CreateChannel(settings, endPoint.ToUri(https));
 
@@ -32,7 +34,8 @@ namespace EventStore.Client {
 				},
 				LoggerFactory = settings.LoggerFactory,
 				Credentials = settings.ChannelCredentials,
-				DisposeHttpClient = true
+				DisposeHttpClient = true,
+				MaxReceiveMessageSize = MaxReceiveMessageLength
 			});
 
 			HttpMessageHandler CreateHandler() {
@@ -56,6 +59,8 @@ namespace EventStore.Client {
 
 				yield return new ChannelOption("grpc.keepalive_timeout_ms",
 					GetValue((int)settings.ConnectivitySettings.KeepAliveTimeout.TotalMilliseconds));
+
+				yield return new ChannelOption("grpc.max_receive_message_length", MaxReceiveMessageLength);
 			}
 
 			static int GetValue(int value) => value switch {

--- a/src/EventStore.Client/Interceptors/ReportLeaderInterceptor.cs
+++ b/src/EventStore.Client/Interceptors/ReportLeaderInterceptor.cs
@@ -64,8 +64,11 @@ namespace EventStore.Client.Interceptors {
 		private void ReportNewLeader<TResponse>(Task<TResponse> task) {
 			if (task.Exception?.InnerException is NotLeaderException ex) {
 				_onError(ex.LeaderEndpoint);
-			} else if (task.Exception?.InnerException?.InnerException is RpcException rpcException &&
-			           rpcException.StatusCode == StatusCode.Unavailable) {
+			} else if (task.Exception?.InnerException is RpcException {
+				           StatusCode: StatusCode.Unavailable or
+				           // StatusCode.Unknown or TODO: use RPC exceptions on server
+				           StatusCode.Aborted
+			           }) {
 				_onError(null);
 			}
 		}

--- a/src/EventStore.Client/Interceptors/ReportLeaderInterceptor.cs
+++ b/src/EventStore.Client/Interceptors/ReportLeaderInterceptor.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Grpc.Core;
@@ -10,13 +9,13 @@ namespace EventStore.Client.Interceptors {
 	// this has become more general than just detecting leader changes.
 	// triggers the action on any rpc exception with StatusCode.Unavailable
 	internal class ReportLeaderInterceptor : Interceptor {
-		private readonly Action<DnsEndPoint?> _onError;
+		private readonly Action<ReconnectionRequired> _onReconnectionRequired;
 
 		private const TaskContinuationOptions ContinuationOptions =
 			TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnFaulted;
 
-		internal ReportLeaderInterceptor(Action<DnsEndPoint?> onError) {
-			_onError = onError;
+		internal ReportLeaderInterceptor(Action<ReconnectionRequired> onReconnectionRequired) {
+			_onReconnectionRequired = onReconnectionRequired;
 		}
 
 		public override AsyncUnaryCall<TResponse> AsyncUnaryCall<TRequest, TResponse>(TRequest request,
@@ -24,7 +23,7 @@ namespace EventStore.Client.Interceptors {
 			AsyncUnaryCallContinuation<TRequest, TResponse> continuation) {
 			var response = continuation(request, context);
 
-			response.ResponseAsync.ContinueWith(ReportNewLeader, ContinuationOptions);
+			response.ResponseAsync.ContinueWith(OnReconnectionRequired, ContinuationOptions);
 
 			return new AsyncUnaryCall<TResponse>(response.ResponseAsync, response.ResponseHeadersAsync,
 				response.GetStatus, response.GetTrailers, response.Dispose);
@@ -35,7 +34,7 @@ namespace EventStore.Client.Interceptors {
 			AsyncClientStreamingCallContinuation<TRequest, TResponse> continuation) {
 			var response = continuation(context);
 
-			response.ResponseAsync.ContinueWith(ReportNewLeader, ContinuationOptions);
+			response.ResponseAsync.ContinueWith(OnReconnectionRequired, ContinuationOptions);
 
 			return new AsyncClientStreamingCall<TRequest, TResponse>(response.RequestStream, response.ResponseAsync,
 				response.ResponseHeadersAsync, response.GetStatus, response.GetTrailers, response.Dispose);
@@ -47,7 +46,8 @@ namespace EventStore.Client.Interceptors {
 			var response = continuation(context);
 
 			return new AsyncDuplexStreamingCall<TRequest, TResponse>(response.RequestStream,
-				new StreamReader<TResponse>(response.ResponseStream, ReportNewLeader), response.ResponseHeadersAsync,
+				new StreamReader<TResponse>(response.ResponseStream, OnReconnectionRequired),
+				response.ResponseHeadersAsync,
 				response.GetStatus, response.GetTrailers, response.Dispose);
 		}
 
@@ -57,20 +57,23 @@ namespace EventStore.Client.Interceptors {
 			var response = continuation(request, context);
 
 			return new AsyncServerStreamingCall<TResponse>(
-				new StreamReader<TResponse>(response.ResponseStream, ReportNewLeader), response.ResponseHeadersAsync,
+				new StreamReader<TResponse>(response.ResponseStream, OnReconnectionRequired),
+				response.ResponseHeadersAsync,
 				response.GetStatus, response.GetTrailers, response.Dispose);
 		}
 
-		private void ReportNewLeader<TResponse>(Task<TResponse> task) {
-			if (task.Exception?.InnerException is NotLeaderException ex) {
-				_onError(ex.LeaderEndpoint);
-			} else if (task.Exception?.InnerException is RpcException {
-				           StatusCode: StatusCode.Unavailable or
-				           // StatusCode.Unknown or TODO: use RPC exceptions on server
-				           StatusCode.Aborted
-			           }) {
-				_onError(null);
-			}
+		private void OnReconnectionRequired<TResponse>(Task<TResponse> task) {
+			ReconnectionRequired reconnectionRequired = task.Exception?.InnerException switch {
+				NotLeaderException ex => new ReconnectionRequired.NewLeader(ex.LeaderEndpoint),
+				RpcException {
+					StatusCode: StatusCode.Unavailable
+					// or StatusCode.Unknown or TODO: use RPC exceptions on server 
+				} => ReconnectionRequired.Rediscover.Instance,
+				_ => ReconnectionRequired.None.Instance
+			};
+
+			if (reconnectionRequired is not ReconnectionRequired.None)
+				_onReconnectionRequired(reconnectionRequired);
 		}
 
 		private class StreamReader<T> : IAsyncStreamReader<T> {

--- a/src/EventStore.Client/Interceptors/TypedExceptionInterceptor.cs
+++ b/src/EventStore.Client/Interceptors/TypedExceptionInterceptor.cs
@@ -91,7 +91,7 @@ namespace EventStore.Client.Interceptors {
 						StatusCode.DeadlineExceeded, ex.Status.Detail, ex.Status.DebugException)),
 					(StatusCode.DeadlineExceeded, _) => ex,
 					(StatusCode.Unauthenticated, _) => new NotAuthenticatedException(ex.Message, ex),
-					_ => new InvalidOperationException(ex.Message, ex)
+					_ => ex
 				}
 			};
 		}

--- a/src/EventStore.Client/ReconnectionRequired.cs
+++ b/src/EventStore.Client/ReconnectionRequired.cs
@@ -1,0 +1,15 @@
+using System.Net;
+
+namespace EventStore.Client {
+	internal abstract record ReconnectionRequired {
+		public record None : ReconnectionRequired {
+			public static None Instance = new();
+		}
+
+		public record Rediscover : ReconnectionRequired {
+			public static Rediscover Instance = new();
+		}
+
+		public record NewLeader(DnsEndPoint EndPoint) : ReconnectionRequired;
+	}
+}

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/create_duplicate.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/create_duplicate.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using Grpc.Core;
 using Xunit;
 
 namespace EventStore.Client.SubscriptionToAll {
@@ -21,10 +22,12 @@ namespace EventStore.Client.SubscriptionToAll {
 		}
 
 		[Fact]
-		public Task the_completion_fails_with_invalid_operation_exception() =>
-			Assert.ThrowsAsync<InvalidOperationException>(
+		public async Task the_completion_fails() {
+			var ex = await Assert.ThrowsAsync<RpcException>(
 				() => _fixture.Client.CreateToAllAsync("group32",
 					new PersistentSubscriptionSettings(),
 					TestCredentials.Root));
+			Assert.Equal(StatusCode.AlreadyExists, ex.StatusCode);
+		}
 	}
 }

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/create_with_commit_position_larger_than_last_indexed_position.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/create_with_commit_position_larger_than_last_indexed_position.cs
@@ -1,6 +1,8 @@
 using System;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Grpc.Core;
 using Xunit;
 
 namespace EventStore.Client.SubscriptionToAll {
@@ -24,11 +26,13 @@ namespace EventStore.Client.SubscriptionToAll {
 		}
 
 		[Fact]
-		public Task fails_with_invalid_operation_exception() =>
-			Assert.ThrowsAsync<InvalidOperationException>(() =>
+		public async Task fails() {
+			var ex = await Assert.ThrowsAsync<RpcException>(() =>
 				_fixture.Client.CreateToAllAsync("group57",
 					new PersistentSubscriptionSettings(
-						startFrom: new Position(_fixture.LastCommitPosition+1, _fixture.LastCommitPosition)),
-						TestCredentials.Root));
+						startFrom: new Position(_fixture.LastCommitPosition + 1, _fixture.LastCommitPosition)),
+					TestCredentials.Root));
+			Assert.Equal(StatusCode.Internal, ex.StatusCode);
+		}
 	}
 }

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/update_existing_with_commit_position_larger_than_last_indexed_position.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/update_existing_with_commit_position_larger_than_last_indexed_position.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Grpc.Core;
 using Xunit;
 
 namespace EventStore.Client.SubscriptionToAll {
@@ -28,13 +29,15 @@ namespace EventStore.Client.SubscriptionToAll {
 			}
 			protected override Task Given() => Task.CompletedTask;
 		}
-
+		
 		[Fact]
-		public Task fails_with_invalid_operation_exception() =>
-			Assert.ThrowsAsync<InvalidOperationException>(() =>
+		public async Task fails() {
+			var ex = await Assert.ThrowsAsync<RpcException>(() =>
 				_fixture.Client.UpdateToAllAsync(Group,
 					new PersistentSubscriptionSettings(
-						startFrom: new Position(_fixture.LastCommitPosition+1, _fixture.LastCommitPosition)),
-						TestCredentials.Root));
+						startFrom: new Position(_fixture.LastCommitPosition + 1, _fixture.LastCommitPosition)),
+					TestCredentials.Root));
+			Assert.Equal(StatusCode.Internal, ex.StatusCode);
+		}
 	}
 }

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/create_duplicate.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/create_duplicate.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using Grpc.Core;
 using Xunit;
 
 namespace EventStore.Client.SubscriptionToStream {
@@ -21,10 +22,12 @@ namespace EventStore.Client.SubscriptionToStream {
 		}
 
 		[Fact]
-		public Task the_completion_fails_with_invalid_operation_exception() =>
-			Assert.ThrowsAsync<InvalidOperationException>(
+		public async Task the_completion_fails() {
+			var ex = await Assert.ThrowsAsync<RpcException>(
 				() => _fixture.Client.CreateAsync(Stream, "group32",
 					new PersistentSubscriptionSettings(),
 					TestCredentials.Root));
+			Assert.Equal(StatusCode.AlreadyExists, ex.StatusCode);
+		}
 	}
 }

--- a/test/EventStore.Client.Streams.Tests/EventStoreClientFixture.cs
+++ b/test/EventStore.Client.Streams.Tests/EventStoreClientFixture.cs
@@ -6,7 +6,7 @@ namespace EventStore.Client {
 	public abstract class EventStoreClientFixture : EventStoreClientFixtureBase {
 		public EventStoreClient Client { get; }
 		protected EventStoreClientFixture(EventStoreClientSettings? settings = null,
-			IDictionary<string, string>? env = null) : base(settings, env) {
+			Dictionary<string, string>? env = null) : base(settings, env) {
 			Client = new EventStoreClient(Settings);
 		}
 

--- a/test/EventStore.Client.Streams.Tests/append_to_stream_retry.cs
+++ b/test/EventStore.Client.Streams.Tests/append_to_stream_retry.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Grpc.Core;
 using Polly;
 using Xunit;
 
@@ -25,7 +26,11 @@ namespace EventStore.Client {
 
 			// writeTask cannot complete because ES is stopped
 			var ex = await Assert.ThrowsAnyAsync<Exception>(() => WriteAnEventAsync(new StreamRevision(0)));
-			Assert.True(ex is InvalidOperationException or DiscoveryException);
+			Assert.True(ex is RpcException {
+				Status: {
+					StatusCode: StatusCode.Unavailable
+				}
+			} or DiscoveryException);
 
 			await _fixture.TestServer.StartAsync().WithTimeout();
 

--- a/test/EventStore.Client.Streams.Tests/reconnection.cs
+++ b/test/EventStore.Client.Streams.Tests/reconnection.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Xunit;
+
+namespace EventStore.Client {
+	public class reconnection : IClassFixture<reconnection.Fixture> {
+		private readonly Fixture _fixture;
+
+		public reconnection(Fixture fixture) {
+			_fixture = fixture;
+		}
+
+		[Fact]
+		public async Task when_the_connection_is_lost() {
+			var streamName = _fixture.GetStreamName();
+			var eventCount = 512;
+			var tcs = new TaskCompletionSource<object>();
+			var signal = new TaskCompletionSource<object>();
+			var events = new List<ResolvedEvent>();
+			var resubscribe = new TaskCompletionSource<StreamSubscription>();
+
+			using var _ = await _fixture.Client.SubscribeToStreamAsync(streamName, FromStream.Start,
+					EventAppeared, subscriptionDropped: SubscriptionDropped)
+				.WithTimeout();
+
+			await _fixture.Client
+				.AppendToStreamAsync(streamName, StreamState.NoStream, _fixture.CreateTestEvents(eventCount))
+				.WithTimeout(); // ensure we get backpressure
+
+			_fixture.TestServer.Stop();
+			await Task.Delay(TimeSpan.FromSeconds(2));
+
+			await _fixture.TestServer.StartAsync().WithTimeout();
+			signal.SetResult(null);
+
+			await resubscribe.Task.WithTimeout(TimeSpan.FromSeconds(10));
+
+			await tcs.Task.WithTimeout(TimeSpan.FromSeconds(10));
+			
+			async Task EventAppeared(StreamSubscription s, ResolvedEvent e, CancellationToken ct) {
+				await signal.Task;
+				events.Add(e);
+				if (events.Count == eventCount) {
+					tcs.TrySetResult(null);
+				}
+			}
+
+			void SubscriptionDropped(StreamSubscription s, SubscriptionDroppedReason reason, Exception ex) {
+				if (reason == SubscriptionDroppedReason.Disposed) {
+					return;
+				}
+
+				if (ex is not RpcException {
+					    Status: {
+						    StatusCode: StatusCode.Unavailable
+					    }
+				    }) {
+					tcs.TrySetException(ex);
+				} else {
+					var task = _fixture.Client.SubscribeToStreamAsync(streamName,
+						FromStream.After(events[^1].OriginalEventNumber),
+						EventAppeared, subscriptionDropped: SubscriptionDropped);
+					task.ContinueWith(_ => resubscribe.SetResult(_.Result), TaskContinuationOptions.NotOnFaulted);
+					task.ContinueWith(_ => resubscribe.SetException(_.Exception!.GetBaseException()),
+						TaskContinuationOptions.OnlyOnFaulted);
+				}
+			}
+		}
+
+		public class Fixture : EventStoreClientFixture {
+			protected override Task Given() => Task.CompletedTask;
+
+			protected override Task When() => Task.CompletedTask;
+
+			public Fixture() : base(env: new() {
+				["EVENTSTORE_MEM_DB"] = "false"
+			}) {
+				Settings.ConnectivitySettings.DiscoveryInterval = TimeSpan.FromMilliseconds(100);
+				Settings.ConnectivitySettings.GossipTimeout = TimeSpan.FromMilliseconds(100);
+			}
+		}
+	}
+}

--- a/test/EventStore.Client.Streams.Tests/sending_and_receiving_large_messages.cs
+++ b/test/EventStore.Client.Streams.Tests/sending_and_receiving_large_messages.cs
@@ -18,11 +18,10 @@ namespace EventStore.Client {
 		[Fact]
 		public async Task over_the_hard_limit() {
 			var streamName = _fixture.GetStreamName();
-			var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _fixture.Client.AppendToStreamAsync(
+			var ex = await Assert.ThrowsAsync<RpcException>(() => _fixture.Client.AppendToStreamAsync(
 				streamName, StreamState.NoStream,
 				_fixture.LargeEvent));
-			var rpcEx = Assert.IsType<RpcException>(ex.InnerException);
-			Assert.Equal(StatusCode.ResourceExhausted, rpcEx.StatusCode);
+			Assert.Equal(StatusCode.ResourceExhausted, ex.StatusCode);
 		}
 
 		public class Fixture : EventStoreClientFixture {

--- a/test/EventStore.Client.Tests/Interceptors/ReportLeaderInterceptorTests.cs
+++ b/test/EventStore.Client.Tests/Interceptors/ReportLeaderInterceptorTests.cs
@@ -10,10 +10,16 @@ using Xunit;
 
 namespace EventStore.Client.Interceptors {
 	public class ReportLeaderInterceptorTests {
-		private static readonly Marshaller<object> _marshaller =
-			new Marshaller<object>(_ => Array.Empty<byte>(), _ => new object());
-
 		public delegate Task GrpcCall(Interceptor interceptor, Task<object> response = null);
+
+		private static readonly Marshaller<object> _marshaller = new(_ => Array.Empty<byte>(), _ => new object());
+
+		private static readonly StatusCode[] ForcesRediscoveryStatusCodes = {
+			StatusCode.Aborted, 
+			//StatusCode.Unknown, TODO: use RPC exceptions on server
+			StatusCode.Unavailable
+		};
+
 
 		private static IEnumerable<GrpcCall> GrpcCalls() {
 			yield return MakeUnaryCall;
@@ -22,9 +28,9 @@ namespace EventStore.Client.Interceptors {
 			yield return MakeServerStreamingCall;
 		}
 
-		public static IEnumerable<object[]> TestCases() => GrpcCalls().Select(call => new object[] {call});
+		public static IEnumerable<object[]> ReportsNewLeaderCases() => GrpcCalls().Select(call => new object[] {call});
 
-		[Theory, MemberData(nameof(TestCases))]
+		[Theory, MemberData(nameof(ReportsNewLeaderCases))]
 		public async Task ReportsNewLeader(GrpcCall call) {
 			EndPoint actual = default;
 			var sut = new ReportLeaderInterceptor(ep => actual = ep);
@@ -33,6 +39,43 @@ namespace EventStore.Client.Interceptors {
 				call(sut, Task.FromException<object>(new NotLeaderException("a.host", 2112))));
 			Assert.Equal(result.LeaderEndpoint, actual);
 		}
+
+		public static IEnumerable<object[]> ForcesRediscoveryCases() => from call in GrpcCalls()
+			from statusCode in ForcesRediscoveryStatusCodes
+			select new object[] {call, statusCode};
+
+		[Theory, MemberData(nameof(ForcesRediscoveryCases))]
+		public async Task ForcesRediscovery(GrpcCall call, StatusCode statusCode) {
+			EndPoint actual = default;
+			bool invoked = false;
+
+			var sut = new ReportLeaderInterceptor(ep => {
+				invoked = true;
+				actual = ep;
+			});
+
+			var result = await Assert.ThrowsAsync<RpcException>(() => call(sut,
+				Task.FromException<object>(new RpcException(new Status(statusCode, "oops")))));
+			Assert.Null(actual);
+			Assert.True(invoked);
+		}
+		
+		public static IEnumerable<object[]> DoesNotForceRediscoveryCases() => from call in GrpcCalls()
+			from statusCode in Enum.GetValues(typeof(StatusCode))
+				.OfType<StatusCode>()
+				.Except(ForcesRediscoveryStatusCodes)
+			select new object[] {call, statusCode};
+
+		[Theory, MemberData(nameof(DoesNotForceRediscoveryCases))]
+		public async Task DoesNotForceRediscovery(GrpcCall call, StatusCode statusCode) {
+			bool invoked = false;
+			var sut = new ReportLeaderInterceptor(ep => invoked = true);
+
+			var result = await Assert.ThrowsAsync<RpcException>(() => call(sut,
+				Task.FromException<object>(new RpcException(new Status(statusCode, "oops")))));
+			Assert.False(invoked);
+		}
+		
 
 		private static async Task MakeUnaryCall(Interceptor interceptor, Task<object> response = null) {
 			using var call = interceptor.AsyncUnaryCall(new object(),
@@ -73,8 +116,7 @@ namespace EventStore.Client.Interceptors {
 		private static void OnDispose() { }
 
 		private static ClientInterceptorContext<object, object> CreateClientInterceptorContext(MethodType methodType) =>
-			new ClientInterceptorContext<object, object>(
-				new Method<object, object>(methodType, string.Empty, string.Empty, _marshaller, _marshaller),
+			new(new Method<object, object>(methodType, string.Empty, string.Empty, _marshaller, _marshaller),
 				null, new CallOptions(new Metadata()));
 
 		private class TestAsyncStreamReader : IAsyncStreamReader<object> {


### PR DESCRIPTION
Added: Set `grpc.max_receive_message_length` to 17MB
Fixed: Force Rediscovery Only when Lost Connection or Unknown error

EventStore allows events of up to 16mb to be written internally. While you can't write events this large through gRPC, you could do so through the TCP client, or through projections. To allow the gRPC clients to read any event that EventStoreDB was able to write, we want to hardcode the max receive message length for all gRPC clients to 17mb.

Some cases where redicovery should have been forced were not handled, are handled now.

Fixes #193