### PR TITLE
fix: Length check after splitting channel target to avoid index out of range exception

### DIFF
--- a/src/KurrentDB.Client/Core/Common/Diagnostics/ActivityTagsCollectionExtensions.cs
+++ b/src/KurrentDB.Client/Core/Common/Diagnostics/ActivityTagsCollectionExtensions.cs
@@ -13,9 +13,12 @@ static class ActivityTagsCollectionExtensions {
         
         var authorityParts = channelInfo.Channel.Target.Split(':');
 
-        return tags
-            .WithRequiredTag(TelemetryTags.Server.Address, authorityParts[0])
-            .WithRequiredTag(TelemetryTags.Server.Port, int.Parse(authorityParts[1]));
+        tags = tags.WithRequiredTag(TelemetryTags.Server.Address, authorityParts[0]);
+
+        if (authorityParts.Length > 1)
+            tags = tags.WithRequiredTag(TelemetryTags.Server.Port, int.Parse(authorityParts[1]));
+
+        return tags;
     }
     
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Added length check before accessing second index during activity tag collection building.
We have meet this issue when tried to run KDB on 80 port.