### PR TITLE
Handle missing null/None event filter cases on Streams APIs

### DIFF
--- a/src/EventStore.Client.Streams/EventStoreClient.Append.cs
+++ b/src/EventStore.Client.Streams/EventStoreClient.Append.cs
@@ -39,8 +39,8 @@ namespace EventStore.Client {
 
 			_log.LogDebug("Append to stream - {streamName}@{expectedRevision}.", streamName, expectedRevision);
 
-			var task = userCredentials is null && await _batchAppender.IsUsable().ConfigureAwait(false)
-                ? _batchAppender.Append(streamName, expectedRevision, eventData, deadline, cancellationToken)
+			var task = userCredentials is null && await BatchAppender.IsUsable().ConfigureAwait(false)
+                ? BatchAppender.Append(streamName, expectedRevision, eventData, deadline, cancellationToken)
                 : AppendToStreamInternal(
                     await GetChannelInfo(cancellationToken).ConfigureAwait(false),
                     new AppendReq {
@@ -85,8 +85,8 @@ namespace EventStore.Client {
 			_log.LogDebug("Append to stream - {streamName}@{expectedState}.", streamName, expectedState);
 
 			var task =
-				userCredentials == null && await _batchAppender.IsUsable().ConfigureAwait(false)
-					? _batchAppender.Append(streamName, expectedState, eventData, deadline, cancellationToken)
+				userCredentials == null && await BatchAppender.IsUsable().ConfigureAwait(false)
+					? BatchAppender.Append(streamName, expectedState, eventData, deadline, cancellationToken)
 					: AppendToStreamInternal(
 						await GetChannelInfo(cancellationToken).ConfigureAwait(false),
 						new AppendReq {

--- a/src/EventStore.Client/EventTypeFilter.cs
+++ b/src/EventStore.Client/EventTypeFilter.cs
@@ -12,7 +12,7 @@ namespace EventStore.Client {
 		/// </summary>
 		public static readonly EventTypeFilter None = default;
 
-		private readonly PrefixFilterExpression[] _prefixes;
+		readonly PrefixFilterExpression[] _prefixes;
 
 
 		/// <inheritdoc />
@@ -76,7 +76,7 @@ namespace EventStore.Client {
 		public static IEventFilter RegularExpression(Regex regex, uint maxSearchWindow = 32)
 			=> new EventTypeFilter(maxSearchWindow, new RegularFilterExpression(regex));
 
-		private EventTypeFilter(uint maxSearchWindow, RegularFilterExpression regex) {
+		EventTypeFilter(uint maxSearchWindow, RegularFilterExpression regex) {
 			if (maxSearchWindow == 0) {
 				throw new ArgumentOutOfRangeException(nameof(maxSearchWindow),
 					maxSearchWindow, $"{nameof(maxSearchWindow)} must be greater than 0.");
@@ -87,9 +87,9 @@ namespace EventStore.Client {
 			MaxSearchWindow = maxSearchWindow;
 		}
 
-		private EventTypeFilter(params PrefixFilterExpression[] prefixes) : this(32, prefixes) { }
+		EventTypeFilter(params PrefixFilterExpression[] prefixes) : this(32, prefixes) { }
 
-		private EventTypeFilter(uint maxSearchWindow, params PrefixFilterExpression[] prefixes) {
+		EventTypeFilter(uint maxSearchWindow, params PrefixFilterExpression[] prefixes) {
 			if (prefixes.Length == 0) {
 				throw new ArgumentException();
 			}

--- a/src/EventStore.Client/StreamFilter.cs
+++ b/src/EventStore.Client/StreamFilter.cs
@@ -12,7 +12,7 @@ namespace EventStore.Client {
 		/// </summary>
 		public static readonly StreamFilter None = default;
 
-		private readonly PrefixFilterExpression[] _prefixes;
+		readonly PrefixFilterExpression[] _prefixes;
 
 		/// <inheritdoc />
 		public PrefixFilterExpression[] Prefixes => _prefixes ?? Array.Empty<PrefixFilterExpression>();
@@ -67,9 +67,9 @@ namespace EventStore.Client {
 		public static IEventFilter RegularExpression(Regex regex, uint maxSearchWindow = 32)
 			=> new StreamFilter(maxSearchWindow, new RegularFilterExpression(regex));
 
-		private StreamFilter(RegularFilterExpression regex) : this(default, regex) { }
+		StreamFilter(RegularFilterExpression regex) : this(default, regex) { }
 
-		private StreamFilter(uint maxSearchWindow, RegularFilterExpression regex) {
+		StreamFilter(uint maxSearchWindow, RegularFilterExpression regex) {
 			if (maxSearchWindow == 0) {
 				throw new ArgumentOutOfRangeException(nameof(maxSearchWindow),
 					maxSearchWindow, $"{nameof(maxSearchWindow)} must be greater than 0.");
@@ -80,9 +80,9 @@ namespace EventStore.Client {
 			MaxSearchWindow = maxSearchWindow;
 		}
 
-		private StreamFilter(params PrefixFilterExpression[] prefixes) : this(32, prefixes) { }
+		StreamFilter(params PrefixFilterExpression[] prefixes) : this(32, prefixes) { }
 
-		private StreamFilter(uint maxSearchWindow, params PrefixFilterExpression[] prefixes) {
+		StreamFilter(uint maxSearchWindow, params PrefixFilterExpression[] prefixes) {
 			if (prefixes.Length == 0) {
 				throw new ArgumentException();
 			}


### PR DESCRIPTION
Changed: Updated Streams APIs to account for `null`, `StreamTypeFilter.None` & `EventTypeFilter.None` event filter scenarios.