### PR TITLE
Add .NET Standard 2.0 support

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -13,7 +13,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        framework: [netcoreapp3.1, net5.0, net6.0]
+        framework: [netstandard2.0, net5.0, net6.0]
+        include:
+          - test_framework: netcoreapp3.1
+            framework: netstandard2.0
+          - test_framework: net5.0
+            framework: net5.0
+          - test_framework: net6.0
+            framework: net6.0
         os: [ubuntu-latest]
         test: [Streams, PersistentSubscriptions, Operations, UserManagement, ProjectionManagement]
         configuration: [release]
@@ -49,7 +56,7 @@ jobs:
           dotnet test --configuration ${{ matrix.configuration }} --blame \
             --logger:"GitHubActions;report-warnings=false" --logger:html --logger:trx --logger:"console;verbosity=normal" \
             --results-directory=$(pwd)/test-results/test/EventStore.Client.${{ matrix.test }}.Tests \
-            --framework ${{ matrix.framework }} \
+            --framework ${{ matrix.test_framework }} \
             test/EventStore.Client.${{ matrix.test }}.Tests
       - name: Collect Test Results
         shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        framework: [ netcoreapp3.1, net5.0, net6.0 ]
+        framework: [netstandard2.0, net5.0, net6.0]
         os: [ ubuntu-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     name: scan-vulnerabilities/${{ matrix.os }}/${{ matrix.framework }}
@@ -74,7 +74,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        framework: [netcoreapp3.1, net5.0, net6.0]
+        framework: [netstandard2.0, net5.0, net6.0]
+        include:
+          - test_framework: netcoreapp3.1
+            framework: netstandard2.0
+          - test_framework: net5.0
+            framework: net5.0
+          - test_framework: net6.0
+            framework: net6.0
         os: [ubuntu-latest, windows-latest]
         configuration: [release]
     runs-on: ${{ matrix.os }}
@@ -102,7 +109,7 @@ jobs:
           dotnet test --configuration ${{ matrix.configuration }} --blame \
             --logger:"GitHubActions;report-warnings=false" --logger:html --logger:trx --logger:"console;verbosity=normal" \
             --results-directory=$(pwd)/test-results/test/EventStore.Client.Tests \
-            --framework ${{ matrix.framework }} \
+            --framework ${{ matrix.test_framework }} \
             test/EventStore.Client.Tests
       - name: Collect Test Results
         shell: bash

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
 		<Platform>x64</Platform>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Nullable>enable</Nullable>
@@ -17,7 +16,7 @@
 		<GrpcCorePackageVersion>2.44.0</GrpcCorePackageVersion>
 		<GrpcToolsPackageVersion>2.44.0</GrpcToolsPackageVersion>
 	</PropertyGroup>
-	<PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-		<DefineConstants>$(DefineConstants);GRPC_CORE</DefineConstants>
+	<PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+		<DefineConstants>$(DefineConstants);GRPC_NETSTANDARD</DefineConstants>
 	</PropertyGroup>
 </Project>

--- a/samples/persistent-subscriptions/persistent-subscriptions.csproj
+++ b/samples/persistent-subscriptions/persistent-subscriptions.csproj
@@ -11,5 +11,8 @@
 			<ProjectReference Include="..\..\src\EventStore.Client.PersistentSubscriptions\EventStore.Client.PersistentSubscriptions.csproj" />
 			<ProjectReference Include="..\..\src\EventStore.Client\EventStore.Client.csproj" />
     </ItemGroup>
+	  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+		  <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+	  </ItemGroup>
 
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,6 +15,7 @@
 			Link="protos/$(ESProto)"/>
 	</ItemGroup>
 	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
 		<PackageIcon>ouro.png</PackageIcon>
 		<PackageLicenseFile>LICENSE.md</PackageLicenseFile>
 		<PackageProjectUrl>https://eventstore.com</PackageProjectUrl>

--- a/src/EventStore.Client.Common/EpochExtensions.cs
+++ b/src/EventStore.Client.Common/EpochExtensions.cs
@@ -2,7 +2,11 @@ using System;
 
 namespace EventStore.Client {
 	internal static class EpochExtensions {
+#if !GRPC_NETSTANDARD
 		private static readonly DateTime UnixEpoch = DateTime.UnixEpoch;
+#else
+		private static readonly DateTime UnixEpoch = DateTimeOffset.FromUnixTimeSeconds(0).DateTime;
+#endif
 
 		public static DateTime FromTicksSinceEpoch(this long value) =>
 			new DateTime(UnixEpoch.Ticks + value, DateTimeKind.Utc);

--- a/src/EventStore.Client.Operations/EventStoreOperationsClientServiceCollectionExtensions.cs
+++ b/src/EventStore.Client.Operations/EventStoreOperationsClientServiceCollectionExtensions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.DependencyInjection {
 	/// A set of extension methods for <see cref="IServiceCollection"/> which provide support for an <see cref="EventStoreOperationsClient"/>.
 	/// </summary>
 	public static class EventStoreOperationsClientServiceCollectionExtensions {
-#if GRPC_CORE
+#if GRPC_NETSTANDARD
 		/// <summary>
 		/// Adds an <see cref="EventStoreOperationsClient"/> to the <see cref="IServiceCollection"/>.
 		/// </summary>

--- a/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClientCollectionExtensions.cs
+++ b/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClientCollectionExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Extensions.DependencyInjection {
 	/// A set of extension methods for <see cref="IServiceCollection"/> which provide support for an <see cref="EventStorePersistentSubscriptionsClient"/>.
 	/// </summary>
 	public static class EventStorePersistentSubscriptionsClientCollectionExtensions {
-#if GRPC_CORE
+#if GRPC_NETSTANDARD
 		/// <summary>
 		/// Adds an <see cref="EventStorePersistentSubscriptionsClient"/> to the <see cref="IServiceCollection"/>.
 		/// </summary>

--- a/src/EventStore.Client.PersistentSubscriptions/PersistentSubscription.cs
+++ b/src/EventStore.Client.PersistentSubscriptions/PersistentSubscription.cs
@@ -34,7 +34,7 @@ namespace EventStore.Client {
 			CancellationToken cancellationToken = default) {
 
 			var cts =
-#if GRPC_CORE
+#if GRPC_NETSTANDARD
 					CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ((Channel)channel).ShutdownToken);
 #else
 					CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);

--- a/src/EventStore.Client.ProjectionManagement/EventStoreProjectionManagementClient.State.cs
+++ b/src/EventStore.Client.ProjectionManagement/EventStoreProjectionManagementClient.State.cs
@@ -24,8 +24,8 @@ namespace EventStore.Client {
 			var value = await GetResultInternalAsync(name, partition, deadline, userCredentials, cancellationToken)
 				.ConfigureAwait(false);
 
-			await using var stream = new MemoryStream();
-			await using var writer = new Utf8JsonWriter(stream);
+			using var stream = new MemoryStream();
+			using var writer = new Utf8JsonWriter(stream);
 			var serializer = new ValueSerializer();
 			serializer.Write(writer, value, new JsonSerializerOptions());
 			await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
@@ -51,8 +51,8 @@ namespace EventStore.Client {
 			CancellationToken cancellationToken = default) {
 			var value = await GetResultInternalAsync(name, partition, deadline, userCredentials, cancellationToken)
 				.ConfigureAwait(false);
-			await using var stream = new MemoryStream();
-			await using var writer = new Utf8JsonWriter(stream);
+			using var stream = new MemoryStream();
+			using var writer = new Utf8JsonWriter(stream);
 			var serializer = new ValueSerializer();
 			serializer.Write(writer, value, new JsonSerializerOptions());
 			await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
@@ -91,8 +91,8 @@ namespace EventStore.Client {
 			var value = await GetStateInternalAsync(name, partition, deadline, userCredentials, cancellationToken)
 				.ConfigureAwait(false);
 
-			await using var stream = new MemoryStream();
-			await using var writer = new Utf8JsonWriter(stream);
+			using var stream = new MemoryStream();
+			using var writer = new Utf8JsonWriter(stream);
 			var serializer = new ValueSerializer();
 			serializer.Write(writer, value, new JsonSerializerOptions());
 			stream.Position = 0;
@@ -118,8 +118,8 @@ namespace EventStore.Client {
 			var value = await GetStateInternalAsync(name, partition, deadline, userCredentials, cancellationToken)
 				.ConfigureAwait(false);
 
-			await using var stream = new MemoryStream();
-			await using var writer = new Utf8JsonWriter(stream);
+			using var stream = new MemoryStream();
+			using var writer = new Utf8JsonWriter(stream);
 			var serializer = new ValueSerializer();
 			serializer.Write(writer, value, new JsonSerializerOptions());
 			await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
@@ -173,9 +173,9 @@ namespace EventStore.Client {
 						break;
 					case Value.KindOneofCase.StructValue:
 						writer.WriteStartObject();
-						foreach (var (name, item) in value.StructValue.Fields) {
-							writer.WritePropertyName(name);
-							Write(writer, item, options);
+						foreach (var entry in value.StructValue.Fields) {
+							writer.WritePropertyName(entry.Key);
+							Write(writer, entry.Value, options);
 						}
 
 						writer.WriteEndObject();

--- a/src/EventStore.Client.ProjectionManagement/EventStoreProjectionManagementClientCollectionExtensions.cs
+++ b/src/EventStore.Client.ProjectionManagement/EventStoreProjectionManagementClientCollectionExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Extensions.DependencyInjection {
 	/// A set of extension methods for <see cref="IServiceCollection"/> which provide support for an <see cref="EventStoreProjectionManagementClient"/>.
 	/// </summary>
 	public static class EventStoreProjectionManagementClientCollectionExtensions {
-#if GRPC_CORE
+#if GRPC_NETSTANDARD
 		/// <summary>
 		/// Adds an <see cref="EventStoreProjectionManagementClient"/> to the <see cref="IServiceCollection"/>.
 		/// </summary>

--- a/src/EventStore.Client.Streams/EventStore.Client.Streams.csproj
+++ b/src/EventStore.Client.Streams/EventStore.Client.Streams.csproj
@@ -3,4 +3,7 @@
 	<PropertyGroup>
 		<Description>The GRPC client API for Event Store Streams. Get the open source or commercial versions of Event Store server from https://eventstore.com/</Description>
 	</PropertyGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+		<PackageReference Include="System.Threading.Channels" Version="6.0.0" />
+	</ItemGroup>
 </Project>

--- a/src/EventStore.Client.Streams/EventStoreClient.cs
+++ b/src/EventStore.Client.Streams/EventStoreClient.cs
@@ -158,7 +158,7 @@ namespace EventStore.Client {
 			return options;
 		}
 
-#if !GRPC_CORE && NET5_0_OR_GREATER
+#if !GRPC_NETSTANDARD && NET5_0_OR_GREATER
 		/// <inheritdoc />
 		public override void Dispose() {
 			if (_streamAppenderLazy.IsValueCreated)

--- a/src/EventStore.Client.Streams/EventStoreClientServiceCollectionExtensions.cs
+++ b/src/EventStore.Client.Streams/EventStoreClientServiceCollectionExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Extensions.DependencyInjection {
 	/// A set of extension methods for <see cref="IServiceCollection"/> which provide support for an <see cref="EventStoreClient"/>.
 	/// </summary>
 	public static class EventStoreClientServiceCollectionExtensions {
-#if GRPC_CORE
+#if GRPC_NETSTANDARD
 		/// <summary>
 		/// Adds an <see cref="EventStoreClient"/> to the <see cref="IServiceCollection"/>.
 		/// </summary>

--- a/src/EventStore.Client.UserManagement/EventStoreUserManagementClientCollectionExtensions.cs
+++ b/src/EventStore.Client.UserManagement/EventStoreUserManagementClientCollectionExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Extensions.DependencyInjection {
 	/// A set of extension methods for <see cref="IServiceCollection"/> which provide support for an <see cref="EventStoreUserManagementClient"/>.
 	/// </summary>
 	public static class EventStoreUserManagementClientCollectionExtensions {
-#if GRPC_CORE
+#if GRPC_NETSTANDARD
 		/// <summary>
 		/// Adds an <see cref="EventStoreUserManagementClient"/> to the <see cref="IServiceCollection"/>.
 		/// </summary>

--- a/src/EventStore.Client/ChannelCache.cs
+++ b/src/EventStore.Client/ChannelCache.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 
-#if GRPC_CORE
+#if GRPC_NETSTANDARD
 using TChannel = Grpc.Core.ChannelBase;
 #else
 using TChannel = Grpc.Net.Client.GrpcChannel;
@@ -15,7 +15,7 @@ namespace EventStore.Client {
 	// Deals with the disposal difference between grpc.net and grpc.core
 	// Thread safe.
 	internal class ChannelCache :
-#if !GRPC_CORE
+#if !GRPC_NETSTANDARD
 		IDisposable, // for grpc.net we can dispose synchronously, but not for grpc.core
 #endif
 		IAsyncDisposable {
@@ -88,7 +88,7 @@ namespace EventStore.Client {
 			}
 		}
 
-#if !GRPC_CORE
+#if !GRPC_NETSTANDARD
 		public void Dispose() {
 			lock (_lock) {
 				if (_disposed)

--- a/src/EventStore.Client/ChannelFactory.cs
+++ b/src/EventStore.Client/ChannelFactory.cs
@@ -1,6 +1,6 @@
 using System;
 using EndPoint = System.Net.EndPoint;
-#if !GRPC_CORE
+#if !GRPC_NETSTANDARD
 using System.Net.Http;
 using Grpc.Net.Client;
 using TChannel = Grpc.Net.Client.GrpcChannel;
@@ -20,7 +20,7 @@ namespace EventStore.Client {
 		public static TChannel CreateChannel(EventStoreClientSettings settings, Uri? address) {
 			address ??= settings.ConnectivitySettings.Address;
 
-#if !GRPC_CORE
+#if !GRPC_NETSTANDARD
 			if (address.Scheme == Uri.UriSchemeHttp ||settings.ConnectivitySettings.Insecure) {
 				//this must be switched on before creation of the HttpMessageHandler
 				AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);

--- a/src/EventStore.Client/EventStore.Client.csproj
+++ b/src/EventStore.Client/EventStore.Client.csproj
@@ -11,11 +11,11 @@
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
 		<PackageReference Include="System.Linq.Async" Version="6.0.1" />
 	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
 		<PackageReference Include="Grpc.Core" Version="$(GrpcCorePackageVersion)" />
 		<PackageReference Include="System.Text.Json" Version="6.0.2" />
 	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+	<ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
 		<PackageReference Include="Grpc.Net.Client" Version="$(GrpcPackageVersion)" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/EventStore.Client/EventStoreClientBase.cs
+++ b/src/EventStore.Client/EventStoreClientBase.cs
@@ -12,7 +12,7 @@ namespace EventStore.Client {
 	/// The base class used by clients used to communicate with the EventStoreDB.
 	/// </summary>
 	public abstract class EventStoreClientBase :
-#if !GRPC_CORE
+#if !GRPC_NETSTANDARD
 		IDisposable, // for grpc.net we can dispose synchronously, but not for grpc.core
 #endif
 		IAsyncDisposable {
@@ -101,7 +101,7 @@ namespace EventStore.Client {
 			_channelInfoProvider.Reset();
 		}
 
-#if !GRPC_CORE
+#if !GRPC_NETSTANDARD
 		/// <inheritdoc />
 		public virtual void Dispose() {
 			_cts.Cancel();

--- a/src/EventStore.Client/EventStoreClientSettings.ConnectionString.cs
+++ b/src/EventStore.Client/EventStoreClientSettings.ConnectionString.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using Timeout_ = System.Threading.Timeout;
-#if !GRPC_CORE
+#if !GRPC_NETSTANDARD
 using System.Net.Http;
 #endif
 
@@ -118,19 +118,19 @@ namespace EventStore.Client {
 					settings.DefaultCredentials = new UserCredentials(userInfo.Value.user, userInfo.Value.pass);
 
 				var typedOptions = new Dictionary<string, object>(StringComparer.InvariantCultureIgnoreCase);
-				foreach (var (key, value) in options) {
-					if (!SettingsType.TryGetValue(key, out var type))
-						throw new InvalidSettingException($"Unknown option: {key}");
+				foreach (var kv in options) {
+					if (!SettingsType.TryGetValue(kv.Key, out var type))
+						throw new InvalidSettingException($"Unknown option: {kv.Key}");
 					if (type == typeof(int)) {
-						if (!int.TryParse(value, out var intValue))
-							throw new InvalidSettingException($"{key} must be an integer value");
-						typedOptions.Add(key, intValue);
+						if (!int.TryParse(kv.Value, out var intValue))
+							throw new InvalidSettingException($"{kv.Key} must be an integer value");
+						typedOptions.Add(kv.Key, intValue);
 					} else if (type == typeof(bool)) {
-						if (!bool.TryParse(value, out var boolValue))
-							throw new InvalidSettingException($"{key} must be either true or false");
-						typedOptions.Add(key, boolValue);
+						if (!bool.TryParse(kv.Value, out var boolValue))
+							throw new InvalidSettingException($"{kv.Key} must be either true or false");
+						typedOptions.Add(kv.Key, boolValue);
 					} else if (type == typeof(string)) {
-						typedOptions.Add(key, value);
+						typedOptions.Add(kv.Key, kv.Value);
 					}
 				}
 
@@ -197,7 +197,7 @@ namespace EventStore.Client {
 						connSettings.IpGossipSeeds = Array.ConvertAll(hosts, x => (IPEndPoint)x);
 				}
 
-#if !GRPC_CORE
+#if !GRPC_NETSTANDARD
 				settings.CreateHttpMessageHandler = () => {
 					var handler = new SocketsHttpHandler {
 						KeepAlivePingDelay = settings.ConnectivitySettings.KeepAliveInterval,

--- a/src/EventStore.Client/StreamIdentifier.cs
+++ b/src/EventStore.Client/StreamIdentifier.cs
@@ -12,7 +12,11 @@ namespace EventStore.Client {
 			}
 			if (source._cached != null || source.StreamName.IsEmpty) return source._cached;
 
+#if !GRPC_NETSTANDARD
 			var tmp = Encoding.UTF8.GetString(source.StreamName.Span);
+#else
+			var tmp = Encoding.UTF8.GetString(source.StreamName.Span.ToArray());
+#endif
 			//this doesn't have to be thread safe, its just a cache in case the identifier is turned into a string several times
 			source._cached = tmp;
 			return source._cached;

--- a/src/EventStore.Client/SystemStreams.cs
+++ b/src/EventStore.Client/SystemStreams.cs
@@ -42,13 +42,13 @@ namespace EventStore.Client {
 		/// </summary>
 		/// <param name="streamId"></param>
 		/// <returns></returns>
-		public static bool IsMetastream(string streamId) => streamId[..2] == "$$";
+		public static bool IsMetastream(string streamId) => streamId[0] == '$' && streamId[1] == '$';
 
 		/// <summary>
 		/// Returns the original stream of the metadata stream.
 		/// </summary>
 		/// <param name="metastreamId"></param>
 		/// <returns></returns>
-		public static string OriginalStreamOf(string metastreamId) => metastreamId[2..];
+		public static string OriginalStreamOf(string metastreamId) => metastreamId.Substring(2);
 	}
 }

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,10 +1,11 @@
 <Project>
 	<Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 	<PropertyGroup>
+		<TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
 		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-		<DefineConstants>$(DefineConstants);GRPC_CORE</DefineConstants>
+		<DefineConstants>$(DefineConstants);GRPC_NETSTANDARD</DefineConstants>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="AutoFixture.Idioms" Version="4.17.0" />

--- a/test/EventStore.Client.Operations.Tests/EventStore.Client.Operations.Tests.csproj
+++ b/test/EventStore.Client.Operations.Tests/EventStore.Client.Operations.Tests.csproj
@@ -5,4 +5,7 @@
 		<ProjectReference Include="..\..\src\EventStore.Client.Streams\EventStore.Client.Streams.csproj" />
 		<ProjectReference Include="..\..\src\EventStore.Client.UserManagement\EventStore.Client.UserManagement.csproj" />
 	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+	</ItemGroup>
 </Project>

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/EventStore.Client.PersistentSubscriptions.Tests.csproj
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/EventStore.Client.PersistentSubscriptions.Tests.csproj
@@ -5,4 +5,7 @@
 		<ProjectReference Include="..\..\src\EventStore.Client.Streams\EventStore.Client.Streams.csproj" />
 		<ProjectReference Include="..\..\src\EventStore.Client.UserManagement\EventStore.Client.UserManagement.csproj" />
 	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+	</ItemGroup>
 </Project>

--- a/test/EventStore.Client.ProjectionManagement.Tests/EventStore.Client.ProjectionManagement.Tests.csproj
+++ b/test/EventStore.Client.ProjectionManagement.Tests/EventStore.Client.ProjectionManagement.Tests.csproj
@@ -5,4 +5,7 @@
 		<ProjectReference Include="..\..\src\EventStore.Client.Streams\EventStore.Client.Streams.csproj" />
 		<ProjectReference Include="..\..\src\EventStore.Client.UserManagement\EventStore.Client.UserManagement.csproj" />
 	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+	</ItemGroup>
 </Project>

--- a/test/EventStore.Client.Streams.Tests/EventStore.Client.Streams.Tests.csproj
+++ b/test/EventStore.Client.Streams.Tests/EventStore.Client.Streams.Tests.csproj
@@ -4,4 +4,7 @@
 		<ProjectReference Include="..\..\src\EventStore.Client.Streams\EventStore.Client.Streams.csproj" />
 		<ProjectReference Include="..\..\src\EventStore.Client.UserManagement\EventStore.Client.UserManagement.csproj" />
 	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+	</ItemGroup>
 </Project>

--- a/test/EventStore.Client.Streams.Tests/read_stream_backward.cs
+++ b/test/EventStore.Client.Streams.Tests/read_stream_backward.cs
@@ -136,7 +136,7 @@ namespace EventStore.Client {
 				.ToArrayAsync();
 
 			Assert.Single(events);
-			Assert.True(EventDataComparer.Equal(testEvents[^1], events[0]));
+			Assert.True(EventDataComparer.Equal(testEvents[testEvents.Length-1], events[0]));
 		}
 
 		[Fact]

--- a/test/EventStore.Client.Streams.Tests/read_stream_backward_messages.cs
+++ b/test/EventStore.Client.Streams.Tests/read_stream_backward_messages.cs
@@ -35,7 +35,7 @@ namespace EventStore.Client {
 			Assert.Equal(StreamMessage.Ok.Instance, result[0]);
 			Assert.Equal(_fixture.Count, result.OfType<StreamMessage.Event>().Count());
 			if (_fixture.HasLastStreamPosition) {
-				Assert.Equal(new StreamMessage.LastStreamPosition(new StreamPosition(31)), result[^1]);
+				Assert.Equal(new StreamMessage.LastStreamPosition(new StreamPosition(31)), result[result.Length - 1]);
 			}
 		}
 

--- a/test/EventStore.Client.Streams.Tests/read_stream_forward_messages.cs
+++ b/test/EventStore.Client.Streams.Tests/read_stream_forward_messages.cs
@@ -36,13 +36,13 @@ namespace EventStore.Client {
 			Assert.Equal(_fixture.Count, result.OfType<StreamMessage.Event>().Count());
 			var first = Assert.IsType<StreamMessage.Event>(result[1]);
 			Assert.Equal(new StreamPosition(0), first.ResolvedEvent.OriginalEventNumber);
-			var last = Assert.IsType<StreamMessage.Event>(result[_fixture.HasStreamPositions ? ^2 : ^1]);
+			var last = Assert.IsType<StreamMessage.Event>(result[_fixture.HasStreamPositions ? result.Length-2 : result.Length-1]);
 			Assert.Equal(new StreamPosition((ulong)_fixture.Count - 1), last.ResolvedEvent.OriginalEventNumber);
 
 			if (_fixture.HasStreamPositions) {
 				if (_fixture.HasStreamPositions) {
 					Assert.Equal(new StreamMessage.LastStreamPosition(new StreamPosition((ulong)_fixture.Count - 1)),
-						result[^1]);
+						result[result.Length-1]);
 				}
 			}
 		}
@@ -73,7 +73,7 @@ namespace EventStore.Client {
 			
 			if (_fixture.HasStreamPositions) {
 				Assert.Equal(new StreamMessage.LastStreamPosition(new StreamPosition((ulong)_fixture.Count - 1)),
-					result[^1]);
+					result[result.Length-1]);
 			}
 		}
 

--- a/test/EventStore.Client.Streams.Tests/reconnection.cs
+++ b/test/EventStore.Client.Streams.Tests/reconnection.cs
@@ -64,7 +64,7 @@ namespace EventStore.Client {
 
 					void Resubscribe() {
 						var task = _fixture.Client.SubscribeToStreamAsync(streamName,
-							FromStream.After(events[^1].OriginalEventNumber),
+							FromStream.After(events[events.Count-1].OriginalEventNumber),
 							EventAppeared, subscriptionDropped: SubscriptionDropped);
 						task.ContinueWith(_ => resubscribe.SetResult(_.Result),
 							TaskContinuationOptions.OnlyOnRanToCompletion);

--- a/test/EventStore.Client.Tests.Common/EventStoreClientFixtureBase.cs
+++ b/test/EventStore.Client.Tests.Common/EventStoreClientFixtureBase.cs
@@ -10,7 +10,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-#if GRPC_CORE
+#if GRPC_NETSTANDARD
 using Grpc.Core;
 #endif
 using Serilog;
@@ -46,7 +46,7 @@ namespace EventStore.Client {
 				.WriteTo.Observers(observable => observable.Subscribe(LogEventSubject.OnNext))
 				.WriteTo.Seq("http://localhost:5341/", period: TimeSpan.FromMilliseconds(1));
 			Log.Logger = loggerConfiguration.CreateLogger();
-#if GRPC_CORE
+#if GRPC_NETSTANDARD
 			GrpcEnvironment.SetLogger(new GrpcCoreSerilogLogger(Log.Logger.ForContext<GrpcCoreSerilogLogger>()));
 #endif
 			AppDomain.CurrentDomain.DomainUnload += (_, e) => Log.CloseAndFlush();
@@ -67,7 +67,7 @@ namespace EventStore.Client {
 			var hostCertificatePath = Path.Combine(ProjectDir.Current, "..", "..",
 				GlobalEnvironment.UseCluster ? "certs-cluster" : "certs");
 
-#if GRPC_CORE
+#if GRPC_NETSTANDARD
 			Settings.ChannelCredentials ??= GetServerCertificate();
 
 			SslCredentials GetServerCertificate() => new SslCredentials(

--- a/test/EventStore.Client.Tests.Common/EventStoreTestServer.cs
+++ b/test/EventStore.Client.Tests.Common/EventStoreTestServer.cs
@@ -36,7 +36,7 @@ namespace EventStore.Client {
 			using var log = eventstore.Logs(true, cts.Token);
 			foreach (var line in log.ReadToEnd()) {
 				if (line.StartsWith(versionPrefix) &&
-				    Version.TryParse(line[(versionPrefix.Length + 1)..].Split(' ')[0], out var version)) {
+				    Version.TryParse(line.Substring(versionPrefix.Length + 1).Split(' ')[0], out var version)) {
 					return version;
 				}
 			}
@@ -68,8 +68,8 @@ namespace EventStore.Client {
 				["EVENTSTORE_STREAM_EXISTENCE_FILTER_SIZE"] = "10000",
 				["EVENTSTORE_ENABLE_ATOM_PUB_OVER_HTTP"] = "True"
 			};
-			foreach (var (key, value) in envOverrides ?? Enumerable.Empty<KeyValuePair<string, string>>()) {
-				env[key] = value;
+			foreach (var kv in envOverrides ?? Enumerable.Empty<KeyValuePair<string, string>>()) {
+				env[kv.Key] = kv.Value;
 			}
 
 			_eventStore = new Builder()

--- a/test/EventStore.Client.Tests.Common/GlobalEnvironment.cs
+++ b/test/EventStore.Client.Tests.Common/GlobalEnvironment.cs
@@ -27,10 +27,10 @@ namespace EventStore.Client {
 				[DbLogFormatName] = DbLogFormat,
 			};
 
-			foreach (var (key, value) in overrides ?? Enumerable.Empty<KeyValuePair<string, string>>()) {
-				if (key.StartsWith("EVENTSTORE") && !_sharedEnv.Contains(key))
-					throw new Exception($"Add {key} to shared.env and _sharedEnv to pass it to the cluster containers");
-				env[key] = value;
+			foreach (var kv in overrides ?? Enumerable.Empty<KeyValuePair<string, string>>()) {
+				if (kv.Key.StartsWith("EVENTSTORE") && !_sharedEnv.Contains(kv.Key))
+					throw new Exception($"Add {kv.Key} to shared.env and _sharedEnv to pass it to the cluster containers");
+				env[kv.Key] = kv.Value;
 			}
 			return env;
 		}

--- a/test/EventStore.Client.Tests.Common/GrpcCoreSerilogLogger.cs
+++ b/test/EventStore.Client.Tests.Common/GrpcCoreSerilogLogger.cs
@@ -1,4 +1,4 @@
-#if GRPC_CORE
+#if GRPC_NETSTANDARD
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/test/EventStore.Client.Tests/ConnectionStringTests.cs
+++ b/test/EventStore.Client.Tests/ConnectionStringTests.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-#if !GRPC_CORE
+#if !GRPC_NETSTANDARD
 using System.Net.Http;
 #endif
 using AutoFixture;
@@ -105,7 +105,7 @@ namespace EventStore.Client {
 			Assert.Equal(expected, result, EventStoreClientSettingsEqualityComparer.Instance);
 		}
 
-#if !GRPC_CORE
+#if !GRPC_NETSTANDARD
 		[Theory, InlineData(false), InlineData(true)]
 		public void tls_verify_cert(bool tlsVerifyCert) {
 			var connectionString = $"esdb://localhost:2113/?tlsVerifyCert={tlsVerifyCert}";
@@ -131,7 +131,7 @@ namespace EventStore.Client {
 			Assert.Equal(System.Threading.Timeout.InfiniteTimeSpan, result.ConnectivitySettings.KeepAliveInterval);
 			Assert.Equal(System.Threading.Timeout.InfiniteTimeSpan, result.ConnectivitySettings.KeepAliveTimeout);
 
-#if !GRPC_CORE
+#if !GRPC_NETSTANDARD
 			using var handler = result.CreateHttpMessageHandler?.Invoke();
 			var socketsHandler = Assert.IsType<SocketsHttpHandler>(handler);
 			Assert.Equal(System.Threading.Timeout.InfiniteTimeSpan, socketsHandler.KeepAlivePingTimeout);
@@ -282,7 +282,7 @@ namespace EventStore.Client {
 					settings.DefaultDeadline.Value.TotalMilliseconds.ToString());
 			}
 
-#if !GRPC_CORE
+#if !GRPC_NETSTANDARD
 			if (settings.CreateHttpMessageHandler != null) {
 				using var handler = settings.CreateHttpMessageHandler.Invoke();
 				if (handler is SocketsHttpHandler socketsHttpHandler &&

--- a/test/EventStore.Client.Tests/EventStore.Client.Tests.csproj
+++ b/test/EventStore.Client.Tests/EventStore.Client.Tests.csproj
@@ -11,6 +11,7 @@
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
 		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.23" />
+		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
 		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="5.0.15" />

--- a/test/EventStore.Client.Tests/GrpcServerCapabilitiesClientTests.cs
+++ b/test/EventStore.Client.Tests/GrpcServerCapabilitiesClientTests.cs
@@ -1,4 +1,4 @@
-#if !GRPC_CORE
+#if !GRPC_NETSTANDARD
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/test/EventStore.Client.UserManagement.Tests/EventStore.Client.UserManagement.Tests.csproj
+++ b/test/EventStore.Client.UserManagement.Tests/EventStore.Client.UserManagement.Tests.csproj
@@ -4,4 +4,7 @@
 		<ProjectReference Include="..\..\src\EventStore.Client.Streams\EventStore.Client.Streams.csproj" />
 		<ProjectReference Include="..\..\src\EventStore.Client.UserManagement\EventStore.Client.UserManagement.csproj" />
 	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
This allows .NET Framework and older .NET Core versions (such as .NET Core 2.2) to be supported (including addressing #181). 

Since much of the existing compiler directives for .NET Core 3.1 also applied to .NET Standard 2.0, I combined them (the .NET Core 3.1 test project now references the .NET Standard 2.0 version of the EventStore libraries). Unfortunately a few things had to be changed such as removing the newer range syntax. Passing all github action tests on my local branch PR.