### PR TITLE
Fix client blocking when subscribing to persistent subscription after leader node failure

### DIFF
--- a/src/EventStore.Client/EventStoreClientBase.cs
+++ b/src/EventStore.Client/EventStoreClientBase.cs
@@ -87,8 +87,10 @@ namespace EventStore.Client {
 		}
 
 #pragma warning disable 1591
-		protected async ValueTask<ChannelInfo> GetChannelInfo(CancellationToken cancellationToken) =>
-			await _channelInfoProvider.CurrentAsync.WithCancellation(cancellationToken).ConfigureAwait(false);
+		protected async ValueTask<ChannelInfo> GetChannelInfo(CancellationToken cancellationToken) {
+			_channelInfoProvider.Reset();
+			return await _channelInfoProvider.CurrentAsync.WithCancellation(cancellationToken).ConfigureAwait(false);
+		}
 #pragma warning restore 1591
 
 		// only exists so that we can manually trigger rediscovery in the tests (by reflection)


### PR DESCRIPTION
Fix client blocking when subscribing to persistent subscription after leader node failure.

Issue: https://github.com/EventStore/EventStore/issues/3535