### PR TITLE
Fix incorrect error message when deleting a stream using gRPC

### DIFF
--- a/src/EventStore.Client.Streams/EventStoreClient.cs
+++ b/src/EventStore.Client.Streams/EventStoreClient.cs
@@ -44,7 +44,7 @@ namespace EventStore.Client {
 				ex.Trailers.FirstOrDefault(x => x.Key == Constants.Exceptions.StreamName)?.Value!,
 				ex.Trailers.GetStreamRevision(Constants.Exceptions.ExpectedVersion),
 				ex.Trailers.GetStreamRevision(Constants.Exceptions.ActualVersion),
-				ex),
+				ex, ex.Message),
 			[Constants.Exceptions.MaximumAppendSizeExceeded] = ex =>
 				new MaximumAppendSizeExceededException(
 					ex.Trailers.GetIntValueOrDefault(Constants.Exceptions.MaximumAppendSize), ex),

--- a/src/EventStore.Client/Exceptions/WrongExpectedVersionException.cs
+++ b/src/EventStore.Client/Exceptions/WrongExpectedVersionException.cs
@@ -35,9 +35,9 @@ namespace EventStore.Client {
 		/// Constructs a new instance of <see cref="WrongExpectedVersionException" /> with the expected and actual versions if available.
 		/// </summary>
 		public WrongExpectedVersionException(string streamName, StreamRevision expectedStreamRevision,
-			StreamRevision actualStreamRevision, Exception? exception = null) :
+			StreamRevision actualStreamRevision, Exception? exception = null, string? message = null) :
 			base(
-				$"Append failed due to WrongExpectedVersion. Stream: {streamName}, Expected version: {expectedStreamRevision}, Actual version: {actualStreamRevision}",
+				message ?? $"Append failed due to WrongExpectedVersion. Stream: {streamName}, Expected version: {expectedStreamRevision}, Actual version: {actualStreamRevision}",
 				exception) {
 			StreamName = streamName;
 			ActualStreamRevision = actualStreamRevision;


### PR DESCRIPTION
Fixed: Incorrect error message when deleting a stream using gRPC.