### PR TITLE
Enable multiple http2 connections

### DIFF
--- a/src/EventStore.Client/EventStoreClientSettings.ConnectionString.cs
+++ b/src/EventStore.Client/EventStoreClientSettings.ConnectionString.cs
@@ -201,7 +201,8 @@ namespace EventStore.Client {
 				settings.CreateHttpMessageHandler = () => {
 					var handler = new SocketsHttpHandler {
 						KeepAlivePingDelay = settings.ConnectivitySettings.KeepAliveInterval,
-						KeepAlivePingTimeout = settings.ConnectivitySettings.KeepAliveTimeout
+						KeepAlivePingTimeout = settings.ConnectivitySettings.KeepAliveTimeout,
+						EnableMultipleHttp2Connections = true,
 					};
 
 					if (typedOptions.TryGetValue(TlsVerifyCert, out var tlsVerifyCert) && !(bool)tlsVerifyCert) {


### PR DESCRIPTION
Allows channels to open extra connections if they reach the max streams per connection limit (i.e. too may concurrent grpc calls- 100 by default)