### PR TITLE
Align persistent subscription names with RFC

### DIFF
--- a/samples/persistent-subscriptions/Program.cs
+++ b/samples/persistent-subscriptions/Program.cs
@@ -95,7 +95,7 @@ namespace persistent_subscriptions
 		    var userCredentials = new UserCredentials("admin", "changeit");
 		    var settings = new PersistentSubscriptionSettings(
 			    resolveLinkTos: true,
-			    minCheckPointCount: 20);
+			    checkPointLowerBound: 20);
 
 		    await client.UpdateAsync(
 			    "test-stream",

--- a/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClient.Create.cs
+++ b/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClient.Create.cs
@@ -206,11 +206,11 @@ namespace EventStore.Client {
 						ResolveLinks = settings.ResolveLinkTos,
 						HistoryBufferSize = settings.HistoryBufferSize,
 						LiveBufferSize = settings.LiveBufferSize,
-						MaxCheckpointCount = settings.MaxCheckPointCount,
+						MaxCheckpointCount = settings.CheckPointUpperBound,
 						MaxRetryCount = settings.MaxRetryCount,
 						MaxSubscriberCount = settings.MaxSubscriberCount,
-						MinCheckpointCount = settings.MinCheckPointCount,
-						NamedConsumerStrategy = NamedConsumerStrategyToCreateProto[settings.NamedConsumerStrategy],
+						MinCheckpointCount = settings.CheckPointLowerBound,
+						NamedConsumerStrategy = NamedConsumerStrategyToCreateProto[settings.ConsumerStrategyName],
 						ReadBatchSize = settings.ReadBatchSize
 					}
 				}

--- a/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClient.Update.cs
+++ b/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClient.Update.cs
@@ -131,12 +131,12 @@ namespace EventStore.Client {
 								ResolveLinks = settings.ResolveLinkTos,
 								HistoryBufferSize = settings.HistoryBufferSize,
 								LiveBufferSize = settings.LiveBufferSize,
-								MaxCheckpointCount = settings.MaxCheckPointCount,
+								MaxCheckpointCount = settings.CheckPointUpperBound,
 								MaxRetryCount = settings.MaxRetryCount,
 								MaxSubscriberCount = settings.MaxSubscriberCount,
-								MinCheckpointCount = settings.MinCheckPointCount,
+								MinCheckpointCount = settings.CheckPointLowerBound,
 								NamedConsumerStrategy =
-									NamedConsumerStrategyToUpdateProto[settings.NamedConsumerStrategy],
+									NamedConsumerStrategyToUpdateProto[settings.ConsumerStrategyName],
 								ReadBatchSize = settings.ReadBatchSize
 							}
 						}

--- a/src/EventStore.Client.PersistentSubscriptions/PersistentSubscriptionSettings.cs
+++ b/src/EventStore.Client.PersistentSubscriptions/PersistentSubscriptionSettings.cs
@@ -52,14 +52,14 @@ namespace EventStore.Client {
 		public readonly TimeSpan CheckPointAfter;
 
 		/// <summary>
-		/// The minimum number of messages to write to a checkpoint.
+		/// The minimum number of messages to process before a checkpoint may be written.
 		/// </summary>
-		public readonly int MinCheckPointCount;
+		public readonly int CheckPointLowerBound;
 
 		/// <summary>
 		/// The maximum number of messages not checkpointed before forcing a checkpoint.
 		/// </summary>
-		public readonly int MaxCheckPointCount;
+		public readonly int CheckPointUpperBound;
 
 		/// <summary>
 		/// The maximum number of subscribers allowed.
@@ -69,7 +69,7 @@ namespace EventStore.Client {
 		/// <summary>
 		/// The strategy to use for distributing events to client consumers. See <see cref="SystemConsumerStrategies"/> for system supported strategies.
 		/// </summary>
-		public readonly string NamedConsumerStrategy;
+		public readonly string ConsumerStrategyName;
 
 		/// <summary>
 		/// Constructs a new <see cref="PersistentSubscriptionSettings"/>.
@@ -83,16 +83,16 @@ namespace EventStore.Client {
 		/// <param name="readBatchSize"></param>
 		/// <param name="historyBufferSize"></param>
 		/// <param name="checkPointAfter"></param>
-		/// <param name="minCheckPointCount"></param>
-		/// <param name="maxCheckPointCount"></param>
+		/// <param name="checkPointLowerBound"></param>
+		/// <param name="checkPointUpperBound"></param>
 		/// <param name="maxSubscriberCount"></param>
-		/// <param name="namedConsumerStrategy"></param>
+		/// <param name="consumerStrategyName"></param>
 		/// <exception cref="ArgumentOutOfRangeException"></exception>
 		public PersistentSubscriptionSettings(bool resolveLinkTos = false, IPosition? startFrom = null,
 			bool extraStatistics = false, TimeSpan? messageTimeout = null, int maxRetryCount = 10,
 			int liveBufferSize = 500, int readBatchSize = 20, int historyBufferSize = 500,
-			TimeSpan? checkPointAfter = null, int minCheckPointCount = 10, int maxCheckPointCount = 1000,
-			int maxSubscriberCount = 0, string namedConsumerStrategy = SystemConsumerStrategies.RoundRobin) {
+			TimeSpan? checkPointAfter = null, int checkPointLowerBound = 10, int checkPointUpperBound = 1000,
+			int maxSubscriberCount = 0, string consumerStrategyName = SystemConsumerStrategies.RoundRobin) {
 			messageTimeout ??= TimeSpan.FromSeconds(30);
 			checkPointAfter ??= TimeSpan.FromSeconds(2);
 
@@ -117,10 +117,10 @@ namespace EventStore.Client {
 			ReadBatchSize = readBatchSize;
 			HistoryBufferSize = historyBufferSize;
 			CheckPointAfter = checkPointAfter.Value;
-			MinCheckPointCount = minCheckPointCount;
-			MaxCheckPointCount = maxCheckPointCount;
+			CheckPointLowerBound = checkPointLowerBound;
+			CheckPointUpperBound = checkPointUpperBound;
 			MaxSubscriberCount = maxSubscriberCount;
-			NamedConsumerStrategy = namedConsumerStrategy;
+			ConsumerStrategyName = consumerStrategyName;
 		}
 	}
 }

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/update_existing_with_check_point.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/update_existing_with_check_point.cs
@@ -50,7 +50,7 @@ namespace EventStore.Client.SubscriptionToAll {
 
 				await Client.CreateToAllAsync(Group,
 					new PersistentSubscriptionSettings(
-						minCheckPointCount: 5,
+						checkPointLowerBound: 5,
 						checkPointAfter: TimeSpan.FromSeconds(1),
 						startFrom: Position.Start),
 					TestCredentials.Root);

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/update_existing_with_check_point_filtered.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/update_existing_with_check_point_filtered.cs
@@ -51,7 +51,7 @@ namespace EventStore.Client.SubscriptionToAll {
 				await Client.CreateToAllAsync(Group,
 					StreamFilter.Prefix("test"),
 					new PersistentSubscriptionSettings(
-						minCheckPointCount: 5,
+						checkPointLowerBound: 5,
 						checkPointAfter: TimeSpan.FromSeconds(1),
 						startFrom: Position.Start),
 					TestCredentials.Root);

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/when_writing_and_filtering_out_events.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/when_writing_and_filtering_out_events.cs
@@ -54,7 +54,7 @@ namespace EventStore.Client.SubscriptionToAll {
 				await Client.CreateToAllAsync(Group,
 					StreamFilter.Prefix("test"),
 					new PersistentSubscriptionSettings(
-						minCheckPointCount: 5,
+						checkPointLowerBound: 5,
 						checkPointAfter: TimeSpan.FromSeconds(1),
 						startFrom: Position.Start),
 					TestCredentials.Root);

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/update_existing_with_check_point.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/update_existing_with_check_point.cs
@@ -51,7 +51,7 @@ namespace EventStore.Client.SubscriptionToStream {
 
 				await Client.CreateAsync(Stream, Group,
 					new PersistentSubscriptionSettings(
-						minCheckPointCount: 5,
+						checkPointLowerBound: 5,
 						checkPointAfter: TimeSpan.FromSeconds(1),
 						startFrom: StreamPosition.Start),
 					TestCredentials.Root);


### PR DESCRIPTION
Changed: Rename `MaxCheckpointCount` to `CheckPointUpperBound`
Changed: Rename `MinCheckpointCount` to `CheckPointLowerBound`
Changed: Rename `NamedConsumerStrategy` to `ConsumerStrategyName`

Aligns the setting names with the ones in the Persistent Subscriptions RFC.

Fixes https://github.com/EventStore/EventStore-Client-Dotnet/issues/164