### PR TITLE
Fix check for parent context when extract propagation context fails

### DIFF
--- a/src/EventStore.Client.Streams/EventStoreClient.Append.cs
+++ b/src/EventStore.Client.Streams/EventStoreClient.Append.cs
@@ -132,13 +132,9 @@ namespace EventStore.Client {
 				foreach (var e in eventData) {
 					var appendReq = new AppendReq {
 						ProposedMessage = new() {
-							Id   = e.EventId.ToDto(),
-							Data = ByteString.CopyFrom(e.Data.Span),
-							CustomMetadata = ByteString.CopyFrom(
-								e.ContentType == Constants.Metadata.ContentTypes.ApplicationJson
-									? e.Metadata.InjectTracingContext(Activity.Current)
-									: e.Metadata.Span
-							),
+							Id             = e.EventId.ToDto(),
+							Data           = ByteString.CopyFrom(e.Data.Span),
+							CustomMetadata = ByteString.CopyFrom(e.Metadata.InjectTracingContext(Activity.Current)),
 							Metadata = {
 								{ Constants.Metadata.Type, e.Type },
 								{ Constants.Metadata.ContentType, e.ContentType }
@@ -392,13 +388,9 @@ namespace EventStore.Client {
 
 				foreach (var eventData in events) {
 					var proposedMessage = new BatchAppendReq.Types.ProposedMessage {
-						Data = ByteString.CopyFrom(eventData.Data.Span),
-						CustomMetadata = ByteString.CopyFrom(
-							eventData.ContentType == Constants.Metadata.ContentTypes.ApplicationJson
-								? eventData.Metadata.InjectTracingContext(Activity.Current)
-								: eventData.Metadata.Span
-						),
-						Id = eventData.EventId.ToDto(),
+						Data           = ByteString.CopyFrom(eventData.Data.Span),
+						CustomMetadata = ByteString.CopyFrom(eventData.Metadata.InjectTracingContext(Activity.Current)),
+						Id             = eventData.EventId.ToDto(),
 						Metadata = {
 							{ Constants.Metadata.Type, eventData.Type },
 							{ Constants.Metadata.ContentType, eventData.ContentType }

--- a/src/EventStore.Client/Common/Diagnostics/ActivitySourceExtensions.cs
+++ b/src/EventStore.Client/Common/Diagnostics/ActivitySourceExtensions.cs
@@ -35,7 +35,7 @@ static class ActivitySourceExtensions {
 		if (source.HasNoActiveListeners())
 			return;
 
-		var parentContext = resolvedEvent.OriginalEvent.Metadata.ExtractPropagationContext();
+		var parentContext = resolvedEvent.Event.Metadata.ExtractPropagationContext();
 
 		if (parentContext == default(ActivityContext)) return;
 

--- a/src/EventStore.Client/Common/Diagnostics/Core/Tracing/TracingMetadata.cs
+++ b/src/EventStore.Client/Common/Diagnostics/Core/Tracing/TracingMetadata.cs
@@ -25,8 +25,7 @@ readonly record struct TracingMetadata(
 					isRemote: isRemote
 				)
 				: default;
-		}
-		catch (Exception) {
+		} catch (Exception) {
 			return default;
 		}
 	}

--- a/src/EventStore.Client/Common/Diagnostics/EventMetadataExtensions.cs
+++ b/src/EventStore.Client/Common/Diagnostics/EventMetadataExtensions.cs
@@ -8,7 +8,9 @@ namespace EventStore.Client.Diagnostics;
 
 static class EventMetadataExtensions {
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public static ReadOnlySpan<byte> InjectTracingContext(this ReadOnlyMemory<byte> eventMetadata, Activity? activity) =>
+	public static ReadOnlySpan<byte> InjectTracingContext(
+		this ReadOnlyMemory<byte> eventMetadata, Activity? activity
+	) =>
 		eventMetadata.InjectTracingMetadata(activity?.GetTracingMetadata() ?? TracingMetadata.None);
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -32,14 +34,15 @@ static class EventMetadataExtensions {
 
 				return new TracingMetadata(traceId.GetString(), spanId.GetString());
 			}
-		}
-		catch (Exception) {
+		} catch (Exception) {
 			return TracingMetadata.None;
 		}
 	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	static ReadOnlySpan<byte> InjectTracingMetadata(this ReadOnlyMemory<byte> eventMetadata, TracingMetadata tracingMetadata) {
+	static ReadOnlySpan<byte> InjectTracingMetadata(
+		this ReadOnlyMemory<byte> eventMetadata, TracingMetadata tracingMetadata
+	) {
 		if (tracingMetadata == TracingMetadata.None || !tracingMetadata.IsValid)
 			return eventMetadata.Span;
 
@@ -49,7 +52,9 @@ static class EventMetadataExtensions {
 	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	static ReadOnlyMemory<byte> TryInjectTracingMetadata(this ReadOnlyMemory<byte> utf8Json, TracingMetadata tracingMetadata) {
+	static ReadOnlyMemory<byte> TryInjectTracingMetadata(
+		this ReadOnlyMemory<byte> utf8Json, TracingMetadata tracingMetadata
+	) {
 		try {
 			using var doc    = JsonDocument.Parse(utf8Json);
 			using var stream = new MemoryStream();
@@ -72,8 +77,7 @@ static class EventMetadataExtensions {
 			writer.Flush();
 
 			return stream.ToArray();
-		}
-		catch (Exception) {
+		} catch (Exception) {
 			return utf8Json;
 		}
 	}

--- a/test/EventStore.Client.Streams.Tests/Diagnostics/StreamsTracingInstrumentationTests.cs
+++ b/test/EventStore.Client.Streams.Tests/Diagnostics/StreamsTracingInstrumentationTests.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using EventStore.Client.Diagnostics;
 using EventStore.Diagnostics.Tracing;
 
@@ -89,7 +88,7 @@ public class StreamsTracingInstrumentationTests(ITestOutputHelper output, Diagno
 	}
 
 	[Fact]
-	public async Task TracingContextIsNotInjectedWhenEventIsNotJsonButHasJsonMetadata() {
+	public async Task TracingContextIsInjectedWhenEventIsNotJsonButHasJsonMetadata() {
 		var stream = Fixture.GetStreamName();
 
 		var inputMetadata = Fixture.CreateTestJsonMetadata().ToArray();
@@ -107,8 +106,11 @@ public class StreamsTracingInstrumentationTests(ITestOutputHelper output, Diagno
 			.ToListAsync();
 
 		var outputMetadata = readResult[0].OriginalEvent.Metadata.ToArray();
-		var test           = JsonSerializer.Deserialize<object>(outputMetadata);
-		outputMetadata.ShouldBe(inputMetadata);
+		outputMetadata.ShouldNotBe(inputMetadata);
+
+		var appendActivities = Fixture.GetActivitiesForOperation(TracingConstants.Operations.Append, stream);
+
+		appendActivities.ShouldNotBeEmpty();
 	}
 
 	[Fact]

--- a/test/EventStore.Client.Tests.Common/Fixtures/DiagnosticsFixture.cs
+++ b/test/EventStore.Client.Tests.Common/Fixtures/DiagnosticsFixture.cs
@@ -14,7 +14,7 @@ public class DiagnosticsFixture : EventStoreFixture {
 	public DiagnosticsFixture() {
 		var diagnosticActivityListener = new ActivityListener {
 			ShouldListenTo = source => source.Name == EventStoreClientDiagnostics.InstrumentationName,
-			Sample         = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+			Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
 			ActivityStopped = activity => {
 				var operation = (string?)activity.GetTagItem(TelemetryTags.Database.Operation);
 				var stream    = (string?)activity.GetTagItem(TelemetryTags.EventStore.Stream);
@@ -71,23 +71,37 @@ public class DiagnosticsFixture : EventStoreFixture {
 		var actualEvent = activity.Events.ShouldHaveSingleItem();
 
 		actualEvent.Name.ShouldBe(TelemetryTags.Exception.EventName);
-		actualEvent.Tags.ShouldContain(new KeyValuePair<string, object?>(TelemetryTags.Exception.Type, actualException.GetType().FullName));
-		actualEvent.Tags.ShouldContain(new KeyValuePair<string, object?>(TelemetryTags.Exception.Message, actualException.Message));
+		actualEvent.Tags.ShouldContain(
+			new KeyValuePair<string, object?>(TelemetryTags.Exception.Type, actualException.GetType().FullName)
+		);
+
+		actualEvent.Tags.ShouldContain(
+			new KeyValuePair<string, object?>(TelemetryTags.Exception.Message, actualException.Message)
+		);
+
 		actualEvent.Tags.Any(x => x.Key == TelemetryTags.Exception.Stacktrace).ShouldBeTrue();
 	}
 
-	public void AssertSubscriptionActivityHasExpectedTags(Activity activity, string stream, string eventId, string? subscriptionId) {
+	public void AssertSubscriptionActivityHasExpectedTags(
+		Activity activity,
+		string stream,
+		string eventId,
+		string? subscriptionId = null
+	) {
 		var expectedTags = new Dictionary<string, string?> {
 			{ TelemetryTags.Database.System, EventStoreClientDiagnostics.InstrumentationName },
 			{ TelemetryTags.Database.Operation, TracingConstants.Operations.Subscribe },
 			{ TelemetryTags.EventStore.Stream, stream },
 			{ TelemetryTags.EventStore.EventId, eventId },
 			{ TelemetryTags.EventStore.EventType, TestEventType },
-			{ TelemetryTags.EventStore.SubscriptionId, subscriptionId },
 			{ TelemetryTags.Database.User, TestCredentials.Root.Username }
 		};
 
-		foreach (var tag in expectedTags)
+		if (subscriptionId != null)
+			expectedTags[TelemetryTags.EventStore.SubscriptionId] = subscriptionId;
+
+		foreach (var tag in expectedTags) {
 			activity.Tags.ShouldContain(tag);
+		}
 	}
 }

--- a/test/EventStore.Client.Tests.Common/Fixtures/EventStoreFixture.Helpers.cs
+++ b/test/EventStore.Client.Tests.Common/Fixtures/EventStoreFixture.Helpers.cs
@@ -19,8 +19,18 @@ public partial class EventStoreFixture {
 
 	public ReadOnlyMemory<byte> CreateTestJsonMetadata() => "{\"Foo\": \"Bar\"}"u8.ToArray();
 
-	public IEnumerable<EventData> CreateTestEvents(int count = 1, string? type = null, ReadOnlyMemory<byte>? metadata = null, string? contentType = null) =>
-		Enumerable.Range(0, count).Select(index => CreateTestEvent(index, type ?? TestEventType, metadata, contentType));
+	public ReadOnlyMemory<byte> CreateTestNonJsonMetadata() => "non-json-metadata"u8.ToArray();
+
+	public IEnumerable<EventData> CreateTestEvents(
+		int count = 1, string? type = null, ReadOnlyMemory<byte>? metadata = null, string? contentType = null
+	) =>
+		Enumerable.Range(0, count)
+			.Select(index => CreateTestEvent(index, type ?? TestEventType, metadata, contentType));
+
+	public EventData CreateTestEvent(
+		string? type = null, ReadOnlyMemory<byte>? metadata = null, string? contentType = null
+	) =>
+		CreateTestEvent(0, type ?? TestEventType, metadata, contentType);
 
 	public IEnumerable<EventData> CreateTestEventsThatThrowsException() {
 		// Ensure initial IEnumerator.Current does not throw
@@ -32,7 +42,9 @@ public partial class EventStoreFixture {
 
 	protected static EventData CreateTestEvent(int index) => CreateTestEvent(index, TestEventType);
 
-	protected static EventData CreateTestEvent(int index, string type, ReadOnlyMemory<byte>? metadata = null, string? contentType = null) =>
+	protected static EventData CreateTestEvent(
+		int index, string type, ReadOnlyMemory<byte>? metadata = null, string? contentType = null
+	) =>
 		new(
 			Uuid.NewUuid(),
 			type,


### PR DESCRIPTION
Changed: Removed check for "application/json" when tracing subscriptions
Changed: Try to inject trace context in metadata regardless of event type.
Changed: Extract trace context from Event rather than OriginalEvent to account for link metadata.
Fixed: Fix check for parent context when extract propagation context fails

Previously, `if (parentContext == null) return;` was returning false even though the extraction of the propagation context had failed. I changed it to `parentContext == default(ActivityContext)` because the tracing method returns a default `ActivityContext` when it fails to extract the trace context.