### PR TITLE
Disable throwing compiler errors for obsolete code

### DIFF
--- a/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClient.Read.cs
+++ b/src/EventStore.Client.PersistentSubscriptions/EventStorePersistentSubscriptionsClient.Read.cs
@@ -11,7 +11,7 @@ namespace EventStore.Client {
 		/// <exception cref="ArgumentNullException"></exception>
 		/// <exception cref="ArgumentException"></exception>
 		/// <exception cref="ArgumentOutOfRangeException"></exception>
-		[Obsolete("SubscribeAsync is no longer supported. Use SubscribeToStream with manual acks instead.", true)]
+		[Obsolete("SubscribeAsync is no longer supported. Use SubscribeToStream with manual acks instead.", false)]
 		public async Task<PersistentSubscription> SubscribeAsync(string streamName, string groupName,
 			Func<PersistentSubscription, ResolvedEvent, int?, CancellationToken, Task> eventAppeared,
 			Action<PersistentSubscription, SubscriptionDroppedReason, Exception?>? subscriptionDropped = null,
@@ -32,7 +32,7 @@ namespace EventStore.Client {
 		/// <exception cref="ArgumentNullException"></exception>
 		/// <exception cref="ArgumentException"></exception>
 		/// <exception cref="ArgumentOutOfRangeException"></exception>
-		[Obsolete("SubscribeToStreamAsync is no longer supported. Use SubscribeToStream with manual acks instead.", true)]
+		[Obsolete("SubscribeToStreamAsync is no longer supported. Use SubscribeToStream with manual acks instead.", false)]
 		public async Task<PersistentSubscription> SubscribeToStreamAsync(string streamName, string groupName,
 		                                                                 Func<PersistentSubscription, ResolvedEvent, int?, CancellationToken, Task> eventAppeared,
 		                                                                 Action<PersistentSubscription, SubscriptionDroppedReason, Exception?>? subscriptionDropped = null,
@@ -102,7 +102,7 @@ namespace EventStore.Client {
 		/// <summary>
 		/// Subscribes to a persistent subscription to $all. Messages must be manually acknowledged
 		/// </summary>
-		[Obsolete("SubscribeToAllAsync is no longer supported. Use SubscribeToAll with manual acks instead.", true)]
+		[Obsolete("SubscribeToAllAsync is no longer supported. Use SubscribeToAll with manual acks instead.", false)]
 		public async Task<PersistentSubscription> SubscribeToAllAsync(string groupName,
 		                                                              Func<PersistentSubscription, ResolvedEvent, int?, CancellationToken, Task> eventAppeared,
 		                                                              Action<PersistentSubscription, SubscriptionDroppedReason, Exception?>? subscriptionDropped = null,

--- a/src/EventStore.Client.Streams/EventStoreClient.Subscriptions.cs
+++ b/src/EventStore.Client.Streams/EventStoreClient.Subscriptions.cs
@@ -16,7 +16,7 @@ namespace EventStore.Client {
 		/// <param name="userCredentials">The optional user credentials to perform operation with.</param>
 		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
 		/// <returns></returns>
-		[Obsolete("SubscribeToAllAsync is no longer supported. Use SubscribeToAll instead.", true)]
+		[Obsolete("SubscribeToAllAsync is no longer supported. Use SubscribeToAll instead.", false)]
 		public Task<StreamSubscription> SubscribeToAllAsync(
 			FromAll start,
 			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
@@ -68,7 +68,7 @@ namespace EventStore.Client {
 		/// <param name="userCredentials">The optional user credentials to perform operation with.</param>
 		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
 		/// <returns></returns>
-		[Obsolete("SubscribeToStreamAsync is no longer supported. Use SubscribeToStream instead.", true)]
+		[Obsolete("SubscribeToStreamAsync is no longer supported. Use SubscribeToStream instead.", false)]
 		public Task<StreamSubscription> SubscribeToStreamAsync(string streamName,
 		                                                       FromStream start,
 		                                                       Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,


### PR DESCRIPTION
Fixed: #290 
Changed: Disable throwing compiler errors for obsolete code