### PR TITLE
Added CLAUDE.md and CC skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,195 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+KurrentDB .NET Client SDK — a gRPC-based .NET client library for KurrentDB (formerly EventStoreDB). Published as the `KurrentDB.Client` NuGet package. Compatible with KurrentDB server v20.6.1+.
+
+## Build Commands
+
+```bash
+# Build the solution
+dotnet build KurrentDB.Client.sln
+
+# Build in release mode
+dotnet build KurrentDB.Client.sln --configuration release
+
+# Pack NuGet package (version derived from git tags via MinVer, tag prefix "v")
+dotnet pack --configuration Release
+```
+
+## Testing
+
+Tests are integration tests that run against a KurrentDB instance via Docker (using FluentDocker/TestContainers). Certificates must be generated before running tests.
+
+```bash
+# Generate test certificates (requires Docker, run with sudo on Linux)
+sudo ./gencert.sh
+
+# Run all tests
+dotnet test --configuration release test/KurrentDB.Client.Tests
+
+# Run tests for a specific category
+dotnet test --configuration release --framework net9.0 \
+  --filter "Category=Target:Streams" \
+  test/KurrentDB.Client.Tests
+
+# Run a single test class
+dotnet test --configuration release --framework net9.0 \
+  --filter "FullyQualifiedName~AppendToStreamTests" \
+  test/KurrentDB.Client.Tests
+```
+
+**Test categories** (used in CI matrix): `Streams`, `PersistentSubscriptions`, `Operations`, `UserManagement`, `ProjectionManagement`, `Security`, `Diagnostics`, `Misc`
+
+**Target frameworks for tests**: `net8.0`, `net9.0`, `net10.0`
+
+**Test infrastructure**: xUnit with Shouldly assertions, Bogus for fake data, Polly for resilience. Tests use `KurrentDBTemporaryFixture` (per-test instance) and `KurrentDBPermanentFixture` (shared across tests).
+
+### Test Conventions
+
+**Class structure** — Tests use primary constructors with dependency injection into a base class:
+
+```csharp
+[Trait("Category", "Target:Streams")]
+[Trait("Category", "Operation:Read")]
+public class ReadStreamForwardTests(ITestOutputHelper output, ReadStreamForwardTests.CustomFixture fixture)
+    : KurrentDBPermanentTests<ReadStreamForwardTests.CustomFixture>(output, fixture) {
+
+    [Fact]
+    public async Task my_test() { ... }
+
+    public class CustomFixture : KurrentDBPermanentFixture {
+        public CustomFixture() {
+            OnSetup = async () => { /* custom setup */ };
+        }
+    }
+}
+```
+
+**Naming** — Test classes: `<Feature>Tests`. Test methods: `snake_case` describing expected behavior (e.g., `throws_when_stream_does_not_exist`).
+
+**Fixtures** — `KurrentDBPermanentFixture` is shared across tests (use when tests don't need isolation). `KurrentDBTemporaryFixture` creates a fresh KurrentDB instance per test class (use for projections or when isolation is needed). Custom fixtures are nested classes inside the test class.
+
+**Fixture helpers** — Fixtures expose client properties (`Streams`, `Subscriptions`, `DBProjections`, `DBUsers`, `DBOperations`) and helper methods:
+- `GetStreamName()` / `GetGroupName()` / `GetProjectionName()` — generate unique names using `[CallerMemberName]` + GUID
+- `CreateTestEvents(count)` / `CreateTestEvent()` — create test `EventData` instances
+- `CreateTestUser()` — create a test user with credentials
+- `Faker` — Bogus faker instance for random data
+
+**Traits** — Every test class must have `[Trait("Category", "Target:<Category>")]` matching one of the CI categories. Additional operation-level traits are optional (e.g., `Operation:Read:Forwards`).
+
+**Special attributes**:
+- `[RetryFact]` — Use instead of `[Fact]` for flaky/timing-sensitive tests (xRetry)
+- `[MinimumVersion.Fact(major, minor?)]` — Skip test if KurrentDB version is too old
+- `[Regression.Fact(version, reason)]` — Mark regression tests
+- `[Theory]` with `[InlineData]`, `[MemberData]`, or custom `TestCaseGenerator` subclasses for data-driven tests
+
+**Assertions** — Mix of Shouldly (`result.ShouldBe(...)`) and xUnit Assert (`Assert.Equal(...)`). Custom Shouldly extension `ShouldThrowAsync` exists for `ReadStreamResult`.
+
+**Auth in tests** — `TestCredentials.Root` provides admin credentials (admin/changeit). Use `CreateTestUser()` for non-admin users. Fixtures can be configured with `.WithoutDefaultCredentials()`.
+
+### Test Infrastructure
+
+Tests spin up KurrentDB via Docker containers managed by FluentDocker. Docker compose files live in `test/KurrentDB.Client.Tests.Common/`:
+- `docker-compose.yml` / `docker-compose.node.yml` — Single node
+- `docker-compose.cluster.yml` — 4-node cluster (3 nodes + 1 read-only replica)
+- `docker-compose.certs.yml` — Certificate generation
+
+The `TESTCONTAINER_KURRENTDB_IMAGE` environment variable controls which Docker image is used.
+
+## Architecture
+
+### Solution Structure
+
+- `src/KurrentDB.Client/` — The main client library (single NuGet package)
+- `test/KurrentDB.Client.Tests/` — Integration tests
+- `test/KurrentDB.Client.Tests.Common/` — Shared test fixtures, Docker compose files, certificates
+- `samples/` — Sample projects (separate `Samples.sln`)
+
+### Client Classes
+
+All clients inherit from `KurrentDBClientBase` and communicate via gRPC:
+
+| Client | Purpose |
+|--------|---------|
+| `KurrentDBClient` | Stream operations (append, read, subscribe, delete, metadata) |
+| `KurrentDBPersistentSubscriptionsClient` | Persistent subscription management |
+| `KurrentDBProjectionManagementClient` | Projection CRUD and control |
+| `KurrentDBUserManagementClient` | User and role management |
+| `KurrentDBOperationsClient` | Admin operations (scavenge, etc.) |
+
+`KurrentDBClient` is split into partial classes by operation: `.Append`, `.Read`, `.Subscriptions`, `.Delete`, `.Metadata`, `.Tombstone`, `.MultiAppend`.
+
+### Source Layout (src/KurrentDB.Client/)
+
+- `Core/` — Base classes, settings, exceptions, gRPC interceptors, proto definitions
+  - `proto/` — Protocol Buffer definitions (v1, v2, and kurrent protocol)
+  - `Interceptors/` — gRPC interceptor chain (exception mapping, leader routing, connection naming)
+  - `Exceptions/` — Domain-specific exception types
+  - `Common/Diagnostics/` — OpenTelemetry tracing
+- `Streams/` — Stream operations and types (the primary API surface)
+- `PersistentSubscriptions/` — Persistent subscription operations
+- `ProjectionManagement/` — Projection operations
+- `UserManagement/` — User management operations
+- `Operations/` — Administrative operations
+- `OpenTelemetry/` — OTel extension methods
+
+### Connection Configuration
+
+Clients are configured via `KurrentDBClientSettings`, which supports:
+- **Connection strings**: `esdb://`, `kdb://`, `kurrent://`, `kurrentdb://` schemes (all with `+discover` variants)
+- **Programmatic configuration**: Direct property assignment
+- **Dependency injection**: `IServiceCollection.AddKurrentDBClient()` extensions
+
+### Key Types
+
+- `EventData` — Event payload (EventId, Type, Data bytes, Metadata bytes, ContentType)
+- `ResolvedEvent` / `EventRecord` — Read-side event representation
+- `StreamState` — Expected stream state for optimistic concurrency (Any, NoStream, StreamExists, or specific revision)
+- `Uuid` — Cross-language compatible RFC-4122 v4 UUID with bit reordering
+
+### gRPC & Protocol Buffers
+
+Proto files live in `Core/proto/` with code generated via `Grpc.Tools`. The library supports:
+- **v1 protocol**: Standard operations (streams, persistent subscriptions, projections, etc.)
+- **v2 protocol**: Newer operations like `MultiStreamAppend` (server 25.1+)
+
+## Samples
+
+13 sample projects in `samples/` (built via `samples/Samples.sln`), targeting `net8.0` and `net9.0`. Each is a standalone console app demonstrating a specific feature (e.g., `appending-events`, `reading-events`, `persistent-subscriptions`).
+
+**Key conventions**:
+- Shared build config in `samples/Directory.Build.props` (sets OutputType, TargetFrameworks, global usings for `KurrentDB.Client` and `System.Text`)
+- Each sample has a `Program.cs` with all demo code
+- **`#region` markers** are used to delimit code snippets that get extracted into documentation (e.g., `#region append-to-stream` ... `#endregion append-to-stream`). Preserve these markers when editing samples.
+- Connection strings support environment variable overrides with fallback defaults
+
+```bash
+# Build all samples
+dotnet build samples/Samples.sln
+```
+
+## Documentation
+
+VuePress 2.0 site in `docs/`, deployed via Cloudflare. API docs are markdown files in `docs/api/` (getting-started, appending-events, reading-events, subscriptions, etc.).
+
+- Page ordering is controlled by `order` frontmatter
+- A custom `xode` markdown plugin imports code snippets from sample files using `#region` markers — this is why region markers in samples matter
+- Documentation builds are triggered automatically on markdown changes to `release/**` branches
+
+```bash
+# Local docs development (requires pnpm)
+cd docs && pnpm install && pnpm dev
+```
+
+## C# Code Style
+
+- **Indentation**: Tabs (size 4), enforced by `.editorconfig`
+- **Braces**: Same-line (K&R style) — `csharp_new_line_before_open_brace = none`
+- **Private fields**: `_camelCase` prefix
+- **Constants**: PascalCase
+- **Nullable reference types**: Enabled globally
+- **Warnings as errors**: Enabled (`TreatWarningsAsErrors: true`)
+- **Target frameworks**: `net48`, `net8.0`, `net9.0`, `net10.0`

--- a/claude-skill/.claude-plugin/plugin.json
+++ b/claude-skill/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "kurrentdb-dotnet",
+  "description": "KurrentDB .NET Client SDK guidance — connection setup, event appending/reading, subscriptions, projections, and migration from EventStoreDB",
+  "version": "1.0.0"
+}

--- a/claude-skill/skills/kurrentdb/SKILL.md
+++ b/claude-skill/skills/kurrentdb/SKILL.md
@@ -122,23 +122,15 @@ var result = await client.AppendToStreamAsync("order-123", StreamState.StreamRev
 
 ### Multi-Stream Append (Server 25.1+)
 
-Atomic writes across multiple streams in a single transaction:
+Atomic writes across multiple streams in a single transaction. `AppendStreamRequest` is a positional record — use constructor syntax with `IEnumerable<EventData>`:
 
 ```csharp
-var requests = new[] {
-    new AppendStreamRequest {
-        Stream = "order-123",
-        ExpectedState = StreamState.Any,
-        Messages = ToAsyncEnumerable([orderEvent])
-    },
-    new AppendStreamRequest {
-        Stream = "inventory-abc",
-        ExpectedState = StreamState.Any,
-        Messages = ToAsyncEnumerable([inventoryEvent])
-    }
-};
+AppendStreamRequest[] requests = [
+    new("order-123", StreamState.Any, [orderEvent]),
+    new("inventory-abc", StreamState.Any, [inventoryEvent])
+];
 
-var response = await client.MultiStreamAppendAsync(requests.ToAsyncEnumerable());
+var response = await client.MultiStreamAppendAsync(requests);
 // response.Responses contains per-stream results
 // response.Position contains the log position
 ```

--- a/claude-skill/skills/kurrentdb/SKILL.md
+++ b/claude-skill/skills/kurrentdb/SKILL.md
@@ -1,0 +1,454 @@
+---
+name: kurrentdb
+description: |
+  Guidance for the KurrentDB .NET Client SDK (NuGet: KurrentDB.Client).
+  Triggers on: KurrentDB, EventStoreDB, event sourcing with .NET, esdb://, kdb://, kurrentdb:// connection strings,
+  KurrentDBClient, EventData, StreamState, persistent subscriptions, catch-up subscriptions, projections.
+user-invocable: true
+---
+
+# KurrentDB .NET Client SDK
+
+The `KurrentDB.Client` NuGet package provides a gRPC-based .NET client for KurrentDB (formerly EventStoreDB). Compatible with server v20.6.1+. Targets `net48`, `net8.0`, `net9.0`, `net10.0`.
+
+For detailed API signatures and complete parameter lists, see `reference.md` in this skill directory.
+
+## 1. Client Setup
+
+### Connection Strings
+
+All these schemes are equivalent and interchangeable:
+
+```csharp
+// Single node
+var settings = KurrentDBClientSettings.Create("kurrentdb://admin:changeit@localhost:2113?tls=true");
+
+// Cluster with discovery
+var settings = KurrentDBClientSettings.Create(
+    "kurrentdb+discover://admin:changeit@node1:2113,node2:2113,node3:2113"
+);
+```
+
+**Supported schemes:** `esdb://`, `kdb://`, `kurrent://`, `kurrentdb://` — each with an optional `+discover` suffix for cluster gossip discovery.
+
+**Format:** `scheme://[user:pass@]host[:port][,host[:port]...][?params]`
+
+Default port is `2113`. Parameters are case-insensitive.
+
+### Connection String Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `tls` | bool | `true` | Enable TLS. Set to `false` for insecure connections. |
+| `tlsVerifyCert` | bool | `true` | Verify the server's TLS certificate. Set to `false` only for development. |
+| `tlsCaFile` | string | — | Path to a CA certificate file for self-signed or private CAs. |
+| `userCertFile` | string | — | Path to client certificate PEM file (certificate-based auth). Must be paired with `userKeyFile`. |
+| `userKeyFile` | string | — | Path to client private key PEM file. Must be paired with `userCertFile`. |
+| `connectionName` | string | — | Identifies this client in server logs. |
+| `defaultDeadline` | int | `10000` | Default timeout for operations, in milliseconds. |
+| `keepAliveInterval` | int | `10000` | gRPC keep-alive ping interval in ms. Use `-1` for infinite. |
+| `keepAliveTimeout` | int | `10000` | gRPC keep-alive ping timeout in ms. Use `-1` for infinite. |
+| `nodePreference` | string | `leader` | Preferred node type: `leader`, `follower`, `random`, or `readonlyreplica`. |
+| `maxDiscoverAttempts` | int | `10` | Max gossip discovery attempts before giving up. |
+| `discoveryInterval` | int | `100` | Interval between gossip discovery attempts, in ms. |
+| `gossipTimeout` | int | `5000` | Timeout for a single gossip request, in ms. |
+| `throwOnAppendFailure` | bool | `true` | When `false`, `AppendToStreamAsync` returns `WrongExpectedVersionResult` instead of throwing `WrongExpectedVersionException`. |
+
+**Examples:**
+
+```
+kurrentdb://localhost:2113?tls=false
+kurrentdb://admin:changeit@localhost:2113?tls=true&tlsVerifyCert=false
+kurrentdb+discover://node1:2113,node2:2113,node3:2113?nodePreference=follower&maxDiscoverAttempts=5
+kurrentdb://localhost:2113?tls=true&tlsCaFile=/path/to/ca.crt
+kurrentdb://localhost:2113?tls=true&userCertFile=/path/to/user.crt&userKeyFile=/path/to/user.key
+```
+
+### Programmatic Configuration
+
+```csharp
+var settings = new KurrentDBClientSettings {
+    ConnectivitySettings = { Address = new Uri("https://localhost:2113") },
+    DefaultCredentials = new UserCredentials("admin", "changeit"),
+    DefaultDeadline = TimeSpan.FromSeconds(30),
+    ConnectionName = "my-app"
+};
+var client = new KurrentDBClient(settings);
+```
+
+### Dependency Injection
+
+```csharp
+// From connection string
+services.AddKurrentDBClient("kurrentdb://admin:changeit@localhost:2113?tls=false");
+
+// From configuration callback
+services.AddKurrentDBClient(settings => {
+    settings.ConnectivitySettings.Address = new Uri("https://localhost:2113");
+    settings.DefaultCredentials = new UserCredentials("admin", "changeit");
+});
+```
+
+This registers `KurrentDBClient` as a singleton. Inject it via constructor injection.
+
+## 2. Appending Events
+
+### Creating Events
+
+```csharp
+var eventData = new EventData(
+    Uuid.NewUuid(),
+    "OrderPlaced",
+    JsonSerializer.SerializeToUtf8Bytes(new { OrderId = "123", Amount = 99.99 }),
+    metadata: JsonSerializer.SerializeToUtf8Bytes(new { UserId = "user-1" }),
+    contentType: "application/json" // default
+);
+```
+
+### Appending with Concurrency Control
+
+```csharp
+// Append to a new stream (fails if stream already exists)
+var result = await client.AppendToStreamAsync("order-123", StreamState.NoStream, [eventData]);
+
+// Append to any stream (no concurrency check)
+var result = await client.AppendToStreamAsync("order-123", StreamState.Any, [eventData]);
+
+// Optimistic concurrency — append only if stream is at expected revision
+var result = await client.AppendToStreamAsync("order-123", StreamState.StreamRevision(5), [eventData]);
+```
+
+`AppendToStreamAsync` returns `IWriteResult`. On success, cast to `SuccessResult` to get `NextExpectedStreamState` and `LogPosition`. When `ThrowOnAppendFailure` is `false`, check for `WrongExpectedVersionResult`.
+
+### Multi-Stream Append (Server 25.1+)
+
+Atomic writes across multiple streams in a single transaction:
+
+```csharp
+var requests = new[] {
+    new AppendStreamRequest {
+        Stream = "order-123",
+        ExpectedState = StreamState.Any,
+        Messages = ToAsyncEnumerable([orderEvent])
+    },
+    new AppendStreamRequest {
+        Stream = "inventory-abc",
+        ExpectedState = StreamState.Any,
+        Messages = ToAsyncEnumerable([inventoryEvent])
+    }
+};
+
+var response = await client.MultiStreamAppendAsync(requests.ToAsyncEnumerable());
+// response.Responses contains per-stream results
+// response.Position contains the log position
+```
+
+## 3. Reading Streams
+
+### Reading a Stream
+
+```csharp
+// Read forwards from the beginning
+var result = client.ReadStreamAsync(Direction.Forwards, "order-123", StreamPosition.Start);
+
+// Check if stream exists
+if (await result.ReadState == ReadState.StreamNotFound) {
+    // stream does not exist
+    return;
+}
+
+// Iterate events
+await foreach (var @event in result) {
+    Console.WriteLine($"{@event.Event.EventType}: {Encoding.UTF8.GetString(@event.Event.Data.Span)}");
+}
+```
+
+### Reading Backwards
+
+```csharp
+// Read last 10 events
+var result = client.ReadStreamAsync(Direction.Backwards, "order-123", StreamPosition.End, maxCount: 10);
+```
+
+### Message-Based Reading
+
+For richer control, use the `Messages` property:
+
+```csharp
+await foreach (var message in result.Messages) {
+    switch (message) {
+        case StreamMessage.Event(var resolvedEvent):
+            // process event
+            break;
+        case StreamMessage.NotFound:
+            // stream doesn't exist
+            break;
+        case StreamMessage.FirstStreamPosition(var pos):
+        case StreamMessage.LastStreamPosition(var pos):
+            // stream position metadata
+            break;
+    }
+}
+```
+
+### Reading $all
+
+```csharp
+var result = client.ReadAllAsync(Direction.Forwards, Position.Start, maxCount: 100);
+
+await foreach (var @event in result) {
+    if (!@event.Event.EventType.StartsWith("$")) // skip system events
+        Console.WriteLine(@event.Event.EventType);
+}
+```
+
+### Resolving Link Events
+
+KurrentDB uses **link events** (type `$>`) to reference events in other streams. System projections like `$by_category` and `$by_event_type` create streams composed entirely of links. By default, reads and subscriptions return the raw link event. Set `resolveLinkTos: true` to automatically follow links and return the original event instead.
+
+```csharp
+// Reading — resolve links to get the original events
+var result = client.ReadStreamAsync(
+    Direction.Forwards, "$ce-order", StreamPosition.Start,
+    resolveLinkTos: true);
+
+// Subscribing — same parameter
+await using var subscription = client.SubscribeToStream(
+    "$ce-order", FromStream.Start, resolveLinkTos: true);
+```
+
+When resolved, `ResolvedEvent.Event` is the original event, `ResolvedEvent.Link` is the link event, and `IsResolved` is `true`. Without resolution, `Event` is the link itself and `Link` is `null`.
+
+**When to use:** Always set `resolveLinkTos: true` when reading projected/system streams (prefixed with `$`). Not needed when reading your own application streams directly.
+
+Persistent subscriptions set this via `PersistentSubscriptionSettings(resolveLinkTos: true)` at creation time.
+
+## 4. Catch-Up Subscriptions
+
+### Subscribe to a Stream
+
+```csharp
+// From the beginning
+await using var subscription = client.SubscribeToStream("order-123", FromStream.Start);
+
+// From a specific position (for recovery after restart)
+await using var subscription = client.SubscribeToStream("order-123", FromStream.After(lastCheckpoint));
+
+// Live only (new events)
+await using var subscription = client.SubscribeToStream("order-123", FromStream.End);
+
+await foreach (var message in subscription.Messages) {
+    switch (message) {
+        case StreamMessage.Event(var evnt):
+            await ProcessEvent(evnt);
+            SaveCheckpoint(evnt.OriginalEventNumber);
+            break;
+    }
+}
+```
+
+### Subscribe to $all
+
+```csharp
+await using var subscription = client.SubscribeToAll(FromAll.Start);
+
+await foreach (var message in subscription.Messages) {
+    switch (message) {
+        case StreamMessage.Event(var evnt):
+            await ProcessEvent(evnt);
+            break;
+        case StreamMessage.AllStreamCheckpointReached(var position):
+            SaveCheckpoint(position);
+            break;
+    }
+}
+```
+
+### Server-Side Filtering
+
+```csharp
+// Filter by event type prefix
+var filter = new SubscriptionFilterOptions(EventTypeFilter.Prefix("Order"));
+
+// Filter by stream name regex
+var filter = new SubscriptionFilterOptions(StreamFilter.RegularExpression("^order-"));
+
+// Exclude system events
+var filter = new SubscriptionFilterOptions(EventTypeFilter.ExcludeSystemEvents());
+
+await using var subscription = client.SubscribeToAll(FromAll.Start, filterOptions: filter);
+```
+
+### Reconnection Pattern
+
+```csharp
+Subscribe:
+try {
+    await using var subscription = client.SubscribeToStream("my-stream", FromStream.After(lastCheckpoint));
+    await foreach (var message in subscription.Messages) {
+        if (message is StreamMessage.Event(var evnt)) {
+            await ProcessEvent(evnt);
+            lastCheckpoint = evnt.OriginalEventNumber;
+        }
+    }
+} catch (OperationCanceledException) {
+    return;
+} catch (ObjectDisposedException) {
+    return;
+} catch {
+    // reconnect after transient failure
+    goto Subscribe;
+}
+```
+
+## 5. Persistent Subscriptions
+
+Persistent subscriptions are server-managed competing consumer groups with manual acknowledgment.
+
+```csharp
+var psClient = new KurrentDBPersistentSubscriptionsClient(settings);
+
+// Create subscription
+await psClient.CreateAsync("order-stream", "order-processor",
+    new PersistentSubscriptionSettings(startFrom: StreamPosition.Start));
+
+// Subscribe and process
+await using var subscription = psClient.SubscribeToStream("order-stream", "order-processor");
+
+await foreach (var message in subscription.Messages) {
+    switch (message) {
+        case PersistentSubscriptionMessage.Event(var evnt, var retryCount):
+            try {
+                await ProcessEvent(evnt);
+                await subscription.Ack(evnt);
+            } catch {
+                await subscription.Nack(PersistentSubscriptionNakEventAction.Park, "Processing failed", evnt);
+            }
+            break;
+    }
+}
+```
+
+### Persistent Subscription to $all
+
+```csharp
+// Requires server support (check ServerCapabilities.SupportsPersistentSubscriptionsToAll)
+await psClient.CreateToAllAsync("all-processor",
+    new PersistentSubscriptionSettings(startFrom: Position.Start),
+    filter: StreamFilter.Prefix("order-"));
+```
+
+### Consumer Strategies
+
+- `SystemConsumerStrategies.RoundRobin` — distribute evenly (default)
+- `SystemConsumerStrategies.DispatchToSingle` — all to one consumer
+- `SystemConsumerStrategies.Pinned` — hash-based pinning to a consumer
+
+## 6. Projections
+
+```csharp
+var projClient = new KurrentDBProjectionManagementClient(settings);
+
+// Create a continuous projection
+await projClient.CreateContinuousAsync("order-totals", @"
+    fromStream('orders')
+    .when({
+        $init: function() { return { total: 0 }; },
+        OrderPlaced: function(state, event) {
+            state.total += event.body.Amount;
+            return state;
+        }
+    })
+    .outputState()
+");
+
+// Get projection state
+var state = await projClient.GetStateAsync("order-totals");
+
+// Enable/disable
+await projClient.EnableAsync("order-totals");
+await projClient.DisableAsync("order-totals");
+
+// Reset
+await projClient.ResetAsync("order-totals");
+```
+
+## 7. Stream Metadata & ACLs
+
+```csharp
+// Set metadata
+await client.SetStreamMetadataAsync("order-123", StreamState.Any,
+    new StreamMetadata(
+        maxCount: 1000,
+        maxAge: TimeSpan.FromDays(30),
+        acl: new StreamAcl(readRole: "$admins", writeRole: "$admins")
+    ));
+
+// Read metadata
+var meta = await client.GetStreamMetadataAsync("order-123");
+Console.WriteLine($"Max count: {meta.Metadata.MaxCount}");
+```
+
+### Soft Delete vs Tombstone
+
+```csharp
+// Soft delete — stream can be recreated
+await client.DeleteAsync("order-123", StreamState.Any);
+
+// Tombstone — permanent, stream name cannot be reused
+await client.TombstoneAsync("order-123", StreamState.Any);
+```
+
+## 8. Observability
+
+```csharp
+using KurrentDB.Client.Extensions.OpenTelemetry;
+
+services.AddOpenTelemetry()
+    .WithTracing(builder => builder
+        .AddKurrentDBClientInstrumentation()
+        .AddConsoleExporter()
+    );
+```
+
+This traces all gRPC operations with span attributes including stream name, event type, and operation.
+
+## 9. Error Handling
+
+| Exception | Cause |
+|-----------|-------|
+| `WrongExpectedVersionException` | Optimistic concurrency conflict — stream not at expected revision |
+| `StreamNotFoundException` | Stream does not exist (reading/subscribing) |
+| `StreamDeletedException` | Stream was soft-deleted |
+| `StreamTombstonedException` | Stream was tombstoned (permanently deleted) |
+| `AccessDeniedException` | Insufficient permissions |
+| `NotAuthenticatedException` | Invalid or missing credentials |
+| `NotLeaderException` | Operation requires leader node; client will auto-redirect |
+| `DiscoveryException` | Failed to discover cluster nodes via gossip |
+| `ConnectionStringParseException` | Invalid connection string syntax |
+| `PersistentSubscriptionNotFoundException` | Subscription group does not exist |
+| `MaximumSubscribersReachedException` | Consumer group at capacity |
+
+## 10. Migration from EventStoreDB
+
+The KurrentDB client is a direct successor to the EventStore.Client.Grpc packages.
+
+**Package change:** Replace `EventStore.Client.Grpc.*` NuGet packages with `KurrentDB.Client`.
+
+**Namespace change:** `EventStore.Client` -> `KurrentDB.Client`
+
+**Connection strings:** All old `esdb://` schemes continue to work. You can optionally migrate:
+- `esdb://` -> `kurrentdb://`
+- `esdb+discover://` -> `kurrentdb+discover://`
+
+**Class renames:**
+- `EventStoreClient` -> `KurrentDBClient`
+- `EventStoreClientSettings` -> `KurrentDBClientSettings`
+- `EventStorePersistentSubscriptionsClient` -> `KurrentDBPersistentSubscriptionsClient`
+- `EventStoreProjectionManagementClient` -> `KurrentDBProjectionManagementClient`
+- `EventStoreUserManagementClient` -> `KurrentDBUserManagementClient`
+- `EventStoreOperationsClient` -> `KurrentDBOperationsClient`
+
+**DI:** `AddEventStoreClient()` -> `AddKurrentDBClient()`
+
+All APIs, types, and behavior remain identical. The migration is purely mechanical namespace/type renaming.

--- a/claude-skill/skills/kurrentdb/reference.md
+++ b/claude-skill/skills/kurrentdb/reference.md
@@ -1,0 +1,864 @@
+# KurrentDB .NET Client SDK — API Reference
+
+Comprehensive reference for the `KurrentDB.Client` NuGet package.
+
+## Connection String Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `tls` | bool | `true` | Enable TLS encryption |
+| `tlsVerifyCert` | bool | `true` | Verify server TLS certificate |
+| `tlsCaFile` | string | — | Path to CA certificate file for custom CAs |
+| `connectionName` | string | — | Identifies the client in server logs |
+| `defaultDeadline` | int | `10000` | Default operation timeout in milliseconds |
+| `keepAliveInterval` | int | `10000` | gRPC keep-alive ping interval (ms), `-1` for infinite |
+| `keepAliveTimeout` | int | `10000` | gRPC keep-alive timeout (ms), `-1` for infinite |
+| `nodePreference` | string | `leader` | Preferred node: `leader`, `follower`, `random`, `readonlyreplica` |
+| `maxDiscoverAttempts` | int | `10` | Maximum gossip discovery attempts |
+| `discoveryInterval` | int | `100` | Gossip discovery polling interval (ms) |
+| `gossipTimeout` | int | `5000` | Gossip request timeout (ms) |
+| `throwOnAppendFailure` | bool | `true` | Throw on append failure vs return `WrongExpectedVersionResult` |
+| `userCertFile` | string | — | Path to user certificate PEM file (certificate auth) |
+| `userKeyFile` | string | — | Path to user private key PEM file (certificate auth) |
+
+**Connection string format:**
+```
+scheme://[user:password@]host[:port][,host[:port]...][?key=value[&key=value...]]
+```
+
+**Supported schemes:** `esdb`, `esdb+discover`, `kdb`, `kdb+discover`, `kurrent`, `kurrent+discover`, `kurrentdb`, `kurrentdb+discover`
+
+The `+discover` suffix enables cluster gossip discovery. Without it, the client connects directly to the specified node(s).
+
+## KurrentDBClientSettings
+
+```csharp
+public class KurrentDBClientSettings {
+    public IEnumerable<Interceptor>? Interceptors { get; set; }
+    public string? ConnectionName { get; set; }
+    public Func<HttpMessageHandler>? CreateHttpMessageHandler { get; set; }
+    public ILoggerFactory? LoggerFactory { get; set; }
+    public ChannelCredentials? ChannelCredentials { get; set; }
+    public KurrentDBClientOperationOptions OperationOptions { get; set; }
+    public KurrentDBClientConnectivitySettings ConnectivitySettings { get; set; }
+    public UserCredentials? DefaultCredentials { get; set; }
+    public TimeSpan? DefaultDeadline { get; set; }
+
+    public static KurrentDBClientSettings Create(string connectionString);
+}
+```
+
+### KurrentDBClientConnectivitySettings
+
+```csharp
+public class KurrentDBClientConnectivitySettings {
+    public Uri? Address { get; set; }
+    public int MaxDiscoverAttempts { get; set; }          // default: 10
+    public DnsEndPoint[]? DnsGossipSeeds { get; set; }
+    public IPEndPoint[]? IpGossipSeeds { get; set; }
+    public EndPoint[] GossipSeeds { get; }
+    public TimeSpan GossipTimeout { get; set; }           // default: 5s
+    public TimeSpan DiscoveryInterval { get; set; }       // default: 100ms
+    public NodePreference NodePreference { get; set; }    // default: Leader
+    public TimeSpan KeepAliveInterval { get; set; }       // default: 10s
+    public TimeSpan KeepAliveTimeout { get; set; }        // default: 10s
+    public bool IsSingleNode { get; }
+    public bool Insecure { get; set; }
+    public bool TlsVerifyCert { get; set; }               // default: true
+    public X509Certificate2? TlsCaFile { get; set; }
+    public X509Certificate2? ClientCertificate { get; set; }
+
+    public static KurrentDBClientConnectivitySettings Default { get; }
+}
+```
+
+### KurrentDBClientOperationOptions
+
+```csharp
+public class KurrentDBClientOperationOptions {
+    public bool ThrowOnAppendFailure { get; set; }        // default: true
+    public int BatchAppendSize { get; set; }
+    public Func<UserCredentials, CancellationToken, ValueTask<string>> GetAuthenticationHeaderValue { get; set; }
+
+    public KurrentDBClientOperationOptions Clone();
+    public static KurrentDBClientOperationOptions Default { get; }
+}
+```
+
+## EventData
+
+```csharp
+public readonly struct EventData {
+    public EventData(
+        Uuid eventId,
+        string type,
+        ReadOnlyMemory<byte> data,
+        ReadOnlyMemory<byte>? metadata = null,
+        string contentType = "application/json"
+    );
+
+    public readonly Uuid EventId;
+    public readonly string Type;
+    public readonly ReadOnlyMemory<byte> Data;
+    public readonly ReadOnlyMemory<byte> Metadata;
+    public readonly string ContentType;
+}
+```
+
+## Uuid
+
+```csharp
+public readonly struct Uuid : IEquatable<Uuid> {
+    public static readonly Uuid Empty;
+
+    public static Uuid NewUuid();
+    public static Uuid FromGuid(Guid value);
+    public static Uuid Parse(string value);
+    public static Uuid FromInt64(long msb, long lsb);
+
+    public Guid ToGuid();
+    public string ToString(string format);
+}
+```
+
+## EventRecord
+
+```csharp
+public readonly struct EventRecord {
+    public readonly string EventStreamId;
+    public readonly Uuid EventId;
+    public readonly StreamPosition EventNumber;
+    public readonly string EventType;
+    public readonly ReadOnlyMemory<byte> Data;
+    public readonly ReadOnlyMemory<byte> Metadata;
+    public readonly DateTime Created;
+    public readonly Position Position;
+    public readonly string ContentType;
+}
+```
+
+## ResolvedEvent
+
+```csharp
+public readonly struct ResolvedEvent {
+    public readonly EventRecord Event;
+    public readonly EventRecord? Link;
+    public readonly Position? OriginalPosition;
+
+    public EventRecord OriginalEvent { get; }     // Link ?? Event
+    public string OriginalStreamId { get; }
+    public StreamPosition OriginalEventNumber { get; }
+    public bool IsResolved { get; }                // Link != null
+}
+```
+
+## StreamState
+
+```csharp
+public readonly struct StreamState : IEquatable<StreamState> {
+    public static readonly StreamState NoStream;       // stream must not exist
+    public static readonly StreamState Any;            // no concurrency check
+    public static readonly StreamState StreamExists;   // stream must exist (any revision)
+
+    public static StreamState StreamRevision(ulong value);  // specific revision
+    public static implicit operator StreamState(ulong value);
+
+    public long ToInt64();
+    public bool HasPosition { get; }
+}
+```
+
+## Position Types
+
+### Position (for $all stream)
+
+```csharp
+public readonly struct Position : IEquatable<Position>, IComparable<Position> {
+    public static readonly Position Start;   // (0, 0)
+    public static readonly Position End;     // (max, max)
+
+    public Position(ulong commitPosition, ulong preparePosition);
+
+    public readonly ulong CommitPosition;
+    public readonly ulong PreparePosition;
+
+    public static bool TryParse(string value, out Position? position);
+}
+```
+
+### StreamPosition (for individual streams)
+
+```csharp
+public readonly struct StreamPosition : IEquatable<StreamPosition>, IComparable<StreamPosition> {
+    public static readonly StreamPosition Start;  // 0
+    public static readonly StreamPosition End;    // max
+
+    public StreamPosition(ulong value);
+    public static StreamPosition FromInt64(long value);
+    public static StreamPosition FromStreamRevision(ulong revision);
+
+    public StreamPosition Next();
+    public ulong ToUInt64();
+    public long ToInt64();
+
+    public static implicit operator ulong(StreamPosition sp);
+    public static implicit operator StreamPosition(ulong value);
+}
+```
+
+### FromStream (subscription starting point)
+
+```csharp
+public readonly struct FromStream : IEquatable<FromStream>, IComparable<FromStream> {
+    public static readonly FromStream Start;  // from beginning
+    public static readonly FromStream End;    // live only
+
+    public static FromStream After(StreamPosition streamPosition);
+}
+```
+
+### FromAll (subscription starting point for $all)
+
+```csharp
+public readonly struct FromAll : IEquatable<FromAll>, IComparable<FromAll> {
+    public static readonly FromAll Start;  // from beginning
+    public static readonly FromAll End;    // live only
+
+    public static FromAll After(Position position);
+}
+```
+
+## UserCredentials
+
+```csharp
+public class UserCredentials {
+    public UserCredentials(string username, string password);
+    public UserCredentials(string bearerToken);
+
+    public string? Username { get; }
+    public string? Password { get; }
+}
+```
+
+## KurrentDBClient
+
+### Append
+
+```csharp
+public Task<IWriteResult> AppendToStreamAsync(
+    string streamName,
+    StreamState expectedState,
+    IEnumerable<EventData> eventData,
+    Action<KurrentDBClientOperationOptions>? configureOperationOptions = null,
+    TimeSpan? deadline = null,
+    UserCredentials? userCredentials = null,
+    CancellationToken cancellationToken = default);
+```
+
+### Multi-Stream Append (Server 25.1+)
+
+```csharp
+public ValueTask<MultiStreamAppendResponse> MultiStreamAppendAsync(
+    IAsyncEnumerable<AppendStreamRequest> requests,
+    CancellationToken cancellationToken = default);
+```
+
+**Supporting types:**
+
+```csharp
+public class AppendStreamRequest {
+    public string Stream { get; set; }
+    public StreamState ExpectedState { get; set; }
+    public IAsyncEnumerable<EventData> Messages { get; set; }
+}
+
+public class AppendResponse {
+    public string Stream { get; }
+    public ulong StreamRevision { get; }
+}
+
+public class MultiStreamAppendResponse {
+    public Position Position { get; }
+    public IEnumerable<AppendResponse> Responses { get; }
+}
+```
+
+### Read Stream
+
+```csharp
+public ReadStreamResult ReadStreamAsync(
+    Direction direction,
+    string streamName,
+    StreamPosition revision,
+    long maxCount = long.MaxValue,
+    bool resolveLinkTos = false,
+    TimeSpan? deadline = null,
+    UserCredentials? userCredentials = null,
+    CancellationToken cancellationToken = default);
+```
+
+**Return type:**
+
+```csharp
+public class ReadStreamResult : IAsyncEnumerable<ResolvedEvent> {
+    public string StreamName { get; }
+    public StreamPosition? FirstStreamPosition { get; }
+    public StreamPosition? LastStreamPosition { get; }
+    public IAsyncEnumerable<StreamMessage> Messages { get; }
+    public Task<ReadState> ReadState { get; }
+}
+
+public enum ReadState { StreamNotFound, Ok }
+```
+
+### Read $all
+
+```csharp
+public ReadAllStreamResult ReadAllAsync(
+    Direction direction,
+    Position position,
+    long maxCount = long.MaxValue,
+    bool resolveLinkTos = false,
+    TimeSpan? deadline = null,
+    UserCredentials? userCredentials = null,
+    CancellationToken cancellationToken = default);
+
+// With server-side filtering
+public ReadAllStreamResult ReadAllAsync(
+    Direction direction,
+    Position position,
+    IEventFilter? eventFilter,
+    long maxCount = long.MaxValue,
+    bool resolveLinkTos = false,
+    TimeSpan? deadline = null,
+    UserCredentials? userCredentials = null,
+    CancellationToken cancellationToken = default);
+```
+
+**Return type:**
+
+```csharp
+public class ReadAllStreamResult : IAsyncEnumerable<ResolvedEvent> {
+    public Position? LastPosition { get; }
+    public IAsyncEnumerable<StreamMessage> Messages { get; }
+}
+```
+
+### Subscribe to Stream
+
+```csharp
+// New API (IAsyncEnumerable-based)
+public StreamSubscriptionResult SubscribeToStream(
+    string streamName,
+    FromStream start,
+    bool resolveLinkTos = false,
+    UserCredentials? userCredentials = null,
+    CancellationToken cancellationToken = default);
+
+// Callback API
+public Task<StreamSubscription> SubscribeToStreamAsync(
+    string streamName,
+    FromStream start,
+    Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
+    bool resolveLinkTos = false,
+    Action<StreamSubscription, SubscriptionDroppedReason, Exception?>? subscriptionDropped = default,
+    UserCredentials? userCredentials = null,
+    CancellationToken cancellationToken = default);
+```
+
+### Subscribe to $all
+
+```csharp
+// New API (IAsyncEnumerable-based)
+public StreamSubscriptionResult SubscribeToAll(
+    FromAll start,
+    bool resolveLinkTos = false,
+    SubscriptionFilterOptions? filterOptions = null,
+    UserCredentials? userCredentials = null,
+    CancellationToken cancellationToken = default);
+
+// Callback API
+public Task<StreamSubscription> SubscribeToAllAsync(
+    FromAll start,
+    Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
+    bool resolveLinkTos = false,
+    Action<StreamSubscription, SubscriptionDroppedReason, Exception?>? subscriptionDropped = default,
+    SubscriptionFilterOptions? filterOptions = null,
+    UserCredentials? userCredentials = null,
+    CancellationToken cancellationToken = default);
+```
+
+**Return type:**
+
+```csharp
+public class StreamSubscriptionResult : IAsyncEnumerable<ResolvedEvent>, IAsyncDisposable, IDisposable {
+    public string? SubscriptionId { get; }
+    public IAsyncEnumerable<StreamMessage> Messages { get; }
+}
+```
+
+### Delete / Tombstone
+
+```csharp
+// Soft delete (stream can be recreated)
+public Task<DeleteResult> DeleteAsync(
+    string streamName,
+    StreamState expectedState,
+    TimeSpan? deadline = null,
+    UserCredentials? userCredentials = null,
+    CancellationToken cancellationToken = default);
+
+// Permanent delete (stream name permanently reserved)
+public Task<DeleteResult> TombstoneAsync(
+    string streamName,
+    StreamState expectedState,
+    TimeSpan? deadline = null,
+    UserCredentials? userCredentials = null,
+    CancellationToken cancellationToken = default);
+```
+
+### Stream Metadata
+
+```csharp
+public Task<StreamMetadataResult> GetStreamMetadataAsync(
+    string streamName,
+    TimeSpan? deadline = null,
+    UserCredentials? userCredentials = null,
+    CancellationToken cancellationToken = default);
+
+public Task<IWriteResult> SetStreamMetadataAsync(
+    string streamName,
+    StreamState expectedState,
+    StreamMetadata metadata,
+    Action<KurrentDBClientOperationOptions>? configureOperationOptions = null,
+    TimeSpan? deadline = null,
+    UserCredentials? userCredentials = null,
+    CancellationToken cancellationToken = default);
+```
+
+## StreamMessage Types
+
+```csharp
+public abstract record StreamMessage {
+    public record Event(ResolvedEvent ResolvedEvent) : StreamMessage;
+    public record NotFound : StreamMessage;
+    public record Ok : StreamMessage;
+    public record FirstStreamPosition(StreamPosition StreamPosition) : StreamMessage;
+    public record LastStreamPosition(StreamPosition StreamPosition) : StreamMessage;
+    public record LastAllStreamPosition(Position Position) : StreamMessage;
+    public record SubscriptionConfirmation(string SubscriptionId) : StreamMessage;
+    public record AllStreamCheckpointReached(Position Position) : StreamMessage;
+    public record StreamCheckpointReached(StreamPosition StreamPosition) : StreamMessage;
+    public record CaughtUp : StreamMessage;
+    public record FellBehind : StreamMessage;
+    public record Unknown : StreamMessage;
+}
+```
+
+## StreamMetadata & StreamAcl
+
+```csharp
+public class StreamMetadata {
+    public StreamMetadata(
+        int? maxCount = null,
+        TimeSpan? maxAge = null,
+        StreamPosition? truncateBefore = null,
+        TimeSpan? cacheControl = null,
+        StreamAcl? acl = null,
+        JsonDocument? customMetadata = null);
+
+    public int? MaxCount { get; }
+    public TimeSpan? MaxAge { get; }
+    public StreamPosition? TruncateBefore { get; }
+    public TimeSpan? CacheControl { get; }
+    public StreamAcl? Acl { get; }
+    public JsonDocument? CustomMetadata { get; }
+}
+
+public class StreamAcl {
+    // Single-role constructor
+    public StreamAcl(
+        string? readRole = null,
+        string? writeRole = null,
+        string? deleteRole = null,
+        string? metaReadRole = null,
+        string? metaWriteRole = null);
+
+    // Multi-role constructor
+    public StreamAcl(
+        string[]? readRoles = null,
+        string[]? writeRoles = null,
+        string[]? deleteRoles = null,
+        string[]? metaReadRoles = null,
+        string[]? metaWriteRoles = null);
+
+    public string[]? ReadRoles { get; }
+    public string[]? WriteRoles { get; }
+    public string[]? DeleteRoles { get; }
+    public string[]? MetaReadRoles { get; }
+    public string[]? MetaWriteRoles { get; }
+}
+```
+
+## Filter Types
+
+### EventTypeFilter
+
+```csharp
+public class EventTypeFilter {
+    public static readonly EventTypeFilter None;
+
+    public static IEventFilter ExcludeSystemEvents(uint maxSearchWindow = 32);
+    public static IEventFilter Prefix(string prefix);
+    public static IEventFilter Prefix(params string[] prefixes);
+    public static IEventFilter Prefix(uint maxSearchWindow, params string[] prefixes);
+    public static IEventFilter RegularExpression(string regex, uint maxSearchWindow = 32);
+    public static IEventFilter RegularExpression(Regex regex, uint maxSearchWindow = 32);
+}
+```
+
+### StreamFilter
+
+```csharp
+public class StreamFilter {
+    public static readonly StreamFilter None;
+
+    public static IEventFilter Prefix(string prefix);
+    public static IEventFilter Prefix(params string[] prefixes);
+    public static IEventFilter Prefix(uint maxSearchWindow, params string[] prefixes);
+    public static IEventFilter RegularExpression(string regex, uint maxSearchWindow = 32);
+    public static IEventFilter RegularExpression(Regex regex, uint maxSearchWindow = 32);
+}
+```
+
+### SubscriptionFilterOptions
+
+```csharp
+public class SubscriptionFilterOptions {
+    public SubscriptionFilterOptions(
+        IEventFilter filter,
+        uint checkpointInterval = 1,
+        Func<StreamSubscription, Position, CancellationToken, Task>? checkpointReached = null);
+
+    public IEventFilter Filter { get; }
+    public uint CheckpointInterval { get; }
+    public Func<StreamSubscription, Position, CancellationToken, Task> CheckpointReached { get; }
+}
+```
+
+## KurrentDBPersistentSubscriptionsClient
+
+```csharp
+public class KurrentDBPersistentSubscriptionsClient : KurrentDBClientBase {
+    // Create
+    public Task CreateAsync(string streamName, string groupName,
+        PersistentSubscriptionSettings settings,
+        TimeSpan? deadline = null, UserCredentials? userCredentials = null,
+        CancellationToken cancellationToken = default);
+
+    public Task CreateToAllAsync(string groupName,
+        PersistentSubscriptionSettings settings,
+        TimeSpan? deadline = null, UserCredentials? userCredentials = null,
+        CancellationToken cancellationToken = default);
+
+    // Update
+    public Task UpdateAsync(string streamName, string groupName,
+        PersistentSubscriptionSettings settings,
+        TimeSpan? deadline = null, UserCredentials? userCredentials = null,
+        CancellationToken cancellationToken = default);
+
+    // Subscribe (IAsyncEnumerable-based)
+    public PersistentSubscriptionResult SubscribeToStream(string streamName, string groupName,
+        int bufferSize = 10, UserCredentials? userCredentials = null,
+        CancellationToken cancellationToken = default);
+
+    // Subscribe (callback-based)
+    public Task<PersistentSubscription> SubscribeToStreamAsync(string streamName, string groupName,
+        Func<PersistentSubscription, ResolvedEvent, int?, CancellationToken, Task> eventAppeared,
+        Action<PersistentSubscription, SubscriptionDroppedReason, Exception?>? subscriptionDropped = null,
+        UserCredentials? userCredentials = null, int bufferSize = 10,
+        CancellationToken cancellationToken = default);
+
+    // Delete
+    public Task DeleteAsync(string streamName, string groupName,
+        TimeSpan? deadline = null, UserCredentials? userCredentials = null,
+        CancellationToken cancellationToken = default);
+
+    // List
+    public IAsyncEnumerable<PersistentSubscriptionInfo> ListAsync(
+        TimeSpan? deadline = null, UserCredentials? userCredentials = null,
+        CancellationToken cancellationToken = default);
+
+    // Info
+    public Task<PersistentSubscriptionInfo> GetInfoAsync(string streamName, string groupName,
+        TimeSpan? deadline = null, UserCredentials? userCredentials = null,
+        CancellationToken cancellationToken = default);
+
+    // Replay parked messages
+    public Task ReplayParkedAsync(string streamName, string groupName,
+        TimeSpan? deadline = null, UserCredentials? userCredentials = null,
+        CancellationToken cancellationToken = default);
+
+    // Restart subsystem
+    public Task RestartSubsystemAsync(
+        TimeSpan? deadline = null, UserCredentials? userCredentials = null,
+        CancellationToken cancellationToken = default);
+}
+```
+
+### PersistentSubscriptionSettings
+
+```csharp
+public class PersistentSubscriptionSettings {
+    public PersistentSubscriptionSettings(
+        bool resolveLinkTos = false,
+        IPosition? startFrom = null,
+        bool extraStatistics = false,
+        TimeSpan? messageTimeout = null,       // default: 30s
+        int maxRetryCount = 10,
+        int liveBufferSize = 500,
+        int readBatchSize = 20,
+        int historyBufferSize = 500,
+        TimeSpan? checkPointAfter = null,      // default: 2s
+        int checkPointLowerBound = 10,
+        int checkPointUpperBound = 1000,
+        int maxSubscriberCount = 0,            // 0 = unlimited
+        string consumerStrategyName = SystemConsumerStrategies.RoundRobin);
+
+    public readonly bool ResolveLinkTos;
+    public readonly IPosition? StartFrom;
+    public readonly bool ExtraStatistics;
+    public readonly TimeSpan MessageTimeout;
+    public readonly int MaxRetryCount;
+    public readonly int LiveBufferSize;
+    public readonly int ReadBatchSize;
+    public readonly int HistoryBufferSize;
+    public readonly TimeSpan CheckPointAfter;
+    public readonly int CheckPointLowerBound;
+    public readonly int CheckPointUpperBound;
+    public readonly int MaxSubscriberCount;
+    public readonly string ConsumerStrategyName;
+}
+```
+
+### Consumer Strategies
+
+```csharp
+public static class SystemConsumerStrategies {
+    public const string RoundRobin = nameof(RoundRobin);
+    public const string DispatchToSingle = nameof(DispatchToSingle);
+    public const string Pinned = nameof(Pinned);
+}
+```
+
+## KurrentDBProjectionManagementClient
+
+```csharp
+public class KurrentDBProjectionManagementClient : KurrentDBClientBase {
+    public Task CreateOneTimeAsync(string query, ...);
+    public Task CreateContinuousAsync(string name, string query,
+        bool trackEmittedStreams = false, ...);
+    public Task CreateTransientAsync(string name, string query, ...);
+    public Task UpdateAsync(string name, string query,
+        bool? trackEmittedStreams = null, ...);
+    public Task DeleteAsync(string name, ...);
+    public Task<string> GetStateAsync(string name, ...);
+    public Task<ProjectionDetails> GetStatusAsync(string name, ...);
+    public IAsyncEnumerable<ProjectionDetails> ListAsync(...);
+    public Task EnableAsync(string name, ...);
+    public Task DisableAsync(string name, ...);
+    public Task ResetAsync(string name, ...);
+}
+```
+
+## KurrentDBOperationsClient
+
+```csharp
+public class KurrentDBOperationsClient : KurrentDBClientBase {
+    public Task<DatabaseScavengeResult> StartScavengeAsync(
+        int threadCount = 1,
+        int startFromChunk = 0,
+        TimeSpan? deadline = null,
+        UserCredentials? userCredentials = null,
+        CancellationToken cancellationToken = default);
+
+    public Task<DatabaseScavengeResult> StopScavengeAsync(
+        string scavengeId,
+        TimeSpan? deadline = null,
+        UserCredentials? userCredentials = null,
+        CancellationToken cancellationToken = default);
+}
+```
+
+## KurrentDBUserManagementClient
+
+```csharp
+public class KurrentDBUserManagementClient : KurrentDBClientBase {
+    public Task CreateUserAsync(string loginName, string fullName,
+        string[] groups, string password, ...);
+    public Task<UserDetails> GetUserAsync(string loginName, ...);
+    public Task DeleteUserAsync(string loginName, ...);
+    public Task EnableUserAsync(string loginName, ...);
+    public Task DisableUserAsync(string loginName, ...);
+    public IAsyncEnumerable<UserDetails> ListAllAsync(...);
+    public Task ChangePasswordAsync(string loginName,
+        string currentPassword, string newPassword, ...);
+    public Task ResetPasswordAsync(string loginName, string newPassword, ...);
+}
+```
+
+## DI Extensions
+
+All in the `Microsoft.Extensions.DependencyInjection` namespace:
+
+```csharp
+public static class KurrentDBClientServiceCollectionExtensions {
+    // From URI
+    public static IServiceCollection AddKurrentDBClient(
+        this IServiceCollection services, Uri address,
+        Func<HttpMessageHandler>? createHttpMessageHandler = null);
+
+    // From URI factory
+    public static IServiceCollection AddKurrentDBClient(
+        this IServiceCollection services, Func<IServiceProvider, Uri> addressFactory,
+        Func<HttpMessageHandler>? createHttpMessageHandler = null);
+
+    // From settings callback
+    public static IServiceCollection AddKurrentDBClient(
+        this IServiceCollection services,
+        Action<KurrentDBClientSettings>? configureSettings = null);
+
+    // From settings callback with IServiceProvider
+    public static IServiceCollection AddKurrentDBClient(
+        this IServiceCollection services,
+        Func<IServiceProvider, Action<KurrentDBClientSettings>> configureSettings);
+
+    // From connection string
+    public static IServiceCollection AddKurrentDBClient(
+        this IServiceCollection services, string connectionString,
+        Action<KurrentDBClientSettings>? configureSettings = null);
+
+    // From connection string factory
+    public static IServiceCollection AddKurrentDBClient(
+        this IServiceCollection services,
+        Func<IServiceProvider, string> connectionStringFactory,
+        Action<KurrentDBClientSettings>? configureSettings = null);
+}
+```
+
+## OpenTelemetry
+
+```csharp
+namespace KurrentDB.Client.Extensions.OpenTelemetry {
+    public static class TracerProviderBuilderExtensions {
+        public static TracerProviderBuilder AddKurrentDBClientInstrumentation(
+            this TracerProviderBuilder builder);
+    }
+}
+```
+
+## ServerCapabilities
+
+```csharp
+public record ServerCapabilities(
+    bool SupportsBatchAppend = false,
+    bool SupportsPersistentSubscriptionsToAll = false,
+    bool SupportsPersistentSubscriptionsGetInfo = false,
+    bool SupportsPersistentSubscriptionsRestartSubsystem = false,
+    bool SupportsPersistentSubscriptionsReplayParked = false,
+    bool SupportsMultiStreamAppend = false,
+    bool SupportsPersistentSubscriptionsList = false
+);
+```
+
+## Exception Types
+
+### Stream Exceptions
+
+| Exception | Cause |
+|-----------|-------|
+| `WrongExpectedVersionException` | Optimistic concurrency check failed. The stream is not at the expected revision. Includes `ExpectedStreamState` and `ActualStreamState` properties. |
+| `StreamNotFoundException` | Attempted to read or subscribe to a stream that does not exist. |
+| `StreamDeletedException` | Stream was soft-deleted. It can be recreated by appending new events. |
+| `StreamTombstonedException` | Stream was permanently deleted (tombstoned). The stream name can never be reused. |
+| `AppendRecordSizeExceededException` | Individual event exceeds the server's maximum record size. |
+| `AppendTransactionMaxSizeExceededException` | Total append transaction exceeds server's maximum transaction size. |
+
+### Auth Exceptions
+
+| Exception | Cause |
+|-----------|-------|
+| `AccessDeniedException` | Authenticated user lacks permission for the operation. |
+| `NotAuthenticatedException` | Credentials are invalid or missing. |
+
+### Connection Exceptions
+
+| Exception | Cause |
+|-----------|-------|
+| `DiscoveryException` | Failed to discover cluster nodes via gossip after all retry attempts. |
+| `NotLeaderException` | Operation was sent to a non-leader node. The client auto-redirects. |
+| `ConnectionStringParseException` | Base class for connection string parsing errors. |
+| `NoSchemeException` | Connection string missing scheme prefix. |
+| `InvalidSchemeException` | Unrecognized connection string scheme. |
+| `InvalidHostException` | Malformed host in connection string. |
+| `InvalidUserCredentialsException` | Malformed credentials in connection string. |
+| `InvalidKeyValuePairException` | Malformed query parameter. |
+| `DuplicateKeyException` | Duplicate query parameter key. |
+| `InvalidSettingException` | Invalid value for a known parameter. |
+| `InvalidClientCertificateException` | Client certificate file is invalid or not found. |
+
+### Persistent Subscription Exceptions
+
+| Exception | Cause |
+|-----------|-------|
+| `PersistentSubscriptionNotFoundException` | Named subscription group does not exist. |
+| `MaximumSubscribersReachedException` | Consumer group has reached `MaxSubscriberCount`. |
+| `PersistentSubscriptionDroppedByServerException` | Server dropped the persistent subscription connection. |
+
+### Other Exceptions
+
+| Exception | Cause |
+|-----------|-------|
+| `ScavengeNotFoundException` | Scavenge operation with the given ID not found. |
+| `UserNotFoundException` | User with the given login name not found. |
+| `RequiredMetadataPropertyMissingException` | Required metadata property is missing from event metadata. |
+
+## Write Result Types
+
+```csharp
+public interface IWriteResult { }
+
+public class SuccessResult : IWriteResult {
+    public StreamState NextExpectedStreamState { get; }
+    public Position LogPosition { get; }
+}
+
+public class WrongExpectedVersionResult : IWriteResult {
+    public string StreamName { get; }
+    public StreamState ExpectedStreamState { get; }
+    public StreamState ActualStreamState { get; }
+}
+
+public class DeleteResult {
+    public Position LogPosition { get; }
+}
+```
+
+## Enums
+
+```csharp
+public enum Direction { Backwards, Forwards }
+public enum ReadState { StreamNotFound, Ok }
+public enum NodePreference { Leader, Follower, Random, ReadOnlyReplica }
+public enum SubscriptionDroppedReason { Disposed, SubscriberError, ServerError }
+```
+
+## Version Compatibility
+
+| Feature | Minimum Server Version |
+|---------|----------------------|
+| Core operations (append, read, subscribe) | 20.6.1 |
+| Persistent subscriptions to $all | 21.10.0 |
+| Server-side filtering | 21.6.0 |
+| Multi-stream append | 25.1.0 |
+| User certificate authentication | 24.6.0 |

--- a/claude-skill/skills/kurrentdb/reference.md
+++ b/claude-skill/skills/kurrentdb/reference.md
@@ -2,33 +2,104 @@
 
 Comprehensive reference for the `KurrentDB.Client` NuGet package.
 
-## Connection String Parameters
+## Connection String
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `tls` | bool | `true` | Enable TLS encryption |
-| `tlsVerifyCert` | bool | `true` | Verify server TLS certificate |
-| `tlsCaFile` | string | — | Path to CA certificate file for custom CAs |
-| `connectionName` | string | — | Identifies the client in server logs |
-| `defaultDeadline` | int | `10000` | Default operation timeout in milliseconds |
-| `keepAliveInterval` | int | `10000` | gRPC keep-alive ping interval (ms), `-1` for infinite |
-| `keepAliveTimeout` | int | `10000` | gRPC keep-alive timeout (ms), `-1` for infinite |
-| `nodePreference` | string | `leader` | Preferred node: `leader`, `follower`, `random`, `readonlyreplica` |
-| `maxDiscoverAttempts` | int | `10` | Maximum gossip discovery attempts |
-| `discoveryInterval` | int | `100` | Gossip discovery polling interval (ms) |
-| `gossipTimeout` | int | `5000` | Gossip request timeout (ms) |
-| `throwOnAppendFailure` | bool | `true` | Throw on append failure vs return `WrongExpectedVersionResult` |
-| `userCertFile` | string | — | Path to user certificate PEM file (certificate auth) |
-| `userKeyFile` | string | — | Path to user private key PEM file (certificate auth) |
+### Format
 
-**Connection string format:**
 ```
 scheme://[user:password@]host[:port][,host[:port]...][?key=value[&key=value...]]
 ```
 
-**Supported schemes:** `esdb`, `esdb+discover`, `kdb`, `kdb+discover`, `kurrent`, `kurrent+discover`, `kurrentdb`, `kurrentdb+discover`
+Default port is `2113`. Parameters are case-insensitive. Duplicate keys are not allowed and will throw `DuplicateKeyException`.
 
-The `+discover` suffix enables cluster gossip discovery. Without it, the client connects directly to the specified node(s).
+### Supported Schemes
+
+All schemes are functionally equivalent — they differ only in name:
+
+| Scheme | Discovery Variant | Notes |
+|--------|------------------|-------|
+| `esdb` | `esdb+discover` | Original EventStoreDB scheme, still fully supported |
+| `kdb` | `kdb+discover` | Short alias |
+| `kurrent` | `kurrent+discover` | Alias |
+| `kurrentdb` | `kurrentdb+discover` | Canonical KurrentDB scheme |
+
+Without `+discover`, the client connects directly to the specified node(s). With `+discover`, the client uses gossip-based discovery to find cluster members — required for clusters, optional for single nodes.
+
+**Single node vs cluster:** When one host is provided without `+discover`, the client treats it as a single-node direct connection. When multiple hosts are provided, or `+discover` is used, hosts are treated as gossip seeds for cluster discovery.
+
+### Parameters
+
+#### TLS & Security
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `tls` | bool | `true` | Enable TLS encryption. Set to `false` for insecure (unencrypted) connections. Maps to `ConnectivitySettings.Insecure` (inverted). |
+| `tlsVerifyCert` | bool | `true` | Verify the server's TLS certificate chain. Set to `false` to accept self-signed certificates (development only). Maps to `ConnectivitySettings.TlsVerifyCert`. |
+| `tlsCaFile` | string | — | Absolute or relative path to a CA certificate file (PEM or DER). Used to trust a private CA. Throws `InvalidClientCertificateException` if the file doesn't exist or has an invalid format. Maps to `ConnectivitySettings.TlsCaFile`. |
+| `userCertFile` | string | — | Path to client certificate PEM file for certificate-based authentication (server 24.6+). **Must** be paired with `userKeyFile`. Maps to `ConnectivitySettings.ClientCertificate`. |
+| `userKeyFile` | string | — | Path to client private key PEM file. **Must** be paired with `userCertFile`. Throws `InvalidClientCertificateException` if only one is set or files don't exist. |
+
+#### Timeouts & Keep-Alive
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `defaultDeadline` | int | `10000` | Default timeout for all operations, in milliseconds. Maps to `DefaultDeadline`. |
+| `keepAliveInterval` | int | `10000` | gRPC keep-alive ping interval in milliseconds. Use `-1` for infinite (disable pings). Must be `>= 0` or `-1`. Maps to `ConnectivitySettings.KeepAliveInterval`. |
+| `keepAliveTimeout` | int | `10000` | gRPC keep-alive ping timeout in milliseconds. If a ping response is not received within this time, the connection is considered dead. Use `-1` for infinite. Must be `>= 0` or `-1`. Maps to `ConnectivitySettings.KeepAliveTimeout`. |
+
+#### Cluster Discovery
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `nodePreference` | string | `leader` | Preferred node type for operations. Values: `leader` (write-capable node), `follower` (read-optimized, redirects writes), `random` (any node), `readonlyreplica` (read-only replica node). Maps to `ConnectivitySettings.NodePreference`. |
+| `maxDiscoverAttempts` | int | `10` | Maximum number of gossip discovery attempts before throwing `DiscoveryException`. Maps to `ConnectivitySettings.MaxDiscoverAttempts`. |
+| `discoveryInterval` | int | `100` | Interval between discovery attempts, in milliseconds. Maps to `ConnectivitySettings.DiscoveryInterval`. |
+| `gossipTimeout` | int | `5000` | Timeout for a single gossip request, in milliseconds. Maps to `ConnectivitySettings.GossipTimeout`. |
+
+#### Client Behavior
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `connectionName` | string | — | A name identifying this client connection in server logs and diagnostics. Maps to `ConnectionName`. |
+| `throwOnAppendFailure` | bool | `true` | When `true`, `AppendToStreamAsync` throws `WrongExpectedVersionException` on concurrency conflicts. When `false`, it returns a `WrongExpectedVersionResult` instead, allowing non-exception control flow. Maps to `OperationOptions.ThrowOnAppendFailure`. |
+
+### Examples
+
+```
+# Insecure local development
+kurrentdb://localhost:2113?tls=false
+
+# With credentials, TLS enabled, skip cert verification
+kurrentdb://admin:changeit@localhost:2113?tls=true&tlsVerifyCert=false
+
+# Cluster discovery with follower preference
+kurrentdb+discover://admin:changeit@node1:2113,node2:2113,node3:2113?nodePreference=follower&maxDiscoverAttempts=5
+
+# Custom CA certificate
+kurrentdb://admin:changeit@localhost:2113?tls=true&tlsCaFile=/path/to/ca.crt
+
+# Client certificate authentication (no user:pass needed)
+kurrentdb://localhost:2113?tls=true&userCertFile=/path/to/user.crt&userKeyFile=/path/to/user.key
+
+# Named connection with custom timeouts
+kurrentdb://admin:changeit@localhost:2113?connectionName=order-service&defaultDeadline=30000&keepAliveInterval=5000
+
+# Non-throwing append failures
+kurrentdb://admin:changeit@localhost:2113?throwOnAppendFailure=false
+```
+
+### Parsing Errors
+
+| Exception | Cause |
+|-----------|-------|
+| `NoSchemeException` | Connection string has no `://` separator |
+| `InvalidSchemeException` | Scheme is not one of the 8 supported values |
+| `InvalidHostException` | Malformed host (empty, non-numeric port) |
+| `InvalidUserCredentialsException` | User info is not in `user:password` format |
+| `InvalidKeyValuePairException` | Query parameter is not in `key=value` format |
+| `DuplicateKeyException` | Same parameter key appears more than once |
+| `InvalidSettingException` | Unknown parameter name, or value has wrong type (e.g., non-integer for `maxDiscoverAttempts`) |
+| `InvalidClientCertificateException` | Certificate/key file not found, invalid format, or only one of `userCertFile`/`userKeyFile` provided |
 
 ## KurrentDBClientSettings
 

--- a/claude-skill/skills/kurrentdb/reference.md
+++ b/claude-skill/skills/kurrentdb/reference.md
@@ -337,20 +337,18 @@ public ValueTask<MultiStreamAppendResponse> MultiStreamAppendAsync(
 **Supporting types:**
 
 ```csharp
-public class AppendStreamRequest {
-    public string Stream { get; set; }
-    public StreamState ExpectedState { get; set; }
-    public IAsyncEnumerable<EventData> Messages { get; set; }
-}
+// Positional record — use constructor syntax, NOT object initializers
+public record AppendStreamRequest(
+    string Stream,
+    StreamState ExpectedState,
+    IEnumerable<EventData> Messages   // NOT IAsyncEnumerable
+);
 
-public class AppendResponse {
-    public string Stream { get; }
-    public ulong StreamRevision { get; }
-}
+public record AppendResponse(string Stream, long StreamRevision);
 
-public class MultiStreamAppendResponse {
-    public Position Position { get; }
-    public IEnumerable<AppendResponse> Responses { get; }
+public readonly struct MultiStreamAppendResponse(long position, IEnumerable<AppendResponse>? responses = null) {
+    public readonly long Position;
+    public readonly IEnumerable<AppendResponse>? Responses;
 }
 ```
 


### PR DESCRIPTION
### **PR Type**
Documentation, Enhancement


___

### **Description**
- Added comprehensive CLAUDE.md guidance document for Claude Code integration

- Created KurrentDB .NET Client SDK skill with detailed API reference

- Documented project structure, build commands, testing conventions

- Provided connection setup, event operations, subscriptions, and migration guides


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Project Documentation"] -->|CLAUDE.md| B["Build & Test Guidance"]
  A -->|CLAUDE.md| C["Architecture Overview"]
  A -->|CLAUDE.md| D["Code Style Standards"]
  E["Claude Skill"] -->|SKILL.md| F["Client Setup & Connection"]
  E -->|SKILL.md| G["Event Operations"]
  E -->|SKILL.md| H["Subscriptions & Projections"]
  E -->|reference.md| I["Complete API Reference"]
  E -->|plugin.json| J["Skill Metadata"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>Project guidance and development standards documentation</code>&nbsp; </dd></summary>
<hr>

CLAUDE.md

<ul><li>Comprehensive project overview for KurrentDB .NET Client SDK <br>(gRPC-based, NuGet package)<br> <li> Build commands for solution, release mode, and NuGet package <br>generation<br> <li> Integration testing setup with Docker, certificate generation, and <br>test categories<br> <li> Test conventions including class structure, naming, fixtures, traits, <br>and special attributes<br> <li> Architecture documentation covering solution structure, client <br>classes, and source layout<br> <li> Connection configuration details and key types (EventData, <br>StreamState, Uuid)<br> <li> Sample projects structure with region markers for documentation <br>extraction<br> <li> C# code style guidelines (tabs, braces, nullable references, warnings <br>as errors)</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB-Client-Dotnet/pull/388/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7">+195/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SKILL.md</strong><dd><code>KurrentDB .NET Client SDK usage guide and API examples</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

claude-skill/skills/kurrentdb/SKILL.md

<ul><li>Client setup with connection string schemes (esdb, kdb, kurrent, <br>kurrentdb)<br> <li> Connection string parameters table with TLS, authentication, and <br>timeout options<br> <li> Programmatic configuration and dependency injection examples<br> <li> Event appending with concurrency control and multi-stream atomic <br>writes<br> <li> Stream reading with forwards/backwards direction and link resolution<br> <li> Catch-up subscriptions with reconnection patterns and server-side <br>filtering<br> <li> Persistent subscriptions with consumer strategies and acknowledgment <br>patterns<br> <li> Projection management (create, state retrieval, enable/disable, reset)<br> <li> Stream metadata, ACLs, soft delete vs tombstone operations<br> <li> Observability via OpenTelemetry instrumentation<br> <li> Error handling exception reference table<br> <li> Migration guide from EventStoreDB with namespace and class renames</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB-Client-Dotnet/pull/388/files#diff-bbede68a6a595679b63f109a5a5a49abdb12fc767e86de44177500d85f0492c1">+454/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>reference.md</strong><dd><code>Complete API reference for KurrentDB .NET Client SDK</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

claude-skill/skills/kurrentdb/reference.md

<ul><li>Complete connection string parameters reference with types and <br>defaults<br> <li> KurrentDBClientSettings and related configuration classes<br> <li> EventData, Uuid, EventRecord, and ResolvedEvent type definitions<br> <li> StreamState, Position, StreamPosition, FromStream, FromAll position <br>types<br> <li> UserCredentials and all client class method signatures<br> <li> Multi-stream append request/response types for atomic transactions<br> <li> Read stream and read all operations with filtering support<br> <li> Subscribe operations with both IAsyncEnumerable and callback APIs<br> <li> Delete, tombstone, and stream metadata operations<br> <li> StreamMessage discriminated union types for subscription events<br> <li> StreamMetadata and StreamAcl configuration classes<br> <li> EventTypeFilter and StreamFilter for server-side filtering<br> <li> Persistent subscriptions client with settings and consumer strategies<br> <li> Projection management, operations, and user management client APIs<br> <li> Dependency injection extension methods for all client types<br> <li> OpenTelemetry instrumentation extensions<br> <li> ServerCapabilities feature detection record<br> <li> Comprehensive exception types table with causes<br> <li> Write result types (SuccessResult, WrongExpectedVersionResult, <br>DeleteResult)<br> <li> Enums and version compatibility matrix</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB-Client-Dotnet/pull/388/files#diff-a4c95123ca5374254374696e33d4a10b36b95a3ff362f31ccbb804a6612bcf07">+864/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>plugin.json</strong><dd><code>Claude skill plugin configuration metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

claude-skill/.claude-plugin/plugin.json

<ul><li>Plugin metadata defining the KurrentDB .NET Client SDK skill<br> <li> Name, description, and version information for Claude Code integration<br> <li> Describes skill focus on connection setup, event operations, and <br>EventStoreDB migration</ul>


</details>


  </td>
  <td><a href="https://github.com/kurrent-io/KurrentDB-Client-Dotnet/pull/388/files#diff-db1dae61a0e97eb3300da88890f120c917f00c593c7faea6d5aa044c1ece9479">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

