### PR TITLE
Read Semantic Versions when Reading Server Version

### DIFF
--- a/test/EventStore.Client.Tests.Common/Fixtures/Base/EventStoreTestServer.cs
+++ b/test/EventStore.Client.Tests.Common/Fixtures/Base/EventStoreTestServer.cs
@@ -110,12 +110,20 @@ public class EventStoreTestServer : IEventStoreTestServer {
 			.Start();
 
 		using var log = eventstore.Logs(true, cts.Token);
-		foreach (var line in log.ReadToEnd())
+		foreach (var line in log.ReadToEnd()) {
 			if (line.StartsWith(versionPrefix) &&
-			    Version.TryParse(line[(versionPrefix.Length + 1)..].Split(' ')[0], out var version))
+			    Version.TryParse(new string(ReadVersion(line[(versionPrefix.Length + 1)..]).ToArray()), out var version)) {
 				return version;
+			}
+		}
 
 		throw new InvalidOperationException("Could not determine server version.");
+
+		IEnumerable<char> ReadVersion(string s) {
+			foreach (var c in s.TakeWhile(c => c == '.' || char.IsDigit(c))) {
+				yield return c;
+			}
+		}
 	}
 
 	void VerifyCertificatesExist() {

--- a/test/EventStore.Client.Tests.Common/Fixtures/EventStoreFixture.cs
+++ b/test/EventStore.Client.Tests.Common/Fixtures/EventStoreFixture.cs
@@ -164,12 +164,20 @@ public partial class EventStoreFixture : IAsyncLifetime, IAsyncDisposable {
 				.Start();
 
 			using var log = eventstore.Logs(true, cancellator.Token);
-			foreach (var line in log.ReadToEnd())
+			foreach (var line in log.ReadToEnd()) {
 				if (line.StartsWith(versionPrefix) &&
-				    Version.TryParse(line[(versionPrefix.Length + 1)..].Split(' ')[0], out var version))
+				    Version.TryParse(new string(ReadVersion(line[(versionPrefix.Length + 1)..]).ToArray()), out var version)) {
 					return version;
+				}
+			}
 
 			throw new InvalidOperationException("Could not determine server version.");
+
+			IEnumerable<char> ReadVersion(string s) {
+				foreach (var c in s.TakeWhile(c => c == '.' || char.IsDigit(c))) {
+					yield return c;
+				}
+			}
 		}
 	}
 

--- a/test/EventStore.Client.Tests.Common/GlobalEnvironment.cs
+++ b/test/EventStore.Client.Tests.Common/GlobalEnvironment.cs
@@ -23,7 +23,7 @@ public static class GlobalEnvironment {
 			configuration.EnsureValue("ES_USE_EXTERNAL_SERVER", "false");
 
 			configuration.EnsureValue("ES_DOCKER_REGISTRY", "ghcr.io/eventstore/eventstore");
-			configuration.EnsureValue("ES_DOCKER_TAG", "latest");
+			configuration.EnsureValue("ES_DOCKER_TAG", "ci");
 			configuration.EnsureValue("ES_DOCKER_IMAGE", $"{configuration["ES_DOCKER_REGISTRY"]}:{configuration["ES_DOCKER_TAG"]}");
 
 			configuration.EnsureValue("EVENTSTORE_MEM_DB", "false");


### PR DESCRIPTION
esdb 24.x prints a semver when running with `--version`

System.Version cannot parse this.
