### PR TITLE
Rename SoftDeleteAsync to DeleteAsync

### DIFF
--- a/src/EventStore.Client.Streams/EventStoreClient.Delete.cs
+++ b/src/EventStore.Client.Streams/EventStoreClient.Delete.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging;
 namespace EventStore.Client {
 	public partial class EventStoreClient {
 		/// <summary>
-		/// Soft Deletes a stream asynchronously.
+		/// Deletes a stream asynchronously.
 		/// </summary>
 		/// <param name="streamName">The name of the stream to delete.</param>
 		/// <param name="expectedRevision">The expected <see cref="StreamRevision"/> of the stream being deleted.</param>
@@ -16,7 +16,7 @@ namespace EventStore.Client {
 		/// <param name="userCredentials">The optional <see cref="UserCredentials"/> to perform operation with.</param>
 		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
 		/// <returns></returns>
-		public Task<DeleteResult> SoftDeleteAsync(
+		public Task<DeleteResult> DeleteAsync(
 			string streamName,
 			StreamRevision expectedRevision,
 			Action<EventStoreClientOperationOptions>? configureOperationOptions = null,
@@ -25,11 +25,11 @@ namespace EventStore.Client {
 			var operationOptions = Settings.OperationOptions.Clone();
 			configureOperationOptions?.Invoke(operationOptions);
 
-			return SoftDeleteAsync(streamName, expectedRevision, operationOptions, userCredentials, cancellationToken);
+			return DeleteAsync(streamName, expectedRevision, operationOptions, userCredentials, cancellationToken);
 		}
 
 		/// <summary>
-		/// Soft Deletes a stream asynchronously.
+		/// Deletes a stream asynchronously.
 		/// </summary>
 		/// <param name="streamName">The name of the stream to delete.</param>
 		/// <param name="expectedState">The expected <see cref="StreamState"/> of the stream being deleted.</param>
@@ -37,7 +37,7 @@ namespace EventStore.Client {
 		/// <param name="userCredentials">The optional <see cref="UserCredentials"/> to perform operation with.</param>
 		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
 		/// <returns></returns>
-		public Task<DeleteResult> SoftDeleteAsync(
+		public Task<DeleteResult> DeleteAsync(
 			string streamName,
 			StreamState expectedState,
 			Action<EventStoreClientOperationOptions>? configureOperationOptions = null,
@@ -46,10 +46,10 @@ namespace EventStore.Client {
 			var options = Settings.OperationOptions.Clone();
 			configureOperationOptions?.Invoke(options);
 
-			return SoftDeleteAsync(streamName, expectedState, options, userCredentials, cancellationToken);
+			return DeleteAsync(streamName, expectedState, options, userCredentials, cancellationToken);
 		}
 
-		private Task<DeleteResult> SoftDeleteAsync(
+		private Task<DeleteResult> DeleteAsync(
 			string streamName,
 			StreamState expectedState,
 			EventStoreClientOperationOptions operationOptions,
@@ -61,7 +61,7 @@ namespace EventStore.Client {
 				}
 			}.WithAnyStreamRevision(expectedState), operationOptions, userCredentials, cancellationToken);
 
-		private Task<DeleteResult> SoftDeleteAsync(
+		private Task<DeleteResult> DeleteAsync(
 			string streamName,
 			StreamRevision expectedRevision,
 			EventStoreClientOperationOptions operationOptions,

--- a/test/EventStore.Client.Streams.Tests/append_to_stream.cs
+++ b/test/EventStore.Client.Streams.Tests/append_to_stream.cs
@@ -313,12 +313,12 @@ namespace EventStore.Client {
 		}
 
 		[Fact]
-		public async Task appending_with_stream_exists_expected_version_to_soft_deleted_stream_throws_stream_deleted() {
+		public async Task appending_with_stream_exists_expected_version_to_deleted_stream_throws_stream_deleted() {
 			var stream = _fixture.GetStreamName();
 
 			await _fixture.Client.AppendToStreamAsync(stream, StreamState.NoStream, _fixture.CreateTestEvents());
 
-			await _fixture.Client.SoftDeleteAsync(stream, StreamState.Any);
+			await _fixture.Client.DeleteAsync(stream, StreamState.Any);
 
 			await Assert.ThrowsAsync<StreamDeletedException>(() => _fixture.Client.AppendToStreamAsync(
 				stream,

--- a/test/EventStore.Client.Streams.Tests/delete_stream_with_timeout.cs
+++ b/test/EventStore.Client.Streams.Tests/delete_stream_with_timeout.cs
@@ -14,21 +14,21 @@ namespace EventStore.Client {
 		}
 
 		[Fact]
-		public async Task any_stream_revision_soft_delete_fails_when_operation_expired() {
+		public async Task any_stream_revision_delete_fails_when_operation_expired() {
 			var stream = _fixture.GetStreamName();
 			var rpcException = await Assert.ThrowsAsync<RpcException>(() =>
-				_fixture.Client.SoftDeleteAsync(stream, StreamState.Any,
+				_fixture.Client.DeleteAsync(stream, StreamState.Any,
 					options => options.TimeoutAfter = TimeSpan.Zero));
 
 			Assert.Equal(StatusCode.DeadlineExceeded, rpcException.StatusCode);
 		}
 
 		[Fact]
-		public async Task stream_revision_soft_delete_fails_when_operation_expired() {
+		public async Task stream_revision_delete_fails_when_operation_expired() {
 			var stream = _fixture.GetStreamName();
 
 			var rpcException = await Assert.ThrowsAsync<RpcException>(() =>
-				_fixture.Client.SoftDeleteAsync(stream, new StreamRevision(0),
+				_fixture.Client.DeleteAsync(stream, new StreamRevision(0),
 					options => options.TimeoutAfter = TimeSpan.Zero));
 
 			Assert.Equal(StatusCode.DeadlineExceeded, rpcException.StatusCode);

--- a/test/EventStore.Client.Streams.Tests/deleting_stream.cs
+++ b/test/EventStore.Client.Streams.Tests/deleting_stream.cs
@@ -30,7 +30,7 @@ namespace EventStore.Client {
 
 			await _fixture.Client.AppendToStreamAsync(stream, StreamRevision.None, _fixture.CreateTestEvents());
 
-			await _fixture.Client.SoftDeleteAsync(stream, StreamState.StreamExists);
+			await _fixture.Client.DeleteAsync(stream, StreamState.StreamExists);
 		}
 
 		[Fact]
@@ -46,7 +46,7 @@ namespace EventStore.Client {
 			var stream = _fixture.GetStreamName();
 
 			await Assert.ThrowsAsync<WrongExpectedVersionException>(
-				() => _fixture.Client.SoftDeleteAsync(stream, new StreamRevision(0)));
+				() => _fixture.Client.DeleteAsync(stream, new StreamRevision(0)));
 		}
 
 		[Fact]
@@ -72,7 +72,7 @@ namespace EventStore.Client {
 				StreamState.NoStream,
 				_fixture.CreateTestEvents());
 
-			var deleteResult = await _fixture.Client.SoftDeleteAsync(stream, writeResult.NextExpectedStreamRevision);
+			var deleteResult = await _fixture.Client.DeleteAsync(stream, writeResult.NextExpectedStreamRevision);
 
 			Assert.True(deleteResult.LogPosition > writeResult.LogPosition);
 		}

--- a/test/EventStore.Client.Streams.Tests/read_events_linked_to_deleted_stream.cs
+++ b/test/EventStore.Client.Streams.Tests/read_events_linked_to_deleted_stream.cs
@@ -46,7 +46,7 @@ namespace EventStore.Client {
 						Array.Empty<byte>(), Constants.Metadata.ContentTypes.ApplicationOctetStream)
 				});
 
-				await Client.SoftDeleteAsync(DeletedStream, StreamState.Any);
+				await Client.DeleteAsync(DeletedStream, StreamState.Any);
 			}
 
 			protected override async Task When() {

--- a/test/EventStore.Client.Streams.Tests/soft_deleted_stream.cs
+++ b/test/EventStore.Client.Streams.Tests/soft_deleted_stream.cs
@@ -6,11 +6,11 @@ using Xunit;
 
 namespace EventStore.Client {
 	[Trait("Category", "LongRunning")]
-	public class soft_deleted_stream : IClassFixture<soft_deleted_stream.Fixture> {
+	public class deleted_stream : IClassFixture<deleted_stream.Fixture> {
 		private readonly Fixture _fixture;
 		private readonly JsonDocument _customMetadata;
 
-		public soft_deleted_stream(Fixture fixture) {
+		public deleted_stream(Fixture fixture) {
 			_fixture = fixture;
 
 			var customMetadata = new Dictionary<string, object> {
@@ -33,7 +33,7 @@ namespace EventStore.Client {
 
 			Assert.Equal(new StreamRevision(0), writeResult.NextExpectedStreamRevision);
 
-			await _fixture.Client.SoftDeleteAsync(stream, writeResult.NextExpectedStreamRevision);
+			await _fixture.Client.DeleteAsync(stream, writeResult.NextExpectedStreamRevision);
 
 			await Assert.ThrowsAsync<StreamNotFoundException>(
 				() => _fixture.Client.ReadStreamAsync(Direction.Forwards, stream, StreamPosition.Start)
@@ -57,7 +57,7 @@ namespace EventStore.Client {
 
 			Assert.Equal(new StreamRevision(0), writeResult.NextExpectedStreamRevision);
 
-			await _fixture.Client.SoftDeleteAsync(stream, writeResult.NextExpectedStreamRevision);
+			await _fixture.Client.DeleteAsync(stream, writeResult.NextExpectedStreamRevision);
 
 			var events = _fixture.CreateTestEvents(3).ToArray();
 
@@ -93,7 +93,7 @@ namespace EventStore.Client {
 
 			Assert.Equal(new StreamRevision(0), writeResult.NextExpectedStreamRevision);
 
-			await _fixture.Client.SoftDeleteAsync(stream, writeResult.NextExpectedStreamRevision);
+			await _fixture.Client.DeleteAsync(stream, writeResult.NextExpectedStreamRevision);
 
 			var events = _fixture.CreateTestEvents(3).ToArray();
 
@@ -173,7 +173,7 @@ namespace EventStore.Client {
 
 			Assert.Equal(new StreamRevision(1), writeResult.NextExpectedStreamRevision);
 
-			await _fixture.Client.SoftDeleteAsync(stream, new StreamRevision(1));
+			await _fixture.Client.DeleteAsync(stream, new StreamRevision(1));
 
 			await _fixture.Client.TombstoneAsync(stream, StreamState.Any);
 
@@ -202,7 +202,7 @@ namespace EventStore.Client {
 
 			Assert.Equal(new StreamRevision(1), writeResult.NextExpectedStreamRevision);
 
-			await _fixture.Client.SoftDeleteAsync(stream, new StreamRevision(1));
+			await _fixture.Client.DeleteAsync(stream, new StreamRevision(1));
 
 			writeResult = await _fixture.Client.AppendToStreamAsync(stream, StreamState.NoStream,
 				_fixture.CreateTestEvents(3));
@@ -223,7 +223,7 @@ namespace EventStore.Client {
 
 			Assert.Equal(new StreamRevision(1), writeResult.NextExpectedStreamRevision);
 
-			await _fixture.Client.SoftDeleteAsync(stream, new StreamRevision(1));
+			await _fixture.Client.DeleteAsync(stream, new StreamRevision(1));
 
 			writeResult = await _fixture.Client.AppendToStreamAsync(stream, StreamState.NoStream,
 				_fixture.CreateTestEvents(3));
@@ -246,7 +246,7 @@ namespace EventStore.Client {
 
 			Assert.Equal(new StreamRevision(1), writeResult.NextExpectedStreamRevision);
 
-			await _fixture.Client.SoftDeleteAsync(stream, new StreamRevision(1));
+			await _fixture.Client.DeleteAsync(stream, new StreamRevision(1));
 
 			var firstEvents = _fixture.CreateTestEvents(3).ToArray();
 			var secondEvents = _fixture.CreateTestEvents(2).ToArray();
@@ -325,7 +325,7 @@ namespace EventStore.Client {
 
 			Assert.Equal(new StreamRevision(1), writeResult.NextExpectedStreamRevision);
 
-			await _fixture.Client.SoftDeleteAsync(stream, writeResult.NextExpectedStreamRevision);
+			await _fixture.Client.DeleteAsync(stream, writeResult.NextExpectedStreamRevision);
 
 			writeResult = await _fixture.Client.SetStreamMetadataAsync(
 				stream,


### PR DESCRIPTION
changed: Rename `SoftDeleteAsync` to `DeleteAsync`.

This brings the streams API into compliance with the minimum viable tier.
Fixes https://github.com/eventstore/eventstore-client-dotnet/issues/148