### PR TITLE
add filtering to non-subscription reads of $all

### DIFF
--- a/src/EventStore.Client.Streams/EventStoreClient.cs
+++ b/src/EventStore.Client.Streams/EventStoreClient.cs
@@ -73,13 +73,10 @@ namespace EventStore.Client {
 			}
 		}
 
-		private static ReadReq.Types.Options.Types.FilterOptions? GetFilterOptions(
-			SubscriptionFilterOptions? filterOptions) {
-			if (filterOptions == null) {
+		private static ReadReq.Types.Options.Types.FilterOptions? GetFilterOptions(IEventFilter? filter, uint checkpointInterval = 0) {
+			if (filter == null) {
 				return null;
 			}
-
-			var filter = filterOptions.Filter;
 
 			var options = filter switch {
 				StreamFilter => new ReadReq.Types.Options.Types.FilterOptions {
@@ -127,10 +124,13 @@ namespace EventStore.Client {
 				options.Count = new Empty();
 			}
 
-			options.CheckpointIntervalMultiplier = filterOptions.CheckpointInterval;
+			options.CheckpointIntervalMultiplier = checkpointInterval;
 
 			return options;
 		}
+
+		private static ReadReq.Types.Options.Types.FilterOptions? GetFilterOptions(SubscriptionFilterOptions? filterOptions)
+			=> filterOptions == null ? null : GetFilterOptions(filterOptions.Filter, filterOptions.CheckpointInterval);
 
 		/// <inheritdoc />
 		public override void Dispose() {

--- a/test/EventStore.Client.Streams.Tests/Read/ReadAllEventsFixture.cs
+++ b/test/EventStore.Client.Streams.Tests/Read/ReadAllEventsFixture.cs
@@ -10,11 +10,9 @@ public class ReadAllEventsFixture : EventStoreFixture {
 				userCredentials: TestCredentials.Root
 			);
 			
-			Events = Enumerable
-				.Concat(
-					CreateTestEvents(20),
-					CreateTestEvents(2, metadataSize: 1_000_000)
-				)
+			Events = CreateTestEvents(20)
+				.Concat(CreateTestEvents(2, metadataSize: 1_000_000))
+				.Concat(CreateTestEvents(2, AnotherTestEventType))
 				.ToArray();
 
 			ExpectedStreamName = GetStreamName();

--- a/test/EventStore.Client.Streams.Tests/Read/read_all_events_backward.cs
+++ b/test/EventStore.Client.Streams.Tests/Read/read_all_events_backward.cs
@@ -72,6 +72,15 @@ public class read_all_events_backward(ITestOutputHelper output, ReadAllEventsFix
 		ex.StatusCode.ShouldBe(StatusCode.DeadlineExceeded);
 	}
 	
+	[Fact]
+	public async Task filter_events_by_type() {
+		var result = await Fixture.Streams
+			.ReadAllAsync(Direction.Backwards, Position.End, EventTypeFilter.Prefix(EventStoreFixture.AnotherTestEventTypePrefix))
+			.ToListAsync();
+			
+		result.ForEach(x => x.Event.EventType.ShouldStartWith(EventStoreFixture.AnotherTestEventTypePrefix));
+	}
+	
 	[Fact(Skip = "Not Implemented")]
 	public Task be_able_to_read_all_one_by_one_until_end_of_stream() => throw new NotImplementedException();
 

--- a/test/EventStore.Client.Streams.Tests/Read/read_all_events_forward.cs
+++ b/test/EventStore.Client.Streams.Tests/Read/read_all_events_forward.cs
@@ -139,6 +139,15 @@ public class read_all_events_forward(ITestOutputHelper output, ReadAllEventsFixt
 		);
 	}
 	
+	[Fact]
+	public async Task filter_events_by_type() {
+		var result = await Fixture.Streams
+			.ReadAllAsync(Direction.Forwards, Position.Start, EventTypeFilter.Prefix(EventStoreFixture.AnotherTestEventTypePrefix))
+			.ToListAsync();
+		
+		result.ForEach(x => x.Event.EventType.ShouldStartWith(EventStoreFixture.AnotherTestEventTypePrefix));
+	}
+	
 	[Fact(Skip = "Not Implemented")]
 	public Task be_able_to_read_all_one_by_one_until_end_of_stream() => throw new NotImplementedException();
 

--- a/test/EventStore.Client.Tests.Common/Fixtures/EventStoreFixture.Helpers.cs
+++ b/test/EventStore.Client.Tests.Common/Fixtures/EventStoreFixture.Helpers.cs
@@ -4,7 +4,9 @@ using System.Text;
 namespace EventStore.Client.Tests;
 
 public partial class EventStoreFixture {
-	public const string TestEventType = "tst";
+	public const string TestEventType = "test-event-type";
+	public const string AnotherTestEventTypePrefix = "another";
+	public const string AnotherTestEventType = $"{AnotherTestEventTypePrefix}-test-event-type";
 
 	public T NewClient<T>(Action<EventStoreClientSettings> configure) where T : EventStoreClientBase, new() =>
 		(T)Activator.CreateInstance(typeof(T), new object?[] { ClientSettings.With(configure) })!;


### PR DESCRIPTION
Added: an `EventStore.Client.EventStoreClient.ReadAllAsync(...)` overload accepting `IEventFilter`.

The change is to use EventStore/EventStore#3133

It'd be great to have this feature available.

If something is out of ordinary let me know :)