### PR TITLE
[DB-1602] Add workflow correlation

### DIFF
--- a/.github/workflows/dispatch-ee.yml
+++ b/.github/workflows/dispatch-ee.yml
@@ -1,5 +1,5 @@
 name: Dispatch
-run-name: "Dispatch [RunId: ${{ github.run_id }}] [${{ inputs.correlation-id }}]"
+run-name: "Dispatch [${{ inputs.correlation-id }}]"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
So that the workflow can be dispatched and monitored programatically.

When dispatching the workflow, a correlation-id can be provided as an input, the github API can then be used to find list the workflow runs and find the one we just started.