### PR TITLE
Fix tracing injection when event is non-JSON

### DIFF
--- a/src/EventStore.Client/Common/Diagnostics/ActivitySourceExtensions.cs
+++ b/src/EventStore.Client/Common/Diagnostics/ActivitySourceExtensions.cs
@@ -6,73 +6,77 @@ using EventStore.Diagnostics.Tracing;
 namespace EventStore.Client.Diagnostics;
 
 static class ActivitySourceExtensions {
-    public static async ValueTask<T> TraceClientOperation<T>(this ActivitySource source,
-        Func<ValueTask<T>> tracedOperation, 
-        string operationName, 
-        ActivityTagsCollection? tags = null
-    ) {
-        using var activity = StartActivity(source, operationName, ActivityKind.Client, tags, Activity.Current?.Context);
+	public static async ValueTask<T> TraceClientOperation<T>(
+		this ActivitySource source,
+		Func<ValueTask<T>> tracedOperation,
+		string operationName,
+		ActivityTagsCollection? tags = null
+	) {
+		using var activity = StartActivity(source, operationName, ActivityKind.Client, tags, Activity.Current?.Context);
 
-        try {
-            var res = await tracedOperation().ConfigureAwait(false);
-            activity?.StatusOk();
-            return res;
-        }
-        catch (Exception ex) {
-            activity?.StatusError(ex);
-            throw;
-        }
-    }
+		try {
+			var res = await tracedOperation().ConfigureAwait(false);
+			activity?.StatusOk();
+			return res;
+		}
+		catch (Exception ex) {
+			activity?.StatusError(ex);
+			throw;
+		}
+	}
 
-    public static void TraceSubscriptionEvent(
-        this ActivitySource source,
-        string? subscriptionId,
-        ResolvedEvent resolvedEvent,
-        ChannelInfo channelInfo,
-        EventStoreClientSettings settings,
-        UserCredentials? userCredentials
-    ) {
-	    if (source.HasNoActiveListeners())
-		    return;
+	public static void TraceSubscriptionEvent(
+		this ActivitySource source,
+		string? subscriptionId,
+		ResolvedEvent resolvedEvent,
+		ChannelInfo channelInfo,
+		EventStoreClientSettings settings,
+		UserCredentials? userCredentials
+	) {
+		if (resolvedEvent.OriginalEvent.ContentType != Constants.Metadata.ContentTypes.ApplicationJson)
+			return;
 
-        var parentContext = resolvedEvent.OriginalEvent.Metadata.ExtractPropagationContext();
+		if (source.HasNoActiveListeners())
+			return;
 
-        if (parentContext is null) return;
+		var parentContext = resolvedEvent.OriginalEvent.Metadata.ExtractPropagationContext();
 
-        var tags = new ActivityTagsCollection()
-            .WithRequiredTag(TelemetryTags.EventStore.Stream, resolvedEvent.OriginalEvent.EventStreamId)
-            .WithOptionalTag(TelemetryTags.EventStore.SubscriptionId, subscriptionId)
-            .WithRequiredTag(TelemetryTags.EventStore.EventId, resolvedEvent.OriginalEvent.EventId.ToString())
-            .WithRequiredTag(TelemetryTags.EventStore.EventType, resolvedEvent.OriginalEvent.EventType)
-            // Ensure consistent server.address attribute when connecting to cluster via dns discovery
-            .WithGrpcChannelServerTags(channelInfo)
-            .WithClientSettingsServerTags(settings)
-            .WithOptionalTag(TelemetryTags.Database.User, userCredentials?.Username ?? settings.DefaultCredentials?.Username);
-        
-        StartActivity(source, TracingConstants.Operations.Subscribe, ActivityKind.Consumer, tags, parentContext)?.Dispose();
-    }
-    
-    static Activity? StartActivity(
-        this ActivitySource source,
-        string operationName, ActivityKind activityKind, ActivityTagsCollection? tags = null, ActivityContext? parentContext = null
-    ) {
-	    if (source.HasNoActiveListeners())
-		    return null;
-	    
-        (tags ??= new ActivityTagsCollection())
-            .WithRequiredTag(TelemetryTags.Database.System, "eventstoredb")
-            .WithRequiredTag(TelemetryTags.Database.Operation, operationName);
-        
-        return source
-            .CreateActivity(
-                operationName,
-                activityKind,
-                parentContext ?? default,
-                tags,
-                idFormat: ActivityIdFormat.W3C
-            )
-            ?.Start();
-    }
-    
-    static bool HasNoActiveListeners(this ActivitySource source) => !source.HasListeners();
+		if (parentContext is null) return;
+
+		var tags = new ActivityTagsCollection()
+			.WithRequiredTag(TelemetryTags.EventStore.Stream, resolvedEvent.OriginalEvent.EventStreamId)
+			.WithOptionalTag(TelemetryTags.EventStore.SubscriptionId, subscriptionId)
+			.WithRequiredTag(TelemetryTags.EventStore.EventId, resolvedEvent.OriginalEvent.EventId.ToString())
+			.WithRequiredTag(TelemetryTags.EventStore.EventType, resolvedEvent.OriginalEvent.EventType)
+			// Ensure consistent server.address attribute when connecting to cluster via dns discovery
+			.WithGrpcChannelServerTags(channelInfo)
+			.WithClientSettingsServerTags(settings)
+			.WithOptionalTag(TelemetryTags.Database.User, userCredentials?.Username ?? settings.DefaultCredentials?.Username);
+
+		StartActivity(source, TracingConstants.Operations.Subscribe, ActivityKind.Consumer, tags, parentContext)?.Dispose();
+	}
+
+	static Activity? StartActivity(
+		this ActivitySource source,
+		string operationName, ActivityKind activityKind, ActivityTagsCollection? tags = null, ActivityContext? parentContext = null
+	) {
+		if (source.HasNoActiveListeners())
+			return null;
+
+		(tags ??= new ActivityTagsCollection())
+			.WithRequiredTag(TelemetryTags.Database.System, "eventstoredb")
+			.WithRequiredTag(TelemetryTags.Database.Operation, operationName);
+
+		return source
+			.CreateActivity(
+				operationName,
+				activityKind,
+				parentContext ?? default,
+				tags,
+				idFormat: ActivityIdFormat.W3C
+			)
+			?.Start();
+	}
+
+	static bool HasNoActiveListeners(this ActivitySource source) => !source.HasListeners();
 }

--- a/src/EventStore.Client/Common/Diagnostics/EventMetadataExtensions.cs
+++ b/src/EventStore.Client/Common/Diagnostics/EventMetadataExtensions.cs
@@ -21,15 +21,20 @@ static class EventMetadataExtensions {
 			return TracingMetadata.None;
 
 		var reader = new Utf8JsonReader(eventMetadata.Span);
-		if (!JsonDocument.TryParseValue(ref reader, out var doc))
-			return TracingMetadata.None;
-	
-		using (doc) {
-			if (!doc.RootElement.TryGetProperty(TracingConstants.Metadata.TraceId, out var traceId)
-			 || !doc.RootElement.TryGetProperty(TracingConstants.Metadata.SpanId, out var spanId))
+		try {
+			if (!JsonDocument.TryParseValue(ref reader, out var doc))
 				return TracingMetadata.None;
 
-			return new TracingMetadata(traceId.GetString(), spanId.GetString());
+			using (doc) {
+				if (!doc.RootElement.TryGetProperty(TracingConstants.Metadata.TraceId, out var traceId)
+				 || !doc.RootElement.TryGetProperty(TracingConstants.Metadata.SpanId, out var spanId))
+					return TracingMetadata.None;
+
+				return new TracingMetadata(traceId.GetString(), spanId.GetString());
+			}
+		}
+		catch (Exception) {
+			return TracingMetadata.None;
 		}
 	}
 

--- a/src/EventStore.Client/EventStore.Client.csproj
+++ b/src/EventStore.Client/EventStore.Client.csproj
@@ -29,7 +29,7 @@
     
     <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
         <PackageReference Include="System.Net.Http.WinHttpHandler" Version="8.0.0"/>
-        <PackageReference Include="System.Text.Json" Version="8.0.3"/>
+        <PackageReference Include="System.Text.Json" Version="8.0.4" />
         <PackageReference Include="System.Threading.Channels" Version="8.0.0"/>
         <PackageReference Include="BouncyCastle.Cryptography" Version="2.3.1" />
     </ItemGroup>

--- a/test/EventStore.Client.Tests.Common/Fixtures/EventStoreFixture.Helpers.cs
+++ b/test/EventStore.Client.Tests.Common/Fixtures/EventStoreFixture.Helpers.cs
@@ -19,8 +19,8 @@ public partial class EventStoreFixture {
 
 	public ReadOnlyMemory<byte> CreateTestJsonMetadata() => "{\"Foo\": \"Bar\"}"u8.ToArray();
 
-	public IEnumerable<EventData> CreateTestEvents(int count = 1, string? type = null, ReadOnlyMemory<byte>? metadata = null) =>
-		Enumerable.Range(0, count).Select(index => CreateTestEvent(index, type ?? TestEventType, metadata));
+	public IEnumerable<EventData> CreateTestEvents(int count = 1, string? type = null, ReadOnlyMemory<byte>? metadata = null, string? contentType = null) =>
+		Enumerable.Range(0, count).Select(index => CreateTestEvent(index, type ?? TestEventType, metadata, contentType));
 
 	public IEnumerable<EventData> CreateTestEventsThatThrowsException() {
 		// Ensure initial IEnumerator.Current does not throw
@@ -32,12 +32,13 @@ public partial class EventStoreFixture {
 
 	protected static EventData CreateTestEvent(int index) => CreateTestEvent(index, TestEventType);
 
-	protected static EventData CreateTestEvent(int index, string type, ReadOnlyMemory<byte>? metadata = null) =>
+	protected static EventData CreateTestEvent(int index, string type, ReadOnlyMemory<byte>? metadata = null, string? contentType = null) =>
 		new(
 			Uuid.NewUuid(),
 			type,
 			Encoding.UTF8.GetBytes($$"""{"x":{{index}}}"""),
-			metadata
+			metadata,
+			contentType ?? "application/json"
 		);
 
 	public async Task<TestUser> CreateTestUser(bool withoutGroups = true, bool useUserCredentials = false) {


### PR DESCRIPTION
Changed: Made trace context injection/extraction more robust.
Changed: Trace context injection/extraction will only occur when event content type is json.

Fixes https://github.com/EventStore/EventStore-Client-Dotnet/issues/316