### PR TITLE
Workaround For Issue w/ dotnet tool restore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
     - name: Scan for Vulnerabilities
       shell: bash
       run: |
+        dotnet nuget list source
         dotnet restore
         dotnet list package --vulnerable --include-transitive --framework ${{ matrix.framework }} | tee vulnerabilities.txt
         ! cat vulnerabilities.txt | grep -q "has the following vulnerable packages"
@@ -143,7 +144,7 @@ jobs:
       id: get_version
       run: | 
         echo "::set-output name=branch::${GITHUB_REF:10}"
-        
+        dotnet nuget list source  
         dotnet tool restore
         version=$(dotnet tool run minver -- --tag-prefix=v)
         echo "::set-output name=version::${version}"
@@ -180,5 +181,6 @@ jobs:
       shell: bash
       if: contains(steps.get_version.outputs.branch, 'v')
       run: |
+        dotnet nuget list source
         dotnet tool restore
         find . -name "*.nupkg" | xargs -n1 dotnet nuget push --api-key=${{ secrets.nuget_key }} --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
There is an [open issue](https://github.com/NuGet/Home/issues/7503) with `dotnet tool restore`, resulting in

> /usr/share/dotnet/sdk/6.0.200/NuGet.targets(564,5): error : The process cannot access the file '/home/runner/.nuget/NuGet/nugetorgadd.trk' because it is being used by another process. [/tmp/w5mpvqp3.lzr/restore.csproj]

when trying to publish. Applying the workaround in the above mentioned issue.
