### PR TITLE
Added 3 overloads of `AddEventStoreClient`

### DIFF
--- a/src/EventStore.Client.Streams/EventStoreClientServiceCollectionExtensions.cs
+++ b/src/EventStore.Client.Streams/EventStoreClientServiceCollectionExtensions.cs
@@ -26,7 +26,23 @@ namespace Microsoft.Extensions.DependencyInjection {
 				options.ConnectivitySettings.Address = address;
 				options.CreateHttpMessageHandler = createHttpMessageHandler;
 			});
-		
+
+		/// <summary>
+		/// Adds an <see cref="EventStoreClient"/> to the <see cref="IServiceCollection"/>.
+		/// </summary>
+		/// <param name="services"></param>
+		/// <param name="addressFactory"></param>
+		/// <param name="createHttpMessageHandler"></param>
+		/// <returns></returns>
+		/// <exception cref="ArgumentNullException"></exception>
+		public static IServiceCollection AddEventStoreClient(this IServiceCollection services,
+			Func<IServiceProvider, Uri> addressFactory,
+			Func<HttpMessageHandler>? createHttpMessageHandler = null)
+			=> services.AddEventStoreClient(provider => options => {
+				options.ConnectivitySettings.Address = addressFactory(provider);
+				options.CreateHttpMessageHandler = createHttpMessageHandler;
+			});
+
 		/// <summary>
 		/// Adds an <see cref="EventStoreClient"/> to the <see cref="IServiceCollection"/>.
 		/// </summary>
@@ -38,6 +54,17 @@ namespace Microsoft.Extensions.DependencyInjection {
 			Action<EventStoreClientSettings>? configureSettings = null) =>
 			services.AddEventStoreClient(new EventStoreClientSettings(), configureSettings);
 
+		/// <summary>
+		/// Adds an <see cref="EventStoreClient"/> to the <see cref="IServiceCollection"/>.
+		/// </summary>
+		/// <param name="services"></param>
+		/// <param name="configureSettings"></param>
+		/// <returns></returns>
+		/// <exception cref="ArgumentNullException"></exception>
+		public static IServiceCollection AddEventStoreClient(this IServiceCollection services,
+			Func<IServiceProvider, Action<EventStoreClientSettings>> configureSettings) =>
+			services.AddEventStoreClient(new EventStoreClientSettings(),
+				configureSettings);
 
 		/// <summary>
 		/// Adds an <see cref="EventStoreClient"/> to the <see cref="IServiceCollection"/>.
@@ -56,6 +83,23 @@ namespace Microsoft.Extensions.DependencyInjection {
 			return services.AddEventStoreClient(EventStoreClientSettings.Create(connectionString), configureSettings);
 		}
 
+		/// <summary>
+		/// Adds an <see cref="EventStoreClient"/> to the <see cref="IServiceCollection"/>.
+		/// </summary>
+		/// <param name="services"></param>
+		/// <param name="connectionStringFactory"></param>
+		/// <param name="configureSettings"></param>
+		/// <returns></returns>
+		/// <exception cref="ArgumentNullException"></exception>
+		public static IServiceCollection AddEventStoreClient(this IServiceCollection services,
+			Func<IServiceProvider, string> connectionStringFactory,
+			Action<EventStoreClientSettings>? configureSettings = null) {
+			if (services == null) {
+				throw new ArgumentNullException(nameof(services));
+			}
+
+			return services.AddEventStoreClient(provider => EventStoreClientSettings.Create(connectionStringFactory(provider)), configureSettings);
+		}
 
 		private static IServiceCollection AddEventStoreClient(this IServiceCollection services,
 			EventStoreClientSettings settings,
@@ -63,6 +107,39 @@ namespace Microsoft.Extensions.DependencyInjection {
 			configureSettings?.Invoke(settings);
 
 			services.TryAddSingleton(provider => {
+				settings.LoggerFactory ??= provider.GetService<ILoggerFactory>();
+				settings.Interceptors ??= provider.GetServices<Interceptor>();
+
+				return new EventStoreClient(settings);
+			});
+
+			return services;
+		}
+
+		private static IServiceCollection AddEventStoreClient(this IServiceCollection services,
+			Func<IServiceProvider, EventStoreClientSettings> settingsFactory,
+			Action<EventStoreClientSettings>? configureSettings = null) {
+
+			services.TryAddSingleton(provider => {
+				var settings = settingsFactory(provider);
+				configureSettings?.Invoke(settings);
+
+				settings.LoggerFactory ??= provider.GetService<ILoggerFactory>();
+				settings.Interceptors ??= provider.GetServices<Interceptor>();
+
+				return new EventStoreClient(settings);
+			});
+
+			return services;
+		}
+
+		private static IServiceCollection AddEventStoreClient(this IServiceCollection services,
+			EventStoreClientSettings settings,
+			Func<IServiceProvider, Action<EventStoreClientSettings>> configureSettingsFactory) {
+
+			services.TryAddSingleton(provider => {
+				configureSettingsFactory(provider).Invoke(settings);
+
 				settings.LoggerFactory ??= provider.GetService<ILoggerFactory>();
 				settings.Interceptors ??= provider.GetServices<Interceptor>();
 

--- a/test/EventStore.Client.Streams.Tests/DependencyInjectionTests.cs
+++ b/test/EventStore.Client.Streams.Tests/DependencyInjectionTests.cs
@@ -13,9 +13,37 @@ namespace EventStore.Client {
 				.GetRequiredService<EventStoreClient>();
 
 		[Fact]
+		public void RegisterWithServiceProvider() =>
+			new ServiceCollection()
+				.AddEventStoreClient(provider => { })
+				.BuildServiceProvider()
+				.GetRequiredService<EventStoreClient>();
+
+		[Fact]
 		public void RegisterSimple() =>
 			new ServiceCollection()
 				.AddEventStoreClient(new Uri("https://localhost:1234"))
+				.BuildServiceProvider()
+				.GetRequiredService<EventStoreClient>();
+
+		[Fact]
+		public void RegisterSimpleWithServiceProvider() =>
+			new ServiceCollection()
+				.AddEventStoreClient(provider => new Uri("https://localhost:1234"))
+				.BuildServiceProvider()
+				.GetRequiredService<EventStoreClient>();
+
+		[Fact]
+		public void RegisterWithAction() =>
+			new ServiceCollection()
+				.AddEventStoreClient(settings => { })
+				.BuildServiceProvider()
+				.GetRequiredService<EventStoreClient>();
+
+		[Fact]
+		public void RegisterWithActionAndServiceProvider() =>
+			new ServiceCollection()
+				.AddEventStoreClient(provider => settings => { })
 				.BuildServiceProvider()
 				.GetRequiredService<EventStoreClient>();
 


### PR DESCRIPTION
These new methods provide access to the `IServiceProvider`, allowing easy configuration across environments. This is very useful when using EventStore on different environments, that use different EventStores.

They allow constructing the following using the ServiceProvider:
- Uri address
- string connectionString
- Action<EventStoreClientSettings` configureSettings

I've also added:
- 2 new private methods that do the actual registration
- tests for all 3 public methods

I currently have one of these extension methods running in production, and it works very well in combination with a configuration manager such as Azure App Configuration, or Azure Key Vault.
