### PR TITLE
Bump newtonsoft from 13.0.1 to 13.0.2

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -22,6 +22,8 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
+		<!-- https://github.com/advisories/GHSA-5crp-9r3c-p9vr -->
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
 	</ItemGroup>
 	<ItemGroup>
 		<CompilerVisibleProperty Include="RootNamespace"/>


### PR DESCRIPTION
For https://github.com/advisories/GHSA-5crp-9r3c-p9vr
We have a transitive dependency via Ductus.FluentDocker (tests only)