### PR TITLE
DEV-45-2 - Pull es-gencert-cli from Cloudsmith

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,10 +80,10 @@ jobs:
       - name: Generate certificates
         run: |
           mkdir -p certs
-          docker run --rm --user root --volume "$PWD/certs:/tmp" ghcr.io/eventstore/es-gencert-cli:1.3 create-ca -out /tmp/ca
-          docker run --rm --user root --volume "$PWD/certs:/tmp" ghcr.io/eventstore/es-gencert-cli:1.3 create-node -ca-certificate /tmp/ca/ca.crt -ca-key /tmp/ca/ca.key -out /tmp/node -ip-addresses 127.0.0.1 -dns-names localhost
-          docker run --rm --user root --volume "$PWD/certs:/tmp" ghcr.io/eventstore/es-gencert-cli:1.3 create-user -username admin -ca-certificate /tmp/ca/ca.crt -ca-key /tmp/ca/ca.key -out /tmp/user-admin
-          docker run --rm --user root --volume "$PWD/certs:/tmp" ghcr.io/eventstore/es-gencert-cli:1.3 create-user -username invalid -ca-certificate /tmp/ca/ca.crt -ca-key /tmp/ca/ca.key -out /tmp/user-invalid
+          docker run --rm --user root --volume "$PWD/certs:/tmp" docker.eventstore.com/eventstore-utils/es-gencert-cli:1.3 create-ca -out /tmp/ca
+          docker run --rm --user root --volume "$PWD/certs:/tmp" docker.eventstore.com/eventstore-utils/es-gencert-cli:1.3 create-node -ca-certificate /tmp/ca/ca.crt -ca-key /tmp/ca/ca.key -out /tmp/node -ip-addresses 127.0.0.1 -dns-names localhost
+          docker run --rm --user root --volume "$PWD/certs:/tmp" docker.eventstore.com/eventstore-utils/es-gencert-cli:1.3 create-user -username admin -ca-certificate /tmp/ca/ca.crt -ca-key /tmp/ca/ca.key -out /tmp/user-admin
+          docker run --rm --user root --volume "$PWD/certs:/tmp" docker.eventstore.com/eventstore-utils/es-gencert-cli:1.3 create-user -username invalid -ca-certificate /tmp/ca/ca.crt -ca-key /tmp/ca/ca.key -out /tmp/user-invalid
       - name: Set permissions on certificates
         run: |
           sudo chown -R $USER:$USER certs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,10 +80,10 @@ jobs:
       - name: Generate certificates
         run: |
           mkdir -p certs
-          docker run --rm --user root --volume "$PWD/certs:/tmp" docker.eventstore.com/eventstore-utils/es-gencert-cli:1.3 create-ca -out /tmp/ca
-          docker run --rm --user root --volume "$PWD/certs:/tmp" docker.eventstore.com/eventstore-utils/es-gencert-cli:1.3 create-node -ca-certificate /tmp/ca/ca.crt -ca-key /tmp/ca/ca.key -out /tmp/node -ip-addresses 127.0.0.1 -dns-names localhost
-          docker run --rm --user root --volume "$PWD/certs:/tmp" docker.eventstore.com/eventstore-utils/es-gencert-cli:1.3 create-user -username admin -ca-certificate /tmp/ca/ca.crt -ca-key /tmp/ca/ca.key -out /tmp/user-admin
-          docker run --rm --user root --volume "$PWD/certs:/tmp" docker.eventstore.com/eventstore-utils/es-gencert-cli:1.3 create-user -username invalid -ca-certificate /tmp/ca/ca.crt -ca-key /tmp/ca/ca.key -out /tmp/user-invalid
+          docker run --rm --user root --volume "$PWD/certs:/tmp" docker.eventstore.com/eventstore-utils/es-gencert-cli:latest create-ca -out /tmp/ca
+          docker run --rm --user root --volume "$PWD/certs:/tmp" docker.eventstore.com/eventstore-utils/es-gencert-cli:latest create-node -ca-certificate /tmp/ca/ca.crt -ca-key /tmp/ca/ca.key -out /tmp/node -ip-addresses 127.0.0.1 -dns-names localhost
+          docker run --rm --user root --volume "$PWD/certs:/tmp" docker.eventstore.com/eventstore-utils/es-gencert-cli:latest create-user -username admin -ca-certificate /tmp/ca/ca.crt -ca-key /tmp/ca/ca.key -out /tmp/user-admin
+          docker run --rm --user root --volume "$PWD/certs:/tmp" docker.eventstore.com/eventstore-utils/es-gencert-cli:latest create-user -username invalid -ca-certificate /tmp/ca/ca.crt -ca-key /tmp/ca/ca.key -out /tmp/user-invalid
       - name: Set permissions on certificates
         run: |
           sudo chown -R $USER:$USER certs

--- a/gencert.ps1
+++ b/gencert.ps1
@@ -7,17 +7,17 @@ New-Item -ItemType Directory -Path .\certs -Force
 icacls .\certs /grant:r "$($env:UserName):(OI)(CI)F"
 
 # Pull the Docker image
-docker pull ghcr.io/eventstore/es-gencert-cli:1.3.0
+docker pull docker.eventstore.com/eventstore-utils/es-gencert-cli:1.3
 
-docker run --rm --volume .\certs:/tmp ghcr.io/eventstore/es-gencert-cli create-ca -out /tmp/ca
+docker run --rm --volume .\certs:/tmp docker.eventstore.com/eventstore-utils/es-gencert-cli create-ca -out /tmp/ca
 
-docker run --rm --volume .\certs:/tmp ghcr.io/eventstore/es-gencert-cli create-node -ca-certificate /tmp/ca/ca.crt -ca-key /tmp/ca/ca.key -out /tmp/node -ip-addresses 127.0.0.1 -dns-names localhost
+docker run --rm --volume .\certs:/tmp docker.eventstore.com/eventstore-utils/es-gencert-cli create-node -ca-certificate /tmp/ca/ca.crt -ca-key /tmp/ca/ca.key -out /tmp/node -ip-addresses 127.0.0.1 -dns-names localhost
 
 # Create admin user
-docker run --rm --volume .\certs:/tmp ghcr.io/eventstore/es-gencert-cli create-user -username admin -ca-certificate /tmp/ca/ca.crt -ca-key /tmp/ca/ca.key -out /tmp/user-admin
+docker run --rm --volume .\certs:/tmp docker.eventstore.com/eventstore-utils/es-gencert-cli create-user -username admin -ca-certificate /tmp/ca/ca.crt -ca-key /tmp/ca/ca.key -out /tmp/user-admin
 
 # Create an invalid user
-docker run --rm --volume .\certs:/tmp ghcr.io/eventstore/es-gencert-cli create-user -username invalid -ca-certificate /tmp/ca/ca.crt -ca-key /tmp/ca/ca.key -out /tmp/user-invalid
+docker run --rm --volume .\certs:/tmp docker.eventstore.com/eventstore-utils/es-gencert-cli create-user -username invalid -ca-certificate /tmp/ca/ca.crt -ca-key /tmp/ca/ca.key -out /tmp/user-invalid
 
 # Set permissions recursively for the directory
 icacls .\certs /grant:r "$($env:UserName):(OI)(CI)F"

--- a/gencert.ps1
+++ b/gencert.ps1
@@ -7,7 +7,7 @@ New-Item -ItemType Directory -Path .\certs -Force
 icacls .\certs /grant:r "$($env:UserName):(OI)(CI)F"
 
 # Pull the Docker image
-docker pull docker.eventstore.com/eventstore-utils/es-gencert-cli:1.3
+docker pull docker.eventstore.com/eventstore-utils/es-gencert-cli:latest
 
 docker run --rm --volume .\certs:/tmp docker.eventstore.com/eventstore-utils/es-gencert-cli create-ca -out /tmp/ca
 

--- a/gencert.sh
+++ b/gencert.sh
@@ -13,15 +13,15 @@ mkdir -p certs
 
 chmod 0755 ./certs
 
-docker pull ghcr.io/eventstore/es-gencert-cli:1.3.0
+docker pull docker.eventstore.com/eventstore-utils/es-gencert-cli:1.3
 
-docker run --rm --volume $PWD/certs:/tmp --user $(id -u):$(id -g) ghcr.io/eventstore/es-gencert-cli create-ca -out /tmp/ca
+docker run --rm --volume $PWD/certs:/tmp --user $(id -u):$(id -g) docker.eventstore.com/eventstore-utils/es-gencert-cli create-ca -out /tmp/ca
 
-docker run --rm --volume $PWD/certs:/tmp --user $(id -u):$(id -g) ghcr.io/eventstore/es-gencert-cli create-node -ca-certificate /tmp/ca/ca.crt -ca-key /tmp/ca/ca.key -out /tmp/node -ip-addresses 127.0.0.1 -dns-names localhost
+docker run --rm --volume $PWD/certs:/tmp --user $(id -u):$(id -g) docker.eventstore.com/eventstore-utils/es-gencert-cli create-node -ca-certificate /tmp/ca/ca.crt -ca-key /tmp/ca/ca.key -out /tmp/node -ip-addresses 127.0.0.1 -dns-names localhost
 
-docker run --rm --volume $PWD/certs:/tmp --user $(id -u):$(id -g) ghcr.io/eventstore/es-gencert-cli create-user -username admin -ca-certificate /tmp/ca/ca.crt -ca-key /tmp/ca/ca.key -out /tmp/user-admin
+docker run --rm --volume $PWD/certs:/tmp --user $(id -u):$(id -g) docker.eventstore.com/eventstore-utils/es-gencert-cli create-user -username admin -ca-certificate /tmp/ca/ca.crt -ca-key /tmp/ca/ca.key -out /tmp/user-admin
 
-docker run --rm --volume $PWD/certs:/tmp --user $(id -u):$(id -g) ghcr.io/eventstore/es-gencert-cli create-user -username invalid -ca-certificate /tmp/ca/ca.crt -ca-key /tmp/ca/ca.key -out /tmp/user-invalid
+docker run --rm --volume $PWD/certs:/tmp --user $(id -u):$(id -g) docker.eventstore.com/eventstore-utils/es-gencert-cli create-user -username invalid -ca-certificate /tmp/ca/ca.crt -ca-key /tmp/ca/ca.key -out /tmp/user-invalid
 
 chmod -R 0755 ./certs
 

--- a/gencert.sh
+++ b/gencert.sh
@@ -13,7 +13,7 @@ mkdir -p certs
 
 chmod 0755 ./certs
 
-docker pull docker.eventstore.com/eventstore-utils/es-gencert-cli:1.3
+docker pull docker.eventstore.com/eventstore-utils/es-gencert-cli:latest
 
 docker run --rm --volume $PWD/certs:/tmp --user $(id -u):$(id -g) docker.eventstore.com/eventstore-utils/es-gencert-cli create-ca -out /tmp/ca
 

--- a/samples/secure-with-tls/docker-compose.certs.yml
+++ b/samples/secure-with-tls/docker-compose.certs.yml
@@ -16,7 +16,7 @@ services:
     network_mode: none
   
   cert-gen:
-    image: eventstore/es-gencert-cli:1.3.0
+    image: eventstore/es-gencert-cli:latest.0
     container_name: cert-gen
     user: "1000:1000"
     entrypoint: [ "/bin/sh","-c" ]

--- a/samples/secure-with-tls/docker-compose.certs.yml
+++ b/samples/secure-with-tls/docker-compose.certs.yml
@@ -16,7 +16,7 @@ services:
     network_mode: none
   
   cert-gen:
-    image: eventstore/es-gencert-cli:latest.0
+    image: docker.eventstore.com/eventstore-utils/es-gencert-cli:latest
     container_name: cert-gen
     user: "1000:1000"
     entrypoint: [ "/bin/sh","-c" ]

--- a/test/EventStore.Client.Tests.Common/Fixtures/CertificatesManager.cs
+++ b/test/EventStore.Client.Tests.Common/Fixtures/CertificatesManager.cs
@@ -55,7 +55,7 @@ static class CertificatesManager {
 		static Task GenerateCertificates(string sourceFolder, string expectedLogMessage, string command, params string[] commandArgs) {
 			using var container = new Builder()
 				.UseContainer()
-				.UseImage("docker.eventstore.com/eventstore-utils/es-gencert-cli:1.3")
+				.UseImage("docker.eventstore.com/eventstore-utils/es-gencert-cli:latest")
 				.MountVolume(sourceFolder, "/tmp", Ductus.FluentDocker.Model.Builders.MountType.ReadWrite)
 				// .MountVolume(Options.CertificateDirectory.FullName, "/etc/eventstore/certs", MountType.ReadOnly)
 				.Command(command, commandArgs)

--- a/test/EventStore.Client.Tests.Common/Fixtures/CertificatesManager.cs
+++ b/test/EventStore.Client.Tests.Common/Fixtures/CertificatesManager.cs
@@ -55,7 +55,7 @@ static class CertificatesManager {
 		static Task GenerateCertificates(string sourceFolder, string expectedLogMessage, string command, params string[] commandArgs) {
 			using var container = new Builder()
 				.UseContainer()
-				.UseImage("ghcr.io/eventstore/es-gencert-cli:1.3.0")
+				.UseImage("docker.eventstore.com/eventstore-utils/es-gencert-cli:1.3")
 				.MountVolume(sourceFolder, "/tmp", Ductus.FluentDocker.Model.Builders.MountType.ReadWrite)
 				// .MountVolume(Options.CertificateDirectory.FullName, "/etc/eventstore/certs", MountType.ReadOnly)
 				.Command(command, commandArgs)

--- a/test/EventStore.Client.Tests.Common/docker-compose.certs.yml
+++ b/test/EventStore.Client.Tests.Common/docker-compose.certs.yml
@@ -16,7 +16,7 @@ services:
     network_mode: none
   
   cert-gen:
-    image: ghcr.io/eventstore/es-gencert-cli:1.3.0
+    image: docker.eventstore.com/eventstore-utils/es-gencert-cli:1.3
     container_name: cert-gen
     user: "1000:1000"
     entrypoint: [ "/bin/sh","-c" ]

--- a/test/EventStore.Client.Tests.Common/docker-compose.certs.yml
+++ b/test/EventStore.Client.Tests.Common/docker-compose.certs.yml
@@ -16,7 +16,7 @@ services:
     network_mode: none
   
   cert-gen:
-    image: docker.eventstore.com/eventstore-utils/es-gencert-cli:1.3
+    image: docker.eventstore.com/eventstore-utils/es-gencert-cli:latest
     container_name: cert-gen
     user: "1000:1000"
     entrypoint: [ "/bin/sh","-c" ]

--- a/test/EventStore.Client.Tests.Common/docker-compose.cluster.yml
+++ b/test/EventStore.Client.Tests.Common/docker-compose.cluster.yml
@@ -11,7 +11,7 @@ services:
     network_mode: none
     
   cert-gen:
-    image: ghcr.io/eventstore/es-gencert-cli:1.3.0
+    image: docker.eventstore.com/eventstore-utils/es-gencert-cli:1.3
     container_name: cert-gen
     user: "1000:1000"
     entrypoint: [ "/bin/sh","-c" ]

--- a/test/EventStore.Client.Tests.Common/docker-compose.cluster.yml
+++ b/test/EventStore.Client.Tests.Common/docker-compose.cluster.yml
@@ -11,7 +11,7 @@ services:
     network_mode: none
     
   cert-gen:
-    image: docker.eventstore.com/eventstore-utils/es-gencert-cli:1.3
+    image: docker.eventstore.com/eventstore-utils/es-gencert-cli:latest
     container_name: cert-gen
     user: "1000:1000"
     entrypoint: [ "/bin/sh","-c" ]

--- a/test/EventStore.Client.Tests.Common/docker-compose.yml
+++ b/test/EventStore.Client.Tests.Common/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     network_mode: none
     
   cert-gen:
-    image: ghcr.io/eventstore/es-gencert-cli:1.3.0
+    image: docker.eventstore.com/eventstore-utils/es-gencert-cli:1.3
     container_name: cert-gen
     user: "1000:1000"
     entrypoint: [ "/bin/sh","-c" ]

--- a/test/EventStore.Client.Tests.Common/docker-compose.yml
+++ b/test/EventStore.Client.Tests.Common/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     network_mode: none
     
   cert-gen:
-    image: docker.eventstore.com/eventstore-utils/es-gencert-cli:1.3
+    image: docker.eventstore.com/eventstore-utils/es-gencert-cli:latest
     container_name: cert-gen
     user: "1000:1000"
     entrypoint: [ "/bin/sh","-c" ]


### PR DESCRIPTION
Changed: Updated everywhere to pull es-gencert-cli from Cloudsmith