### PR TITLE
Improve the error message when reading/subscribing from an invalid po…

### DIFF
--- a/src/EventStore.Client/Exceptions/InvalidPositionException.cs
+++ b/src/EventStore.Client/Exceptions/InvalidPositionException.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace EventStore.Client {
+	/// <summary>
+	/// Exception thrown when a user is not authorised to carry out
+	/// an operation.
+	/// </summary>
+	public class InvalidPositionException : Exception {
+		/// <summary>
+		/// Constructs a new <see cref="InvalidPositionException" />.
+		/// </summary>
+		public InvalidPositionException(string message, Exception innerException) : base(message, innerException) {
+		}
+
+		/// <summary>
+		/// Constructs a new <see cref="InvalidPositionException" />.
+		/// </summary>
+		public InvalidPositionException() : base("The specified position is invalid") {
+
+		}
+	}
+}

--- a/src/EventStore.Client/Interceptors/TypedExceptionInterceptor.cs
+++ b/src/EventStore.Client/Interceptors/TypedExceptionInterceptor.cs
@@ -108,9 +108,12 @@ namespace EventStore.Client.Interceptors {
 			public async Task<bool> MoveNext(CancellationToken cancellationToken) {
 				try {
 					return await _inner.MoveNext(cancellationToken).ConfigureAwait(false);
-				} catch (Exception) {
-					throw new InvalidPositionException();
-				}
+				} 
+				catch (RpcException ex) {
+					if (ex.StatusCode.ToString().Equals("Unknown"))
+						throw new InvalidPositionException();
+					throw ConvertRpcException(ex, _exceptionMap);
+				} 
 			}
 
 			public TResponse Current => _inner.Current;

--- a/src/EventStore.Client/Interceptors/TypedExceptionInterceptor.cs
+++ b/src/EventStore.Client/Interceptors/TypedExceptionInterceptor.cs
@@ -108,8 +108,8 @@ namespace EventStore.Client.Interceptors {
 			public async Task<bool> MoveNext(CancellationToken cancellationToken) {
 				try {
 					return await _inner.MoveNext(cancellationToken).ConfigureAwait(false);
-				} catch (RpcException ex) {
-					throw ConvertRpcException(ex, _exceptionMap);
+				} catch (Exception) {
+					throw new InvalidPositionException();
 				}
 			}
 


### PR DESCRIPTION
Fixed : https://github.com/EventStore/EventStore/issues/3195 (on the client side)
When the above mentioned exception was thrown, the error message on the client side was unclear stating "An exception was thrown by the handler", without specifying the actual error message, thus making it difficult to diagnose what the actual issue was on client side. This PR improves the error message when the above issue is encountered.