### PR TITLE
Tracing improvements

### DIFF
--- a/src/EventStore.Client/Common/Diagnostics/ActivitySourceExtensions.cs
+++ b/src/EventStore.Client/Common/Diagnostics/ActivitySourceExtensions.cs
@@ -32,6 +32,9 @@ static class ActivitySourceExtensions {
         EventStoreClientSettings settings,
         UserCredentials? userCredentials
     ) {
+	    if (source.HasNoActiveListeners())
+		    return;
+
         var parentContext = resolvedEvent.OriginalEvent.Metadata.ExtractPropagationContext();
 
         if (parentContext is null) return;
@@ -53,6 +56,9 @@ static class ActivitySourceExtensions {
         this ActivitySource source,
         string operationName, ActivityKind activityKind, ActivityTagsCollection? tags = null, ActivityContext? parentContext = null
     ) {
+	    if (source.HasNoActiveListeners())
+		    return null;
+	    
         (tags ??= new ActivityTagsCollection())
             .WithRequiredTag(TelemetryTags.Database.System, "eventstoredb")
             .WithRequiredTag(TelemetryTags.Database.Operation, operationName);
@@ -67,4 +73,6 @@ static class ActivitySourceExtensions {
             )
             ?.Start();
     }
+    
+    static bool HasNoActiveListeners(this ActivitySource source) => !source.HasListeners();
 }

--- a/src/EventStore.Client/Common/Diagnostics/EventMetadataExtensions.cs
+++ b/src/EventStore.Client/Common/Diagnostics/EventMetadataExtensions.cs
@@ -17,14 +17,20 @@ static class EventMetadataExtensions {
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public static TracingMetadata ExtractTracingMetadata(this ReadOnlyMemory<byte> eventMetadata) {
-		var reader = new Utf8JsonReader(eventMetadata.Span);
-		
-		if (!JsonDocument.TryParseValue(ref reader, out var doc)
-		 || !doc.RootElement.TryGetProperty(TracingConstants.Metadata.TraceId, out var traceId)
-		 || !doc.RootElement.TryGetProperty(TracingConstants.Metadata.SpanId, out var spanId))
+		if (eventMetadata.IsEmpty)
 			return TracingMetadata.None;
 
-		return new TracingMetadata(traceId.GetString(), spanId.GetString());
+		var reader = new Utf8JsonReader(eventMetadata.Span);
+		if (!JsonDocument.TryParseValue(ref reader, out var doc))
+			return TracingMetadata.None;
+
+		using (doc) {
+			if (!doc.RootElement.TryGetProperty(TracingConstants.Metadata.TraceId, out var traceId)
+			 || !doc.RootElement.TryGetProperty(TracingConstants.Metadata.SpanId, out var spanId))
+				return TracingMetadata.None;
+
+			return new TracingMetadata(traceId.GetString(), spanId.GetString());
+		}
 	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/EventStore.Client/Common/Diagnostics/EventMetadataExtensions.cs
+++ b/src/EventStore.Client/Common/Diagnostics/EventMetadataExtensions.cs
@@ -23,7 +23,7 @@ static class EventMetadataExtensions {
 		var reader = new Utf8JsonReader(eventMetadata.Span);
 		if (!JsonDocument.TryParseValue(ref reader, out var doc))
 			return TracingMetadata.None;
-
+	
 		using (doc) {
 			if (!doc.RootElement.TryGetProperty(TracingConstants.Metadata.TraceId, out var traceId)
 			 || !doc.RootElement.TryGetProperty(TracingConstants.Metadata.SpanId, out var spanId))


### PR DESCRIPTION
Changed: Use TryParseValue when attempting to parse event metadata as JsonDocument, to prevent _unneccessary_ exception with catch.
Changed: Use TryGetProperty when extracting tracing metadata to prevent _unneccessary_ exception being thrown in absence thereof.
Changed: Added short-circuit to tracing logic to prevent unnecessary parsing of event data et al when there are no diagnostic listeners.

Fixes https://github.com/EventStore/EventStore-Client-Dotnet/issues/310