### PR TITLE
[DEV-890] Fix certificate loading for net 8

### DIFF
--- a/src/KurrentDB.Client/Kurrent.Client/Internal/CertificateLoader.cs
+++ b/src/KurrentDB.Client/Kurrent.Client/Internal/CertificateLoader.cs
@@ -56,7 +56,7 @@ static class CertificateLoader {
         #if NET9_0_OR_GREATER
         return X509CertificateLoader.LoadCertificateFromFile(certPath);
         #else
-        return X509Certificate2.CreateFromPemFile(certPath);
+        return new(certPath);
         #endif
 
         return IsNullOrEmpty(password)


### PR DESCRIPTION
`X509Certificate2.CreateFromPemFile` with a single parameter uses the same file content for both certificate and key parameters internally, expecting to find both a certificate and private key in the same file.

