### PR TITLE
Support authenticated gossip read request (DB-305)

### DIFF
--- a/src/EventStore.Client.Common/EventStoreCallOptions.cs
+++ b/src/EventStore.Client.Common/EventStoreCallOptions.cs
@@ -12,6 +12,10 @@ namespace EventStore.Client {
 			Create(settings, deadline, userCredentials, cancellationToken);
 
 		// deadline falls back to connection DefaultDeadline
+		public static CallOptions CreateNonStreaming(EventStoreClientSettings settings,
+			CancellationToken cancellationToken) => Create(settings, settings.DefaultDeadline,
+			settings.DefaultCredentials, cancellationToken);
+		
 		public static CallOptions CreateNonStreaming(EventStoreClientSettings settings, TimeSpan? deadline,
 			UserCredentials? userCredentials, CancellationToken cancellationToken) => Create(settings,
 			deadline ?? settings.DefaultDeadline, userCredentials, cancellationToken);
@@ -28,10 +32,10 @@ namespace EventStore.Client {
 						: bool.FalseString
 				}
 			},
-			credentials: (settings.DefaultCredentials ?? userCredentials) == null
+			credentials: (userCredentials ?? settings.DefaultCredentials) == null
 				? null
 				: CallCredentials.FromInterceptor(async (_, metadata) => {
-					var credentials = settings.DefaultCredentials ?? userCredentials;
+					var credentials = userCredentials ?? settings.DefaultCredentials;
 
 					var authorizationHeader = await settings.OperationOptions
 						.GetAuthenticationHeaderValue(credentials!, CancellationToken.None)

--- a/src/EventStore.Client/ChannelSelector.cs
+++ b/src/EventStore.Client/ChannelSelector.cs
@@ -12,7 +12,7 @@ namespace EventStore.Client {
 			ChannelCache channelCache) {
 			_inner = settings.ConnectivitySettings.IsSingleNode
 				? new SingleNodeChannelSelector(settings, channelCache)
-				: new GossipChannelSelector(settings, channelCache, new GrpcGossipClient());
+				: new GossipChannelSelector(settings, channelCache, new GrpcGossipClient(settings));
 		}
 
 		public Task<ChannelBase> SelectChannelAsync(CancellationToken cancellationToken) =>

--- a/test/EventStore.Client.Operations.Tests/AuthenticationTests.cs
+++ b/test/EventStore.Client.Operations.Tests/AuthenticationTests.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace EventStore.Client {
+	public class AuthenticationTests : IClassFixture<AuthenticationTests.Fixture> {
+		private readonly Fixture _fixture;
+		private static readonly Dictionary<string, UserCredentials> _credentials =
+			new Dictionary<string, UserCredentials> {
+				{ nameof(TestCredentials.Root), TestCredentials.Root },
+				{ nameof(TestCredentials.TestUser1), TestCredentials.TestUser1 },
+			};
+
+		public AuthenticationTests(Fixture fixture) {
+			_fixture = fixture;
+		}
+
+		public static IEnumerable<object?[]> AuthenticationCases() {
+			var root = nameof(TestCredentials.Root);
+			var testUser = nameof(TestCredentials.TestUser1);
+			
+			var shouldFail = false;
+			var shouldSucceed = true;
+			
+			// no user credentials
+			yield return new object?[] {1, root,     null, shouldSucceed};
+			yield return new object?[] {2, testUser, null, shouldFail};
+			yield return new object?[] {3, null,     null, shouldFail};
+			
+			// unprivileged user credentials
+			yield return new object?[] {4, root,      testUser, shouldFail};
+			yield return new object?[] {5, testUser,  testUser, shouldFail};
+			yield return new object?[] {6, null,      testUser, shouldFail};
+			
+			// root user credentials
+			yield return new object?[] {7, root,     root, shouldSucceed};
+			yield return new object?[] {8, testUser, root, shouldSucceed};
+			yield return new object?[] {9, null,     root, shouldSucceed};
+		}
+
+		[Theory, MemberData(nameof(AuthenticationCases))]
+		public async Task system_call_with_credentials_combination(int caseNr, string? defaultUser, string? user, bool succeeds) {
+
+			_fixture.Settings.DefaultCredentials = defaultUser != null ? _credentials[defaultUser] : null;
+			_fixture.Settings.ConnectionName = $"Authentication case #{caseNr} {defaultUser}";
+			
+			await using var client = new EventStoreOperationsClient(_fixture.Settings);
+
+			var result = await Record.ExceptionAsync(() =>
+				client.SetNodePriorityAsync(1, userCredentials: user != null ? _credentials[user] : null));
+			
+			if (succeeds) {
+				Assert.Null(result);
+				return;
+			}
+
+			Assert.NotNull(result);
+		}
+		
+		public class Fixture : EventStoreClientFixture {
+			protected override async Task Given() {
+				var userManagementClient = new EventStoreUserManagementClient(Settings);
+				await userManagementClient.WarmUpAsync();
+
+				await userManagementClient.CreateUserWithRetry(
+					loginName: TestCredentials.TestUser1.Username!,
+					fullName: nameof(TestCredentials.TestUser1),
+					groups: Array.Empty<string>(),
+					password: TestCredentials.TestUser1.Password!,
+					userCredentials: TestCredentials.Root)
+					.WithTimeout(TimeSpan.FromMilliseconds(1000));				
+			}
+			
+			protected override Task When() => Task.CompletedTask;
+		}
+	}
+}

--- a/test/EventStore.Client.Operations.Tests/EventStoreClientFixture.cs
+++ b/test/EventStore.Client.Operations.Tests/EventStoreClientFixture.cs
@@ -1,13 +1,28 @@
+using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace EventStore.Client {
 	public abstract class EventStoreClientFixture : EventStoreClientFixtureBase {
 		public EventStoreOperationsClient Client { get; }
 		public EventStoreClient StreamsClient { get; }
+		public new EventStoreClientSettings Settings => base.Settings;
 
-		protected EventStoreClientFixture(EventStoreClientSettings? settings = null) : base(settings) {
+		protected EventStoreClientFixture(EventStoreClientSettings? settings = null, bool? runInMemory = null)
+			: base(settings, noDefaultCredentials: true, env: Env(runInMemory)) {
+			
 			Client = new EventStoreOperationsClient(Settings);
 			StreamsClient = new EventStoreClient(Settings);
+		}
+
+		private static IDictionary<string, string>? Env(bool? runInMemory) {
+			if (runInMemory == null) {
+				return null;
+			}
+
+			return new Dictionary<string, string>() {
+				{ "EVENTSTORE_MEM_DB", runInMemory.Value.ToString() },
+			};
 		}
 
 		protected override async Task OnServerUpAsync() {

--- a/test/EventStore.Client.Operations.Tests/scavenge.cs
+++ b/test/EventStore.Client.Operations.Tests/scavenge.cs
@@ -60,6 +60,10 @@ namespace EventStore.Client {
 		}
 
 		public class Fixture : EventStoreClientFixture {
+			// always run scavenge against physical database
+			public Fixture () : base(runInMemory: false) {
+			}
+			
 			protected override Task Given() => Task.CompletedTask;
 			protected override Task When() => Task.CompletedTask;
 		}

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/EventStoreClientFixture.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/EventStoreClientFixture.cs
@@ -8,7 +8,9 @@ namespace EventStore.Client {
 		public EventStoreClient StreamsClient { get; }
 		public EventStoreUserManagementClient UserManagementClient { get; }
 
-		protected EventStoreClientFixture(EventStoreClientSettings? settings = null, bool skipPSWarmUp=false) : base(settings) {
+		protected EventStoreClientFixture(EventStoreClientSettings? settings = null, bool skipPSWarmUp=false, bool noDefaultCredentials=false)
+			: base(settings, noDefaultCredentials: noDefaultCredentials){
+
 			_skipPsWarmUp = skipPSWarmUp;
 			
 			Client = new EventStorePersistentSubscriptionsClient(Settings);

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/connect_to_existing_without_permissions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/connect_to_existing_without_permissions.cs
@@ -16,6 +16,9 @@ namespace EventStore.Client.SubscriptionToAll {
 			}).WithTimeout();
 
 		public class Fixture : EventStoreClientFixture {
+			public Fixture () : base(noDefaultCredentials: true){
+			}
+			
 			protected override Task Given() =>
 				Client.CreateToAllAsync(
 					"agroupname55",

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/connect_to_existing_without_read_all_permissions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/connect_to_existing_without_read_all_permissions.cs
@@ -16,6 +16,9 @@ namespace EventStore.Client.SubscriptionToAll {
 			}).WithTimeout();
 
 		public class Fixture : EventStoreClientFixture {
+			public Fixture () : base(noDefaultCredentials: true){
+			}
+			
 			protected override Task Given() =>
 				Client.CreateToAllAsync(
 					"agroupname55",

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/create_without_permissions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/create_without_permissions.cs
@@ -12,6 +12,9 @@ namespace EventStore.Client.SubscriptionToAll {
 		private readonly Fixture _fixture;
 
 		public class Fixture : EventStoreClientFixture {
+			public Fixture () : base(noDefaultCredentials: true){
+			}
+			
 			protected override Task Given() => Task.CompletedTask;
 			protected override Task When() => Task.CompletedTask;
 		}

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/deleting_without_permissions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/deleting_without_permissions.cs
@@ -20,6 +20,9 @@ namespace EventStore.Client.SubscriptionToAll {
 		}
 
 		public class Fixture : EventStoreClientFixture {
+			public Fixture () : base(noDefaultCredentials: true){
+			}
+			
 			protected override Task Given() => Task.CompletedTask;
 			protected override Task When() => Task.CompletedTask;
 		}

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/get_info.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/get_info.cs
@@ -139,6 +139,9 @@ namespace EventStore.Client.SubscriptionToAll {
 		}
 		
 		public class Fixture : EventStoreClientFixture {
+			public Fixture () : base(noDefaultCredentials: true){
+			}
+			
 			protected override async Task Given() {
 				if (SupportsPSToAll.No) {
 					return;

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/list_with_persistent_subscriptions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/list_with_persistent_subscriptions.cs
@@ -61,7 +61,7 @@ namespace EventStore.Client.SubscriptionToAll {
         }
         
 		public class Fixture : EventStoreClientFixture {
-			public Fixture () : base(skipPSWarmUp: true) {
+			public Fixture () : base(skipPSWarmUp: true, noDefaultCredentials: true) {
 			}
 			
 			protected override async Task Given() {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/replay_parked.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/replay_parked.cs
@@ -66,6 +66,9 @@ namespace EventStore.Client.SubscriptionToAll {
 		}
 
 		public class Fixture : EventStoreClientFixture {
+			public Fixture () : base(noDefaultCredentials: true) {
+			}
+			
 			protected override async Task Given() {
 				if (SupportsPSToAll.No) {
 					return;

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/update_existing_without_permissions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToAll/update_existing_without_permissions.cs
@@ -20,6 +20,9 @@ namespace EventStore.Client.SubscriptionToAll {
 		}
 
 		public class Fixture : EventStoreClientFixture {
+			public Fixture () : base(noDefaultCredentials: true){
+			}
+			
 			protected override async Task Given() {
 				await Client.CreateToAllAsync(Group, new PersistentSubscriptionSettings(),
 					userCredentials: TestCredentials.Root);

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_without_permissions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/connect_to_existing_without_permissions.cs
@@ -16,6 +16,9 @@ namespace EventStore.Client.SubscriptionToStream {
 			}).WithTimeout();
 
 		public class Fixture : EventStoreClientFixture {
+			public Fixture () : base(noDefaultCredentials: true){
+			}
+			
 			protected override Task Given() =>
 				Client.CreateToStreamAsync(
 					Stream,

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/create_without_permissions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/create_without_permissions.cs
@@ -12,6 +12,9 @@ namespace EventStore.Client.SubscriptionToStream {
 		private readonly Fixture _fixture;
 
 		public class Fixture : EventStoreClientFixture {
+			public Fixture () : base(noDefaultCredentials: true){
+			}
+			
 			protected override Task Given() => Task.CompletedTask;
 			protected override Task When() => Task.CompletedTask;
 		}

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/deleting_without_permissions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/deleting_without_permissions.cs
@@ -20,6 +20,9 @@ namespace EventStore.Client.SubscriptionToStream {
 		}
 
 		public class Fixture : EventStoreClientFixture {
+			public Fixture () : base(noDefaultCredentials: true){
+			}
+			
 			protected override Task Given() => Task.CompletedTask;
 			protected override Task When() => Task.CompletedTask;
 		}

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/get_info.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/get_info.cs
@@ -142,6 +142,9 @@ namespace EventStore.Client.SubscriptionToStream {
 		}
 		
 		public class Fixture : EventStoreClientFixture {
+			public Fixture () : base(noDefaultCredentials: true) {
+			}
+			
 			protected override Task Given() =>
 				Client.CreateToStreamAsync(
 					groupName: GroupName,
@@ -174,7 +177,7 @@ namespace EventStore.Client.SubscriptionToStream {
 				for (int i = 0; i < 15; i++) {
 					await StreamsClient.AppendToStreamAsync(StreamName, StreamState.Any, new [] {
 						new EventData(Uuid.NewUuid(), "test-event", ReadOnlyMemory<byte>.Empty)
-					});
+					}, userCredentials: TestCredentials.Root);
 				}
 				
 				await tcs.Task;

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/list_with_persistent_subscriptions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/list_with_persistent_subscriptions.cs
@@ -56,7 +56,7 @@ namespace EventStore.Client.SubscriptionToStream {
 		}
 
 		public class Fixture : EventStoreClientFixture {
-			public Fixture () : base(skipPSWarmUp: true) {
+			public Fixture () : base(skipPSWarmUp: true, noDefaultCredentials: true) {
 			}
 			
 			protected override async Task Given() {

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/replay_parked.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/replay_parked.cs
@@ -59,6 +59,9 @@ namespace EventStore.Client.SubscriptionToStream {
 		}
 		
 		public class Fixture : EventStoreClientFixture {
+			public Fixture () : base(noDefaultCredentials: true) {
+			}
+			
 			protected override Task Given() =>
 				Client.CreateToStreamAsync(
 					StreamName,

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/update_existing_without_permissions.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/SubscriptionToStream/update_existing_without_permissions.cs
@@ -20,8 +20,12 @@ namespace EventStore.Client.SubscriptionToStream {
 		}
 
 		public class Fixture : EventStoreClientFixture {
+			public Fixture () : base(noDefaultCredentials: true){
+			}
+			
 			protected override async Task Given() {
-				await StreamsClient.AppendToStreamAsync(Stream, StreamState.NoStream, CreateTestEvents());
+				await StreamsClient.AppendToStreamAsync(Stream, StreamState.NoStream, CreateTestEvents(),
+					userCredentials: TestCredentials.Root);
 				await Client.CreateToStreamAsync(Stream, Group, new PersistentSubscriptionSettings(),
 					userCredentials: TestCredentials.Root);
 			}

--- a/test/EventStore.Client.PersistentSubscriptions.Tests/restart_subsystem.cs
+++ b/test/EventStore.Client.PersistentSubscriptions.Tests/restart_subsystem.cs
@@ -33,6 +33,9 @@ namespace EventStore.Client {
 		}
 		
 		public class Fixture : EventStoreClientFixture {
+			public Fixture () : base(noDefaultCredentials: true) {
+			}
+			
 			protected override Task Given() => Task.CompletedTask;
 			protected override Task When() => Task.CompletedTask;
 		}

--- a/test/EventStore.Client.ProjectionManagement.Tests/EventStoreClientFixture.cs
+++ b/test/EventStore.Client.ProjectionManagement.Tests/EventStoreClientFixture.cs
@@ -9,11 +9,11 @@ namespace EventStore.Client {
 		public EventStoreClient StreamsClient { get; }
 		public EventStoreProjectionManagementClient Client { get; }
 
-		protected EventStoreClientFixture(EventStoreClientSettings? settings = null) : base(settings,
-			new Dictionary<string, string> {
+		protected EventStoreClientFixture(EventStoreClientSettings? settings = null, bool noDefaultCredentials = false) :
+			base(settings, new Dictionary<string, string> {
 				["EVENTSTORE_RUN_PROJECTIONS"] = "ALL",
 				["EVENTSTORE_START_STANDARD_PROJECTIONS"] = "True"
-			}) {
+			}, noDefaultCredentials) {
 			Client = new EventStoreProjectionManagementClient(Settings);
 			UserManagementClient = new EventStoreUserManagementClient(Settings);
 			StreamsClient = new EventStoreClient(Settings);

--- a/test/EventStore.Client.ProjectionManagement.Tests/restart_subsystem.cs
+++ b/test/EventStore.Client.ProjectionManagement.Tests/restart_subsystem.cs
@@ -20,6 +20,9 @@ namespace EventStore.Client {
 		}
 
 		public class Fixture : EventStoreClientFixture {
+			public Fixture () : base(noDefaultCredentials: true) {
+			}
+			
 			protected override Task Given() => Task.CompletedTask;
 			protected override Task When() => Task.CompletedTask;
 		}

--- a/test/EventStore.Client.Streams.Tests/AnonymousAccess.cs
+++ b/test/EventStore.Client.Streams.Tests/AnonymousAccess.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace EventStore.Client;
+
+public class AnonymousAccess {
+	private static readonly Version LegacySince = new Version(23, 6);
+	private static readonly string SkipMessage = 
+		"Anonymous access is turned off since v23.6.0!";
+
+	internal class FactAttribute : Deprecation.FactAttribute {
+		public FactAttribute() : base(LegacySince, SkipMessage) { }
+	}
+
+	internal class TheoryAttribute : Deprecation.TheoryAttribute {
+		public TheoryAttribute() : base(LegacySince, SkipMessage) { }
+	}
+}

--- a/test/EventStore.Client.Streams.Tests/EventStoreClientFixture.cs
+++ b/test/EventStore.Client.Streams.Tests/EventStoreClientFixture.cs
@@ -5,7 +5,9 @@ namespace EventStore.Client {
 	public abstract class EventStoreClientFixture : EventStoreClientFixtureBase {
 		public EventStoreClient Client { get; }
 		protected EventStoreClientFixture(EventStoreClientSettings? settings = null,
-			Dictionary<string, string>? env = null) : base(settings, env) {
+			Dictionary<string, string>? env = null, bool noDefaultCredentials = false)
+			: base(settings, env, noDefaultCredentials) {
+			
 			Client = new EventStoreClient(Settings);
 		}
 

--- a/test/EventStore.Client.Streams.Tests/Security/SecurityFixture.cs
+++ b/test/EventStore.Client.Streams.Tests/Security/SecurityFixture.cs
@@ -19,7 +19,7 @@ namespace EventStore.Client.Security {
 
 		public EventStoreUserManagementClient UserManagementClient { get; }
 
-		protected SecurityFixture() {
+		protected SecurityFixture() : base(noDefaultCredentials: true) {
 			UserManagementClient = new EventStoreUserManagementClient(Settings);
 		}
 

--- a/test/EventStore.Client.Streams.Tests/Security/delete_stream_security.cs
+++ b/test/EventStore.Client.Streams.Tests/Security/delete_stream_security.cs
@@ -16,7 +16,7 @@ namespace EventStore.Client.Security {
 			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.DeleteStream(SecurityFixture.AllStream, userCredentials: TestCredentials.TestAdmin));
 		}
 
-		[Fact]
+		[AnonymousAccess.Fact]
 		public async Task deleting_normal_no_acl_stream_with_no_user_is_allowed() {
 			var streamId = await _fixture.CreateStreamWithMeta(new StreamMetadata());
 			await _fixture.DeleteStream(streamId);
@@ -89,7 +89,7 @@ namespace EventStore.Client.Security {
 		}
 
 
-		[Fact]
+		[AnonymousAccess.Fact]
 		public async Task deleting_normal_all_stream_with_no_user_is_allowed() {
 			var streamId =
 				await _fixture.CreateStreamWithMeta(
@@ -188,7 +188,7 @@ namespace EventStore.Client.Security {
 		}
 
 
-		[Fact]
+		[AnonymousAccess.Fact]
 		public async Task deleting_system_all_stream_with_no_user_is_allowed() {
 			var streamId = await _fixture.CreateStreamWithMeta(streamId: $"${_fixture.GetStreamName()}",
 				metadata: new StreamMetadata(acl: new StreamAcl(deleteRole: SystemRoles.All)));

--- a/test/EventStore.Client.Streams.Tests/Security/multiple_role_security.cs
+++ b/test/EventStore.Client.Streams.Tests/Security/multiple_role_security.cs
@@ -21,12 +21,16 @@ namespace EventStore.Client.Security {
 			await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.AppendStream("usr-stream", TestCredentials.TestUser2));
 			await _fixture.AppendStream("usr-stream", userCredentials: TestCredentials.TestAdmin);
 
-			await _fixture.DeleteStream("usr-stream1");
 			await _fixture.DeleteStream("usr-stream2", userCredentials: TestCredentials.TestUser1);
 			await _fixture.DeleteStream("usr-stream3", TestCredentials.TestUser2);
 			await _fixture.DeleteStream("usr-stream4", userCredentials: TestCredentials.TestAdmin);
 		}
 
+		[AnonymousAccess.Fact]
+		public async Task multiple_roles_are_handled_correctly_without_authentication() {
+			await _fixture.DeleteStream("usr-stream1");
+		}
+		
 
 		public class Fixture : SecurityFixture {
 			protected override Task When() {

--- a/test/EventStore.Client.Streams.Tests/Security/overriden_system_stream_security_for_all.cs
+++ b/test/EventStore.Client.Streams.Tests/Security/overriden_system_stream_security_for_all.cs
@@ -35,7 +35,7 @@ namespace EventStore.Client.Security {
 			await _fixture.DeleteStream(stream, userCredentials: TestCredentials.TestUser1);
 		}
 
-		[Fact]
+		[AnonymousAccess.Fact]
 		public async Task operations_on_system_stream_fail_for_anonymous_user() {
 			var stream = $"${_fixture.GetStreamName()}";
 			await _fixture.AppendStream(stream);

--- a/test/EventStore.Client.Streams.Tests/Security/read_stream_meta_security.cs
+++ b/test/EventStore.Client.Streams.Tests/Security/read_stream_meta_security.cs
@@ -41,7 +41,7 @@ namespace EventStore.Client.Security {
 		}
 
 
-		[Fact]
+		[AnonymousAccess.Fact]
 		public async Task reading_no_acl_stream_meta_succeeds_when_no_credentials_are_passed() {
 			await _fixture.ReadMeta(SecurityFixture.NoAclStream);
 		}
@@ -62,9 +62,8 @@ namespace EventStore.Client.Security {
 		public async Task reading_no_acl_stream_meta_succeeds_when_admin_user_credentials_are_passed() {
 			await _fixture.ReadMeta(SecurityFixture.NoAclStream, userCredentials: TestCredentials.TestAdmin);
 		}
-
-
-		[Fact]
+		
+		[AnonymousAccess.Fact]
 		public async Task reading_all_access_normal_stream_meta_succeeds_when_no_credentials_are_passed() {
 			await _fixture.ReadMeta(SecurityFixture.NormalAllStream);
 		}

--- a/test/EventStore.Client.Streams.Tests/Security/read_stream_security.cs
+++ b/test/EventStore.Client.Streams.Tests/Security/read_stream_security.cs
@@ -61,7 +61,7 @@ namespace EventStore.Client.Security {
 		}
 
 
-		[Fact]
+		[AnonymousAccess.Fact]
 		public async Task reading_no_acl_stream_succeeds_when_no_credentials_are_passed() {
 			await _fixture.AppendStream(SecurityFixture.NoAclStream);
 
@@ -101,7 +101,7 @@ namespace EventStore.Client.Security {
 		}
 
 
-		[Fact]
+		[AnonymousAccess.Fact]
 		public async Task reading_all_access_normal_stream_succeeds_when_no_credentials_are_passed() {
 			await _fixture.AppendStream(SecurityFixture.NormalAllStream);
 			await _fixture.ReadEvent(SecurityFixture.NormalAllStream);

--- a/test/EventStore.Client.Streams.Tests/Security/stream_security_inheritance.cs
+++ b/test/EventStore.Client.Streams.Tests/Security/stream_security_inheritance.cs
@@ -79,13 +79,10 @@ namespace EventStore.Client.Security {
 				_fixture.AppendStream("user-w-restricted", TestCredentials.TestUser2));
 			await _fixture.AppendStream("user-w-restricted", userCredentials: TestCredentials.TestAdmin);
 
-			await _fixture.AppendStream("user-w-all");
 			await _fixture.AppendStream("user-w-all", userCredentials: TestCredentials.TestUser1);
 			await _fixture.AppendStream("user-w-all", TestCredentials.TestUser2);
 			await _fixture.AppendStream("user-w-all", userCredentials: TestCredentials.TestAdmin);
 
-
-			await _fixture.ReadEvent("user-no-acl");
 			await _fixture.ReadEvent("user-no-acl", userCredentials: TestCredentials.TestUser1);
 			await _fixture.ReadEvent("user-no-acl", TestCredentials.TestUser2);
 			await _fixture.ReadEvent("user-no-acl", userCredentials: TestCredentials.TestAdmin);
@@ -96,6 +93,15 @@ namespace EventStore.Client.Security {
 			await Assert.ThrowsAsync<AccessDeniedException>(() =>
 				_fixture.ReadEvent("user-r-restricted", TestCredentials.TestUser2));
 			await _fixture.ReadEvent("user-r-restricted", userCredentials: TestCredentials.TestAdmin);
+		}
+
+		[AnonymousAccess.Fact]
+		public async Task acl_inheritance_is_working_properly_on_user_streams_when_not_authenticated() {
+			await _fixture.AppendStream("user-w-all");
+			
+			// make sure the stream exists before trying to read it without authentication
+			await _fixture.AppendStream("user-no-acl", userCredentials: TestCredentials.TestAdmin);
+			await _fixture.ReadEvent("user-no-acl");
 		}
 
 		[Fact]
@@ -125,7 +131,6 @@ namespace EventStore.Client.Security {
 				_fixture.AppendStream("$sys-w-restricted", TestCredentials.TestUser2));
 			await _fixture.AppendStream("$sys-w-restricted", userCredentials: TestCredentials.TestAdmin);
 
-			await _fixture.AppendStream("$sys-w-all");
 			await _fixture.AppendStream("$sys-w-all", userCredentials: TestCredentials.TestUser1);
 			await _fixture.AppendStream("$sys-w-all", TestCredentials.TestUser2);
 			await _fixture.AppendStream("$sys-w-all", userCredentials: TestCredentials.TestAdmin);
@@ -136,6 +141,11 @@ namespace EventStore.Client.Security {
 			await Assert.ThrowsAsync<AccessDeniedException>(() =>
 				_fixture.ReadEvent("$sys-no-acl", TestCredentials.TestUser2));
 			await _fixture.ReadEvent("$sys-no-acl", userCredentials: TestCredentials.TestAdmin);
+		}
+
+		[AnonymousAccess.Fact]
+		public async Task acl_inheritance_is_working_properly_on_system_streams_when_not_authenticated() {
+			await _fixture.AppendStream("$sys-w-all");
 		}
 	}
 }

--- a/test/EventStore.Client.Streams.Tests/Security/subscribe_to_stream_security.cs
+++ b/test/EventStore.Client.Streams.Tests/Security/subscribe_to_stream_security.cs
@@ -43,7 +43,7 @@ namespace EventStore.Client.Security {
 			await _fixture.SubscribeToStream(SecurityFixture.ReadStream, userCredentials: TestCredentials.TestAdmin);
 		}
 
-		[Fact]
+		[AnonymousAccess.Fact]
 		public async Task subscribing_to_no_acl_stream_succeeds_when_no_credentials_are_passed() {
 			await _fixture.AppendStream(SecurityFixture.NoAclStream);
 			await _fixture.SubscribeToStream(SecurityFixture.NoAclStream);
@@ -69,7 +69,7 @@ namespace EventStore.Client.Security {
 		}
 
 
-		[Fact]
+		[AnonymousAccess.Fact]
 		public async Task subscribing_to_all_access_normal_stream_succeeds_when_no_credentials_are_passed() {
 			await _fixture.AppendStream(SecurityFixture.NormalAllStream);
 			await _fixture.SubscribeToStream(SecurityFixture.NormalAllStream);

--- a/test/EventStore.Client.Streams.Tests/Security/system_stream_security.cs
+++ b/test/EventStore.Client.Streams.Tests/Security/system_stream_security.cs
@@ -119,7 +119,7 @@ namespace EventStore.Client.Security
 		}
 
 
-		[Fact]
+		[AnonymousAccess.Fact]
 		public async Task operations_on_system_stream_with_acl_set_to_all_succeed_for_not_authenticated_user() {
 			await _fixture.AppendStream(SecurityFixture.SystemAllStream);
 			await _fixture.ReadEvent(SecurityFixture.SystemAllStream);

--- a/test/EventStore.Client.Streams.Tests/Security/write_stream_meta_security.cs
+++ b/test/EventStore.Client.Streams.Tests/Security/write_stream_meta_security.cs
@@ -46,7 +46,7 @@ namespace EventStore.Client.Security {
 		}
 
 
-		[Fact]
+		[AnonymousAccess.Fact]
 		public async Task writing_meta_to_no_acl_stream_succeeds_when_no_credentials_are_passed() {
 			await _fixture.WriteMeta(SecurityFixture.NoAclStream);
 		}
@@ -70,7 +70,7 @@ namespace EventStore.Client.Security {
 		}
 
 
-		[Fact]
+		[AnonymousAccess.Fact]
 		public async Task writing_meta_to_all_access_normal_stream_succeeds_when_no_credentials_are_passed() {
 			await _fixture.WriteMeta(SecurityFixture.NormalAllStream, role: SystemRoles.All);
 		}

--- a/test/EventStore.Client.Streams.Tests/Security/write_stream_security.cs
+++ b/test/EventStore.Client.Streams.Tests/Security/write_stream_security.cs
@@ -52,7 +52,7 @@ namespace EventStore.Client.Security {
 		}
 
 
-		[Fact]
+		[AnonymousAccess.Fact]
 		public async Task writing_to_no_acl_stream_succeeds_when_no_credentials_are_passed() {
 			await _fixture.AppendStream(SecurityFixture.NoAclStream);
 		}
@@ -73,9 +73,8 @@ namespace EventStore.Client.Security {
 		public async Task writing_to_no_acl_stream_succeeds_when_any_admin_user_credentials_are_passed() {
 			await _fixture.AppendStream(SecurityFixture.NoAclStream, userCredentials: TestCredentials.TestAdmin);
 		}
-
-
-		[Fact]
+		
+		[AnonymousAccess.Fact]
 		public async Task writing_to_all_access_normal_stream_succeeds_when_no_credentials_are_passed() {
 			await _fixture.AppendStream(SecurityFixture.NormalAllStream);
 		}

--- a/test/EventStore.Client.Streams.Tests/reconnection.cs
+++ b/test/EventStore.Client.Streams.Tests/reconnection.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Grpc.Core;
@@ -64,7 +65,9 @@ namespace EventStore.Client {
 				try {
 					var sub = await _fixture.Client.SubscribeToStreamAsync(
 						streamName,
-						FromStream.After(receivedEvents[^1].OriginalEventNumber),
+						receivedEvents.Any()
+							? FromStream.After(receivedEvents[^1].OriginalEventNumber)
+							: FromStream.Start,
 						EventAppeared,
 						subscriptionDropped: SubscriptionDropped);
 					resubscribed.SetResult(sub);

--- a/test/EventStore.Client.Tests.Common/Deprecation.cs
+++ b/test/EventStore.Client.Tests.Common/Deprecation.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+namespace EventStore.Client;
+
+internal class Deprecation {
+	internal class FactAttribute : Xunit.FactAttribute {
+		private readonly Version _legacySince;
+		private readonly string _skipMessage;
+
+		public FactAttribute(Version since, string skipMessage) {
+			_legacySince = since;
+			_skipMessage = skipMessage;
+		}
+
+		public override string? Skip {
+			get => EventStoreTestServer.Version >= _legacySince
+				? _skipMessage
+				: null;
+			set => throw new NotSupportedException();
+		}
+	}
+
+	internal class TheoryAttribute : Xunit.TheoryAttribute {
+		private readonly Version _legacySince;
+		private readonly string _skipMessage;
+
+		public TheoryAttribute(Version since, string skipMessage) {
+			_legacySince = since;
+			_skipMessage = skipMessage;
+		}
+
+		public override string? Skip {
+			get => EventStoreTestServer.Version >= _legacySince
+				? _skipMessage
+				: null;
+			set => throw new NotSupportedException();
+		}
+	}
+}

--- a/test/EventStore.Client.Tests.Common/EventStoreClientExtensions.cs
+++ b/test/EventStore.Client.Tests.Common/EventStoreClientExtensions.cs
@@ -26,7 +26,7 @@ namespace EventStore.Client {
 
 				// the read from leader above is not enough to guarantee the next write goes to leader
 				await self.AppendToStreamAsync($"warmup", StreamState.Any, Enumerable.Empty<EventData>(),
-					cancellationToken: cancellationToken);
+					userCredentials: TestCredentials.Root, cancellationToken: cancellationToken);
 			});
 		}
 

--- a/test/EventStore.Client.Tests.Common/EventStoreClientFixtureBase.cs
+++ b/test/EventStore.Client.Tests.Common/EventStoreClientFixtureBase.cs
@@ -21,8 +21,8 @@ namespace EventStore.Client {
 	public abstract class EventStoreClientFixtureBase : IAsyncLifetime {
 		public const string TestEventType = "-";
 
-		private const string ConnectionStringSingle = "esdb://localhost:2113/?tlsVerifyCert=false";
-		private const string ConnectionStringCluster = "esdb://localhost:2113,localhost:2112,localhost:2111?tls=true&tlsVerifyCert=false";
+		private const string ConnectionStringSingle = "esdb://admin:changeit@localhost:2113/?tlsVerifyCert=false";
+		private const string ConnectionStringCluster = "esdb://admin:changeit@localhost:2113,localhost:2112,localhost:2111?tls=true&tlsVerifyCert=false";
 
 		private static readonly Subject<LogEvent> LogEventSubject = new Subject<LogEvent>();
 
@@ -50,13 +50,17 @@ namespace EventStore.Client {
 		}
 
 		protected EventStoreClientFixtureBase(EventStoreClientSettings? clientSettings,
-			IDictionary<string, string>? env = null) {
+			IDictionary<string, string>? env = null, bool noDefaultCredentials = false) {
 			_disposables = new List<IDisposable>();
 			ServicePointManager.ServerCertificateValidationCallback = delegate { return true; };
 
 			var connectionString = GlobalEnvironment.UseCluster ? ConnectionStringCluster : ConnectionStringSingle;
 			Settings = clientSettings ?? EventStoreClientSettings.Create(connectionString);
 
+			if (noDefaultCredentials) {
+				Settings.DefaultCredentials = null;
+			}
+			
 			Settings.DefaultDeadline = Debugger.IsAttached
 				? new TimeSpan?()
 				: TimeSpan.FromSeconds(30);

--- a/test/EventStore.Client.Tests.Common/EventStoreTestServer.cs
+++ b/test/EventStore.Client.Tests.Common/EventStoreTestServer.cs
@@ -60,11 +60,13 @@ namespace EventStore.Client {
 			var env = new Dictionary<string, string> {
 				["EVENTSTORE_DB_LOG_FORMAT"] = GlobalEnvironment.DbLogFormat,
 				["EVENTSTORE_MEM_DB"] = "true",
+				["EVENTSTORE_CHUNK_SIZE"] = (1024 * 1024).ToString(),
 				["EVENTSTORE_CERTIFICATE_FILE"] = "/etc/eventstore/certs/node/node.crt",
 				["EVENTSTORE_CERTIFICATE_PRIVATE_KEY_FILE"] = "/etc/eventstore/certs/node/node.key",
 				["EVENTSTORE_TRUSTED_ROOT_CERTIFICATES_PATH"] = "/etc/eventstore/certs/ca",
 				["EVENTSTORE_LOG_LEVEL"] = "Verbose",
 				["EVENTSTORE_STREAM_EXISTENCE_FILTER_SIZE"] = "10000",
+				["EVENTSTORE_STREAM_INFO_CACHE_CAPACITY"] = "10000",
 				["EVENTSTORE_ENABLE_ATOM_PUB_OVER_HTTP"] = "True"
 			};
 			foreach (var (key, value) in envOverrides ?? Enumerable.Empty<KeyValuePair<string, string>>()) {

--- a/test/EventStore.Client.UserManagement.Tests/EventStoreClientFixture.cs
+++ b/test/EventStore.Client.UserManagement.Tests/EventStoreClientFixture.cs
@@ -4,7 +4,9 @@ namespace EventStore.Client {
 	public abstract class EventStoreClientFixture : EventStoreClientFixtureBase {
 		public EventStoreUserManagementClient Client { get; }
 		public EventStoreClient StreamsClient { get; }
-		protected EventStoreClientFixture(EventStoreClientSettings? settings = null) : base(settings) {
+		protected EventStoreClientFixture(EventStoreClientSettings? settings = null, bool noDefaultCredentials = false)
+			: base(settings, noDefaultCredentials: noDefaultCredentials) {
+			
 			Client = new EventStoreUserManagementClient(Settings);
 			StreamsClient = new EventStoreClient(Settings);
 		}

--- a/test/EventStore.Client.UserManagement.Tests/creating_a_user.cs
+++ b/test/EventStore.Client.UserManagement.Tests/creating_a_user.cs
@@ -78,6 +78,9 @@ namespace EventStore.Client {
 		}
 
 		public class Fixture : EventStoreClientFixture {
+			public Fixture () : base(noDefaultCredentials: true){
+			}
+			
 			protected override Task Given() => Task.CompletedTask;
 			protected override Task When() => Task.CompletedTask;
 		}

--- a/test/EventStore.Client.UserManagement.Tests/deleting_a_user.cs
+++ b/test/EventStore.Client.UserManagement.Tests/deleting_a_user.cs
@@ -66,6 +66,9 @@ namespace EventStore.Client {
 		}
 
 		public class Fixture : EventStoreClientFixture {
+			public Fixture () : base(noDefaultCredentials: true){
+			}
+			
 			protected override Task Given() => Task.CompletedTask;
 			protected override Task When() => Task.CompletedTask;
 		}

--- a/test/EventStore.Client.UserManagement.Tests/disabling_a_user.cs
+++ b/test/EventStore.Client.UserManagement.Tests/disabling_a_user.cs
@@ -58,6 +58,9 @@ namespace EventStore.Client {
 		}
 
 		public class Fixture : EventStoreClientFixture {
+			public Fixture () : base(noDefaultCredentials: true){
+			}
+			
 			protected override Task Given() => Task.CompletedTask;
 			protected override Task When() => Task.CompletedTask;
 		}

--- a/test/EventStore.Client.UserManagement.Tests/enabling_a_user.cs
+++ b/test/EventStore.Client.UserManagement.Tests/enabling_a_user.cs
@@ -58,6 +58,9 @@ namespace EventStore.Client {
 		}
 
 		public class Fixture : EventStoreClientFixture {
+			public Fixture () : base(noDefaultCredentials: true){
+			}
+			
 			protected override Task Given() => Task.CompletedTask;
 			protected override Task When() => Task.CompletedTask;
 		}

--- a/test/EventStore.Client.UserManagement.Tests/reset_user_password.cs
+++ b/test/EventStore.Client.UserManagement.Tests/reset_user_password.cs
@@ -81,6 +81,9 @@ namespace EventStore.Client {
 		}
 
 		public class Fixture : EventStoreClientFixture {
+			public Fixture () : base(noDefaultCredentials: true){
+			}
+			
 			protected override Task Given() => Task.CompletedTask;
 			protected override Task When() => Task.CompletedTask;
 		}


### PR DESCRIPTION
Fixed: User credentials always overridden when default credentials are specified.
Added: Support authenticated gossip read request.
Changed: Always run scavenge tests against physical database.

_Should have kept sperate commits 😬_ 
User credential fix is in: `src/EventStore.Client.Common/EventStoreCallOptions.cs`
Gossip authentication change is in: `src/EventStore.Client/GrpcGossipClient.cs`
Scavenge fix mostly done in: `test/EventStore.Client.Operations.Tests/EventStoreClientFixture.cs`

Other changes are mostly related to stop using anonymous calls & flakey tests.