### PR TITLE
[DEV-1271] Support atomic cross-stream consistency validation when appending events

### DIFF
--- a/docs/api/appending-events.md
+++ b/docs/api/appending-events.md
@@ -138,58 +138,132 @@ await client.AppendToStreamAsync(
 );
 ```
 
-## Append to multiple streams
+## Atomic appends
 
-::: note
-This feature is only available in KurrentDB 25.1 and later. 
+KurrentDB provides two operations for appending events to one or more streams in a single atomic transaction: `AppendRecords` and `MultiStreamAppend`. Both guarantee that either all writes succeed or the entire operation fails, but they differ in how records are organized, ordered, and validated.
+
+|                        | `AppendRecords`                                                                                                 | `MultiStreamAppend`                                                                             |
+|------------------------|-----------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
+| **Available since**    | KurrentDB 26.1                                                                                                  | KurrentDB 25.1                                                                                  |
+| **Record ordering**    | Interleaved. Records from different streams can be mixed, and their exact order is preserved in the global log. | Grouped. All records for a stream are sent together; ordering across streams is not guaranteed. |
+| **Consistency checks** | Decoupled. Can validate the state of any stream, including streams not being written to.                        | Coupled. Expected state is specified per stream being written to.                               |
+
+::: warning
+Metadata must be a valid JSON object, using string keys and string values only.
+Binary metadata is not supported in this version to maintain compatibility with
+KurrentDB's metadata handling. This restriction will be lifted in the next major
+release.
 :::
 
-You can append events to multiple streams in a single atomic operation. Either all streams are updated, or the entire operation fails.
+### AppendRecords
+
+::: note
+This feature is only available in KurrentDB 26.1 and later.
+:::
+
+`AppendRecords` appends events to one or more streams atomically. Each record specifies which stream it targets, and the exact order of records is preserved in the global log across all streams.
+
+#### Single stream
+
+The simplest usage appends events to a single stream:
 
 ```cs
-using System.Text.Json;
+var eventOne = new EventData(
+  Uuid.NewUuid(), "OrderPlaced", "{\"orderId\": \"123\"}"u8.ToArray()
+);
 
+var eventTwo = new EventData(
+  Uuid.NewUuid(), "OrderShipped", "{\"orderId\": \"123\"}"u8.ToArray()
+);
+
+await client.AppendRecordsAsync("order-123", [eventOne, eventTwo]);
+```
+
+When no expected state is provided, no consistency check is performed, which is equivalent to `StreamState.Any`.
+
+You can also pass an expected stream state for optimistic concurrency:
+
+```cs
+await client.AppendRecordsAsync(
+  "order-123",
+  StreamState.NoStream,
+  [eventOne, eventTwo]
+);
+```
+
+#### Multiple streams
+
+Use `AppendRecord` to target different streams. Records can be interleaved freely, and the global log preserves the exact order you specify:
+
+```cs
+var records = new[] {
+  new AppendRecord("order-stream", new EventData(
+    Uuid.NewUuid(), "OrderCreated", "{\"orderId\": \"123\"}"u8.ToArray()
+  )),
+  new AppendRecord("inventory-stream", new EventData(
+    Uuid.NewUuid(), "ItemReserved", "{\"itemId\": \"abc\", \"quantity\": 2}"u8.ToArray()
+  )),
+  new AppendRecord("order-stream", new EventData(
+    Uuid.NewUuid(), "OrderConfirmed", "{\"orderId\": \"123\"}"u8.ToArray()
+  )),
+};
+
+await client.AppendRecordsAsync(records);
+```
+
+#### Consistency checks
+
+Consistency checks let you validate the state of any stream, including streams you are not writing to, before the append is committed. All checks are evaluated atomically: if any check fails, the entire operation is rejected and an `AppendConsistencyViolationException` is thrown with details about every failing check and the actual state observed.
+
+```cs
+var records = new[] {
+  new AppendRecord("order-stream", new EventData(
+    Uuid.NewUuid(), "OrderConfirmed", "{\"orderId\": \"123\"}"u8.ToArray()
+  )),
+};
+
+var checks = new[] {
+  // ensure the inventory stream exists before confirming the order,
+  // even though we are not writing to it
+  new ConsistencyCheck.StreamStateCheck("inventory-stream", StreamState.StreamExists),
+};
+
+await client.AppendRecordsAsync(records, checks);
+```
+
+Because checks are decoupled from writes, you can validate the state of streams you are not writing to, enabling patterns where a business decision depends on the state of multiple streams but the resulting event is written to only one of them.
+
+### MultiStreamAppend
+
+::: note
+This feature is only available in KurrentDB 25.1 and later.
+:::
+
+`MultiStreamAppend` appends events to one or more streams atomically. Records are grouped per stream using `AppendStreamRequest`, where each request specifies a stream name, an expected state, and the events for that stream.
+
+```cs
 AppendStreamRequest[] requests = [
-	new(
-		"order-stream",
-		StreamState.Any,
-		[
-			new EventData(Uuid.NewUuid(), "OrderCreated", Encoding.UTF8.GetBytes("{\"orderId\": \"21345\", \"amount\": 99.99}"))
-		]
-	),
-	new(
-		"inventory-stream",
-		StreamState.Any,
-		[
-			new EventData(Uuid.NewUuid(), "ItemReserved", Encoding.UTF8.GetBytes("{\"itemId\": \"abc123\", \"quantity\": 2}"))
-		]
-	)
+  new(
+    "order-stream",
+    StreamState.Any,
+    [
+      new EventData(Uuid.NewUuid(), "OrderCreated",
+        Encoding.UTF8.GetBytes("{\"orderId\": \"21345\", \"amount\": 99.99}"))
+    ]
+  ),
+  new(
+    "inventory-stream",
+    StreamState.Any,
+    [
+      new EventData(Uuid.NewUuid(), "ItemReserved",
+        Encoding.UTF8.GetBytes("{\"itemId\": \"abc123\", \"quantity\": 2}"))
+    ]
+  )
 ];
 
 await client.MultiStreamAppendAsync(requests);
 ```
 
-The result returns the position of the last appended record in the transaction and a collection of responses for each stream appended in the transaction.
+Each stream can only appear once in the request. The expected state is validated per stream before the transaction is committed.
 
-::: warning
-The metadata for an event must be a valid JSON object where both keys and values are strings. It is essential that the JSON is well-formed and not missing, as any malformed or absent metadata will result in an `ArgumentException` being thrown.
-
-You can use the provided `Encode` and `Decode` extension methods when writing
-and reading metadata. For example:
-
-```cs
-var metadata = new Dictionary<string, string>
-{
-  { "userId", "user-456" }
-};
-
-// encode to bytes before appending
-var metadataBytes = metadata.Encode();
-```
-
-And when reading metadata back:
-
-```cs
-var metadata = metadataBytes.Decode();
-```
-:::
+The result returns the position of the last appended record in the transaction and a collection of responses for each stream.

--- a/samples/appending-events/Program.cs
+++ b/samples/appending-events/Program.cs
@@ -8,6 +8,9 @@ settings.OperationOptions.ThrowOnAppendFailure = false;
 
 await using var client = new KurrentDBClient(settings);
 
+await AppendRecords(client);
+await AppendRecordsMultipleStreams(client);
+await AppendRecordsWithConsistencyCheck(client);
 await MultiStreamAppend(client);
 await AppendToStream(client);
 await AppendWithConcurrencyCheck(client);
@@ -15,6 +18,59 @@ await AppendWithNoStream(client);
 await AppendWithSameId(client);
 
 return;
+
+static async Task AppendRecords(KurrentDBClient client) {
+	#region append-records
+
+	var eventOne = new EventData(
+		Uuid.NewUuid(),
+		"some-event",
+		"{\"id\": \"1\" \"value\": \"some value\"}"u8.ToArray()
+	);
+
+	var eventTwo = new EventData(
+		Uuid.NewUuid(),
+		"some-event",
+		"{\"id\": \"2\" \"value\": \"some other value\"}"u8.ToArray()
+	);
+
+	await client.AppendRecordsAsync(
+		"some-stream",
+		[eventOne, eventTwo]
+	);
+
+	#endregion append-records
+}
+
+static async Task AppendRecordsMultipleStreams(KurrentDBClient client) {
+	#region append-records-multiple-streams
+
+	var records = new[] {
+		new AppendRecord("stream-one", new EventData(Uuid.NewUuid(), "event-one", "{\"id\": \"1\"}"u8.ToArray())),
+		new AppendRecord("stream-two", new EventData(Uuid.NewUuid(), "event-two", "{\"id\": \"2\"}"u8.ToArray())),
+		new AppendRecord("stream-one", new EventData(Uuid.NewUuid(), "event-three", "{\"id\": \"3\"}"u8.ToArray())),
+	};
+
+	await client.AppendRecordsAsync(records);
+
+	#endregion append-records-multiple-streams
+}
+
+static async Task AppendRecordsWithConsistencyCheck(KurrentDBClient client) {
+	#region append-records-with-consistency-check
+
+	var records = new[] {
+		new AppendRecord("stream-one", new EventData(Uuid.NewUuid(), "some-event", "{\"id\": \"1\"}"u8.ToArray())),
+	};
+
+	var checks = new[] {
+		new ConsistencyCheck.StreamStateCheck("stream-one", StreamState.NoStream),
+	};
+
+	await client.AppendRecordsAsync(records, checks);
+
+	#endregion append-records-with-consistency-check
+}
 
 static async Task MultiStreamAppend(KurrentDBClient client) {
 	var metadata = JsonSerializer.SerializeToUtf8Bytes(

--- a/src/KurrentDB.Client/Core/Exceptions/AppendConsistencyViolationException.cs
+++ b/src/KurrentDB.Client/Core/Exceptions/AppendConsistencyViolationException.cs
@@ -1,0 +1,59 @@
+using Grpc.Core;
+using KurrentDB.Protocol.V2.Streams.Errors;
+
+namespace KurrentDB.Client;
+
+/// <summary>
+/// Exception thrown when one or more consistency checks fail during an AppendRecords operation.
+/// The entire transaction is aborted and no records are written.
+/// </summary>
+public class AppendConsistencyViolationException : Exception {
+	/// <summary>
+	/// The consistency violations that caused the transaction to be aborted.
+	/// </summary>
+	public IReadOnlyList<Violation> Violations { get; }
+
+	/// <summary>
+	/// Constructs a new <see cref="AppendConsistencyViolationException"/>.
+	/// </summary>
+	public AppendConsistencyViolationException(IReadOnlyList<Violation> violations, Exception? innerException = null)
+		: base(FormatMessage(violations), innerException) {
+		Violations = violations;
+	}
+
+	public static AppendConsistencyViolationException FromRpcException(RpcException ex) => FromRpcStatus(ex.GetRpcStatus()!);
+
+	public static AppendConsistencyViolationException FromRpcStatus(Google.Rpc.Status status) {
+		var details = status.GetDetail<AppendConsistencyViolationErrorDetails>();
+		var violations = details.Violations.Select(v => {
+			if (v.StreamState != null) {
+				return new Violation(
+					v.CheckIndex,
+					v.StreamState.Stream,
+					new StreamState(v.StreamState.ExpectedState),
+					new StreamState(v.StreamState.ActualState)
+				);
+			}
+
+			return new Violation(v.CheckIndex, string.Empty, default, default);
+		}).ToList();
+
+		return new AppendConsistencyViolationException(violations);
+	}
+
+	static string FormatMessage(IReadOnlyList<Violation> violations) {
+		var details = string.Join(", ", violations.Select(v =>
+			$"[Check {v.CheckIndex}: Stream '{v.Stream}' expected state {v.ExpectedState}, actual state {v.ActualState}]"
+		));
+		return $"Append failed due to consistency violation(s): {details}";
+	}
+
+	/// <summary>
+	/// Represents a single consistency check violation.
+	/// </summary>
+	/// <param name="CheckIndex">Index of the check in the original consistency checks list.</param>
+	/// <param name="Stream">The name of the stream whose state was checked.</param>
+	/// <param name="ExpectedState">The expected state of the stream.</param>
+	/// <param name="ActualState">The actual state of the stream at the time the check was evaluated.</param>
+	public record Violation(int CheckIndex, string Stream, StreamState ExpectedState, StreamState ActualState);
+}

--- a/src/KurrentDB.Client/Core/GrpcServerCapabilitiesClient.cs
+++ b/src/KurrentDB.Client/Core/GrpcServerCapabilitiesClient.cs
@@ -30,6 +30,7 @@ namespace KurrentDB.Client {
 				var supportsPersistentSubscriptionsReplayParked = false;
 				var supportsPersistentSubscriptionsList = false;
 				var supportsMultiStreamAppend = false;
+				var supportsAppendRecords = false;
 
 				var response = await call.ResponseAsync.ConfigureAwait(false);
 
@@ -56,6 +57,9 @@ namespace KurrentDB.Client {
 						case ("kurrentdb.protocol.v2.streams.streamsservice", "appendsession"):
 							supportsMultiStreamAppend = true;
 							continue;
+						case ("kurrentdb.protocol.v2.streams.streamsservice", "appendrecords"):
+							supportsAppendRecords = true;
+							continue;
 					}
 				}
 
@@ -66,7 +70,8 @@ namespace KurrentDB.Client {
 					SupportsPersistentSubscriptionsRestartSubsystem: supportsPersistentSubscriptionsRestartSubsystem,
 					SupportsPersistentSubscriptionsReplayParked: supportsPersistentSubscriptionsReplayParked,
 					SupportsPersistentSubscriptionsList: supportsPersistentSubscriptionsList,
-					SupportsMultiStreamAppend: supportsMultiStreamAppend);
+					SupportsMultiStreamAppend: supportsMultiStreamAppend,
+					SupportsAppendRecords: supportsAppendRecords);
 
 			} catch (Exception ex) when (ex.GetBaseException() is RpcException rpcException &&
 				rpcException.StatusCode == StatusCode.Unimplemented) {

--- a/src/KurrentDB.Client/Core/ServerCapabilities.cs
+++ b/src/KurrentDB.Client/Core/ServerCapabilities.cs
@@ -7,5 +7,6 @@ namespace KurrentDB.Client {
 		bool SupportsPersistentSubscriptionsRestartSubsystem = false,
 		bool SupportsPersistentSubscriptionsReplayParked = false,
 		bool SupportsMultiStreamAppend = false,
-		bool SupportsPersistentSubscriptionsList = false);
+		bool SupportsPersistentSubscriptionsList = false,
+		bool SupportsAppendRecords = false);
 }

--- a/src/KurrentDB.Client/Core/StreamState.cs
+++ b/src/KurrentDB.Client/Core/StreamState.cs
@@ -18,6 +18,10 @@ namespace KurrentDB.Client {
 		/// </summary>
 		public static readonly StreamState StreamExists = new StreamState(Constants.StreamExists);
 
+		internal static readonly StreamState Deleted = new StreamState(Constants.Deleted);
+
+		internal static readonly StreamState Tombstoned = new StreamState(Constants.Tombstoned);
+
 		public static StreamState StreamRevision(ulong value) => new StreamState((long)value);
 
 		private readonly long _value;
@@ -26,6 +30,8 @@ namespace KurrentDB.Client {
 			public const int NoStream = -1;
 			public const int Any = -2;
 			public const int StreamExists = -4;
+			public const int Deleted = -5;
+			public const int Tombstoned = -6;
 		}
 
 		internal StreamState(long value) {
@@ -33,6 +39,8 @@ namespace KurrentDB.Client {
 				case Constants.NoStream:
 				case Constants.Any:
 				case Constants.StreamExists:
+				case Constants.Deleted:
+				case Constants.Tombstoned:
 					_value = value;
 					return;
 				default:
@@ -84,6 +92,8 @@ namespace KurrentDB.Client {
 			Constants.NoStream => nameof(NoStream),
 			Constants.Any => nameof(Any),
 			Constants.StreamExists => nameof(StreamExists),
+			Constants.Deleted => nameof(Deleted),
+			Constants.Tombstoned => nameof(Tombstoned),
 			_ => _value.ToString()
 		};
 	}

--- a/src/KurrentDB.Client/Core/proto/kurrentdb/protocol/v2/streams/errors.proto
+++ b/src/KurrentDB.Client/Core/proto/kurrentdb/protocol/v2/streams/errors.proto
@@ -144,6 +144,21 @@ enum StreamsError {
   STREAMS_ERROR_APPEND_SESSION_NO_REQUESTS = 9 [(kurrent.rpc.error) = {
     status_code: FAILED_PRECONDITION
   }];
+
+  // One or more consistency checks failed during an AppendRecords operation.
+  // The transaction is aborted — no records are written.
+  //
+  // Common causes:
+  // - A stream state check found the stream at a different revision than expected
+  // - A stream referenced in a state check does not exist, was deleted, or was tombstoned
+  //
+  // Client action: Inspect the AppendConsistencyViolationErrorDetails to determine which
+  // checks failed and why, then correct the request or refresh local state and retry.
+  // Recoverable by reading the current state and resubmitting with updated checks.
+  STREAMS_ERROR_APPEND_CONSISTENCY_VIOLATION = 14 [(kurrent.rpc.error) = {
+    status_code: FAILED_PRECONDITION,
+    has_details: true
+  }];
 }
 
 // Details for STREAM_NOT_FOUND errors.
@@ -210,4 +225,36 @@ message AppendTransactionSizeExceededErrorDetails {
 message StreamAlreadyInAppendSessionErrorDetails {
   // The name of the stream that appears multiple times.
   string stream = 1;
+}
+
+// Details for APPEND_CONSISTENCY_VIOLATION errors.
+//
+// Contains all consistency checks that were violated during the append operation.
+// Only violated checks are included; satisfied checks are omitted.
+message AppendConsistencyViolationErrorDetails {
+  // The consistency checks that were violated.
+  repeated ConsistencyViolation violations = 1;
+}
+
+// Details for a single consistency check that was violated.
+message ConsistencyViolation {
+  // Index of the check in the original consistency_checks list.
+  int32 check_index = 1;
+
+  oneof type {
+    // The stream was not at the expected state.
+    StreamStateViolation stream_state = 2;
+  }
+
+  // A stream state check was violated because the actual state did not match the expected state.
+  message StreamStateViolation {
+    // The name of the stream whose state was checked.
+    string stream = 1;
+
+    // The expected state of the stream as specified in the consistency check.
+    sint64 expected_state = 2;
+
+    // The actual state of the stream at the time the check was evaluated.
+    sint64 actual_state = 3;
+  }
 }

--- a/src/KurrentDB.Client/Core/proto/kurrentdb/protocol/v2/streams/streams.proto
+++ b/src/KurrentDB.Client/Core/proto/kurrentdb/protocol/v2/streams/streams.proto
@@ -31,6 +31,28 @@ service StreamsService {
   //   4. Client completes the stream
   //   5. Server validates, commits, returns AppendSessionResponse with positions
   rpc AppendSession(stream AppendRequest) returns (AppendSessionResponse);
+
+  // Appends records to multiple streams atomically with cross-stream consistency checks.
+  //
+  // This is a unary RPC where the client sends all records and consistency checks
+  // in a single request and receives a single AppendRecordsResponse.
+  //
+  // Records can be interleaved across streams in any order and the global log preserves
+  // the exact sequence from the request.
+  //
+  // Consistency checks are decoupled from writes: a check can reference any stream,
+  // whether or not the request writes to it. This enables Dynamic Consistency Boundary
+  // (DCB) patterns where a decision depends on multiple streams but only produces
+  // events for a subset.
+  //
+  // Guarantees:
+  // - Atomicity: All writes succeed or all fail together
+  // - Ordering: Records maintain the exact send order in the global log
+  // - Cross-stream checks: Consistency checks can reference any stream
+  //
+  // On consistency check failure, no records are written and all failing checks
+  // are reported in the response so the client can refresh stale state in one round trip.
+  rpc AppendRecords(AppendRecordsRequest) returns (AppendRecordsResponse);
 }
 
 // Represents the input for appending records to a specific stream.
@@ -132,6 +154,11 @@ message AppendRecord {
   // The record payload as raw bytes.
   // The format specified in SchemaInfo determines how to interpret these bytes.
   bytes data = 4;
+
+  // Target stream for this record.
+  // Required for AppendRecords (each record specifies its own stream).
+  // Ignored for AppendSession (the stream is specified in AppendRequest).
+  string stream = 5;
 }
 
 // Constants for expected revision validation in optimistic concurrency control.
@@ -152,4 +179,62 @@ enum ExpectedRevisionConstants {
   // The stream must exist (have at least one record).
   // Fails if the stream doesn't exist yet.
   EXPECTED_REVISION_CONSTANTS_EXISTS = -4;
+}
+
+// Request to append records to one or more streams atomically.
+//
+// All records are committed in a single transaction. Each record specifies its
+// target stream via AppendRecord.stream. Consistency checks are evaluated before
+// any records are written.
+message AppendRecordsRequest {
+  // The records to append. Records targeting the same stream maintain their
+  // order from this list.
+  repeated AppendRecord records = 1;
+
+  // Optional consistency checks evaluated before commit. If any check fails,
+  // the entire transaction is aborted.
+  repeated ConsistencyCheck checks = 2;
+}
+
+// Response from a successful AppendRecords operation.
+//
+// Contains the resulting revision for each stream that was written to and the
+// global commit position of the transaction.
+message AppendRecordsResponse {
+  // The resulting revision for each stream that received records. One entry per
+  // distinct stream written to, in no guaranteed order.
+  repeated StreamRevision revisions = 1;
+
+  // The global commit position of the last record written in this transaction.
+  // Can be used for read-your-writes consistency or progress tracking.
+  sint64 position = 2;
+}
+
+// A pre-commit condition that must hold true for the transaction to succeed.
+//
+// Consistency checks are evaluated atomically before any records are written. If
+// any check is violated, the entire transaction is aborted.
+message ConsistencyCheck {
+  oneof type {
+    // Check that a stream is at a specific revision or lifecycle state.
+    StreamStateCheck stream_state = 1;
+  }
+
+  // Asserts a stream is at a specific revision or lifecycle state before commit.
+  message StreamStateCheck {
+    // The stream name.
+    string stream = 1;
+
+    // The expected state of the stream (revision number or state constant).
+    sint64 expected_state = 2;
+  }
+}
+
+// A specific revision of a stream.
+message StreamRevision {
+  // Stream name.
+  string stream = 1;
+
+  // Revision within the stream.
+  sint64 revision = 2;
 }

--- a/src/KurrentDB.Client/Streams/AppendRecords.Extensions.cs
+++ b/src/KurrentDB.Client/Streams/AppendRecords.Extensions.cs
@@ -1,0 +1,76 @@
+namespace KurrentDB.Client;
+
+public static class AppendRecordsExtensions {
+	/// <summary>
+	/// Appends records to one or more streams atomically with cross-stream consistency checks.
+	/// </summary>
+	public static ValueTask<AppendRecordsResponse> AppendRecordsAsync(
+		this KurrentDBClient client,
+		IEnumerable<AppendRecord> records,
+		CancellationToken cancellationToken = default
+	) =>
+		client.AppendRecordsAsync(records, checks: null, cancellationToken);
+
+	/// <summary>
+	/// Appends a single record to a stream atomically.
+	/// </summary>
+	public static ValueTask<AppendRecordsResponse> AppendRecordsAsync(
+		this KurrentDBClient client,
+		AppendRecord record,
+		CancellationToken cancellationToken = default
+	) =>
+		client.AppendRecordsAsync([record], checks: null, cancellationToken);
+
+	/// <summary>
+	/// Appends records to a single stream atomically.
+	/// </summary>
+	public static ValueTask<AppendRecordsResponse> AppendRecordsAsync(
+		this KurrentDBClient client,
+		string stream,
+		IEnumerable<EventData> events,
+		CancellationToken cancellationToken = default
+	) =>
+		client.AppendRecordsAsync(
+			events.Select(e => new AppendRecord(stream, e)),
+			checks: null,
+			cancellationToken
+		);
+
+	/// <summary>
+	/// Appends records to a single stream atomically with a consistency check.
+	/// </summary>
+	public static ValueTask<AppendRecordsResponse> AppendRecordsAsync(
+		this KurrentDBClient client,
+		string stream,
+		StreamState expectedState,
+		IEnumerable<EventData> events,
+		CancellationToken cancellationToken = default
+	) =>
+		client.AppendRecordsAsync(
+			events.Select(e => new AppendRecord(stream, e)),
+			[new ConsistencyCheck.StreamStateCheck(stream, expectedState)],
+			cancellationToken
+		);
+
+	/// <summary>
+	/// Appends a single record to a stream atomically with a consistency check.
+	/// </summary>
+	public static ValueTask<AppendRecordsResponse> AppendRecordsAsync(
+		this KurrentDBClient client,
+		AppendRecord record,
+		ConsistencyCheck check,
+		CancellationToken cancellationToken = default
+	) =>
+		client.AppendRecordsAsync([record], [check], cancellationToken);
+
+	/// <summary>
+	/// Appends records to one or more streams atomically with consistency checks.
+	/// </summary>
+	public static ValueTask<AppendRecordsResponse> AppendRecordsAsync(
+		this KurrentDBClient client,
+		IEnumerable<AppendRecord> records,
+		IEnumerable<ConsistencyCheck> checks,
+		CancellationToken cancellationToken = default
+	) =>
+		client.AppendRecordsAsync(records, checks, cancellationToken);
+}

--- a/src/KurrentDB.Client/Streams/KurrentDBClient.AppendRecords.cs
+++ b/src/KurrentDB.Client/Streams/KurrentDBClient.AppendRecords.cs
@@ -1,0 +1,112 @@
+// ReSharper disable SwitchExpressionHandlesSomeKnownEnumValuesWithExceptionInDefault
+
+#pragma warning disable CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
+
+using System.Diagnostics;
+using Google.Rpc;
+using Grpc.Core;
+using KurrentDB.Client.Diagnostics;
+using KurrentDB.Diagnostics;
+using KurrentDB.Diagnostics.Telemetry;
+using KurrentDB.Protocol.V2.Streams;
+using static KurrentDB.Diagnostics.Tracing.TracingConstants;
+using static KurrentDB.Protocol.V2.Streams.StreamsService;
+using ConsistencyCheckProto = KurrentDB.Protocol.V2.Streams.ConsistencyCheck;
+using Contracts = KurrentDB.Protocol.V2.Streams;
+
+namespace KurrentDB.Client;
+
+public partial class KurrentDBClient {
+	/// <summary>
+	/// Appends records to one or more streams atomically with cross-stream consistency checks.
+	/// Records can be interleaved across streams in any order and the global log preserves
+	/// the exact sequence from the request.
+	/// </summary>
+	/// <param name="records">The records to append. Each record specifies its target stream.</param>
+	/// <param name="checks">Optional consistency checks evaluated before commit. If any check fails, the entire transaction is aborted.</param>
+	/// <param name="cancellationToken">An optional cancellation token.</param>
+	/// <returns>
+	/// A task representing the asynchronous operation, with a result of type <see cref="AppendRecordsResponse"/>.
+	/// </returns>
+	/// <exception cref="ArgumentException">Thrown if <paramref name="records"/> is empty.</exception>
+	/// <exception cref="InvalidOperationException">Thrown if the server does not support the AppendRecords operation.</exception>
+	/// <exception cref="AppendRecordSizeExceededException">Thrown when a single record exceeds the maximum allowed size.</exception>
+	/// <exception cref="AppendTransactionMaxSizeExceededException">Thrown when the total transaction size exceeds the maximum allowed size.</exception>
+	/// <exception cref="AppendConsistencyViolationException">Thrown when one or more consistency checks fail, including stream revision conflicts and tombstoned stream writes.</exception>
+	public async ValueTask<AppendRecordsResponse> AppendRecordsAsync(
+		IEnumerable<AppendRecord> records,
+		IEnumerable<ConsistencyCheck>? checks = null,
+		CancellationToken cancellationToken = default
+	) {
+		var recordsList = records as IReadOnlyCollection<AppendRecord> ?? records.ToList();
+
+		if (recordsList.Count == 0)
+			throw new ArgumentException("At least one record is required.", nameof(records));
+
+		var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
+
+		if (!channelInfo.ServerCapabilities.SupportsAppendRecords)
+			throw new InvalidOperationException($"{nameof(AppendRecordsAsync)} requires a server version that supports the AppendRecords operation.");
+
+		var client = new StreamsServiceClient(channelInfo.CallInvoker);
+
+		var tags = new ActivityTagsCollection()
+			.WithGrpcChannelServerTags(channelInfo)
+			.WithClientSettingsServerTags(Settings)
+			.WithOptionalTag(TelemetryTags.Database.User, Settings.DefaultCredentials?.Username);
+
+		return await KurrentDBClientDiagnostics.ActivitySource.TraceClientOperation(Operation, Operations.MultiAppend, tags).ConfigureAwait(false);
+
+		async ValueTask<AppendRecordsResponse> Operation() {
+			try {
+				var appendRecords = new List<Contracts.AppendRecord>();
+				foreach (var record in recordsList) {
+					var mapped = await record.Map().ConfigureAwait(false);
+					appendRecords.Add(mapped);
+				}
+
+				var request = new AppendRecordsRequest {
+					Records = { appendRecords }
+				};
+
+				if (checks != null) {
+					foreach (var check in checks) {
+						request.Checks.Add(check.ToProto());
+					}
+				}
+
+				var response = await client
+					.AppendRecordsAsync(request, KurrentDBCallOptions.CreateNonStreaming(Settings, cancellationToken))
+					.ResponseAsync
+					.ConfigureAwait(false);
+
+				var revisions = response.Revisions
+					.Select(r => new AppendResponse(r.Stream, r.Revision))
+					.ToList();
+
+				return new AppendRecordsResponse(response.Position, revisions);
+			} catch (RpcException ex) {
+				var status = ex.GetRpcStatus()!;
+				throw status.GetDetail<ErrorInfo>() switch {
+					{ Reason: "APPEND_RECORD_SIZE_EXCEEDED" }      => AppendRecordSizeExceededException.FromRpcException(ex),
+					{ Reason: "APPEND_TRANSACTION_SIZE_EXCEEDED" } => AppendTransactionMaxSizeExceededException.FromRpcException(ex),
+					{ Reason: "APPEND_CONSISTENCY_VIOLATION" }     => AppendConsistencyViolationException.FromRpcException(ex),
+					_                                              => ex
+				};
+			}
+		}
+	}
+}
+
+static class ConsistencyCheckExtensions {
+	public static ConsistencyCheckProto ToProto(this ConsistencyCheck check) =>
+		check switch {
+			ConsistencyCheck.StreamStateCheck s => new ConsistencyCheckProto {
+				StreamState = new ConsistencyCheckProto.Types.StreamStateCheck {
+					Stream        = s.Stream,
+					ExpectedState = s.ExpectedState.ToInt64()
+				}
+			},
+			_ => throw new ArgumentException($"Unknown consistency check type: {check.GetType().Name}", nameof(check))
+		};
+}

--- a/src/KurrentDB.Client/Streams/Streams/Model/AppendRecordsModel.cs
+++ b/src/KurrentDB.Client/Streams/Streams/Model/AppendRecordsModel.cs
@@ -1,0 +1,27 @@
+using JetBrains.Annotations;
+
+namespace KurrentDB.Client;
+
+/// <summary>
+/// Represents a record to be appended to a specific stream in an <see cref="KurrentDBClient.AppendRecordsAsync"/> operation.
+/// Each record specifies its own target stream, allowing interleaved writes across multiple streams.
+/// </summary>
+/// <param name="Stream">The name of the target stream for this record.</param>
+/// <param name="Record">The event data to append.</param>
+[PublicAPI]
+public record AppendRecord(string Stream, EventData Record);
+
+/// <summary>
+/// Represents a consistency check to be evaluated before committing an <see cref="KurrentDBClient.AppendRecordsAsync"/> operation.
+/// Checks are decoupled from writes: a check can reference any stream, whether or not the request writes to it.
+/// </summary>
+[PublicAPI]
+public abstract record ConsistencyCheck {
+	/// <summary>
+	/// A check that asserts a stream is at a specific revision or lifecycle state before commit.
+	/// </summary>
+	/// <param name="Stream">The stream name to check.</param>
+	/// <param name="ExpectedState">The expected state of the stream (revision number or state constant).</param>
+	[PublicAPI]
+	public record StreamStateCheck(string Stream, StreamState ExpectedState) : ConsistencyCheck;
+}

--- a/src/KurrentDB.Client/Streams/Streams/Model/StreamsClientMapper.cs
+++ b/src/KurrentDB.Client/Streams/Streams/Model/StreamsClientMapper.cs
@@ -4,18 +4,25 @@ using KurrentDB.Client.Diagnostics;
 using KurrentDB.Protocol.V2.Streams;
 using static KurrentDB.Client.Constants.Metadata;
 using SchemaFormat = KurrentDB.Protocol.V2.Streams.SchemaFormat;
+using Contracts = KurrentDB.Protocol.V2.Streams;
 
 namespace KurrentDB.Client;
 
 static class StreamsClientMapper {
-	public static async IAsyncEnumerable<AppendRecord> Map(this IEnumerable<EventData> source) {
+	public static async IAsyncEnumerable<Contracts.AppendRecord> Map(this IEnumerable<EventData> source) {
 		foreach (var message in source)
 			yield return await message
 				.Map()
 				.ConfigureAwait(false);
 	}
 
-	public static ValueTask<AppendRecord> Map(this EventData source) {
+	public static async ValueTask<Contracts.AppendRecord> Map(this AppendRecord source) {
+		var record = await source.Record.Map().ConfigureAwait(false);
+		record.Stream = source.Stream;
+		return record;
+	}
+
+	public static ValueTask<Contracts.AppendRecord> Map(this EventData source) {
 		Dictionary<string, string> metadata;
 
 		try {
@@ -29,7 +36,7 @@ static class StreamsClientMapper {
 
 		metadata.InjectTracingContext(Activity.Current);
 
-		var record = new AppendRecord {
+		var record = new Contracts.AppendRecord {
 			RecordId = source.EventId.ToString(),
 			Data     = ByteString.CopyFrom(source.Data.Span),
 			Schema = new SchemaInfo {
@@ -41,6 +48,6 @@ static class StreamsClientMapper {
 			Properties = { metadata.MapToMapValue() }
 		};
 
-		return new ValueTask<AppendRecord>(record);
+		return new ValueTask<Contracts.AppendRecord>(record);
 	}
 }

--- a/src/KurrentDB.Client/Streams/Streams/Model/StreamsClientModel.cs
+++ b/src/KurrentDB.Client/Streams/Streams/Model/StreamsClientModel.cs
@@ -33,6 +33,20 @@ public record AppendStreamRequest(string Stream, StreamState ExpectedState, IEnu
 public record AppendResponse(string Stream, long StreamRevision);
 
 [PublicAPI]
+public readonly struct AppendRecordsResponse(long position, IEnumerable<AppendResponse>? responses = null) {
+	/// <summary>
+	/// The position of the last appended record in the transaction.
+	/// </summary>
+	public readonly long Position = position;
+
+	/// <summary>
+	/// The collection of responses for each stream appended in the transaction.
+	/// </summary>
+	public readonly IEnumerable<AppendResponse>? Responses = responses;
+}
+
+// TODO: MultiStreamAppendResponse will be removed in a future version. Use AppendRecordsResponse instead.
+[PublicAPI]
 public readonly struct MultiStreamAppendResponse(long position, IEnumerable<AppendResponse>? responses = null) {
 	/// <summary>
 	/// The position of the last appended record in the transaction.

--- a/test/KurrentDB.Client.Tests/Diagnostics/AppendRecordsTracingTests.cs
+++ b/test/KurrentDB.Client.Tests/Diagnostics/AppendRecordsTracingTests.cs
@@ -1,0 +1,79 @@
+// ReSharper disable AccessToDisposedClosure
+
+using System.Diagnostics;
+using KurrentDB.Client.Diagnostics;
+using KurrentDB.Client.Tests.Fixtures;
+using KurrentDB.Diagnostics.Telemetry;
+using KurrentDB.Diagnostics;
+using KurrentDB.Diagnostics.Tracing;
+using static KurrentDB.Diagnostics.Tracing.TracingConstants;
+
+namespace KurrentDB.Client.Tests.Diagnostics;
+
+[Trait("Category", "Target:Diagnostics")]
+[Trait("Category", "Operation:AppendRecords")]
+public class AppendRecordsTracingTests(ITestOutputHelper output, DiagnosticsFixture fixture) : KurrentDBPermanentTests<DiagnosticsFixture>(output, fixture) {
+	[MinimumVersion.Fact(26, 1)]
+	public async Task append_records_creates_trace_activity() {
+		// Arrange
+		var traceId = Fixture.CreateTraceId();
+
+		var stream = Fixture.GetStreamName();
+		var records = Fixture.CreateTestEvents(3).Select(e => new AppendRecord(stream, e));
+
+		// Act
+		var result = await Fixture.Streams.AppendRecordsAsync(records);
+
+		// Assert
+		result.Position.ShouldBePositive();
+
+		var appendActivities = Fixture.GetActivities(TracingConstants.Operations.MultiAppend, traceId);
+
+		appendActivities.ShouldNotBeEmpty();
+		appendActivities.Count.ShouldBe(1);
+
+		var activity = appendActivities.First();
+
+		var expectedTags = new Dictionary<string, string?> {
+			{ TelemetryTags.Database.System, KurrentDBClientDiagnostics.InstrumentationName },
+			{ TelemetryTags.Database.Operation, TracingConstants.Operations.MultiAppend },
+			{ TelemetryTags.Database.User, TestCredentials.Root.Username },
+			{ TelemetryTags.Otel.StatusCode, ActivityStatusCodeHelper.OkStatusCodeTagValue }
+		};
+
+		foreach (var tag in expectedTags)
+			activity.Tags.ShouldContain(tag);
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task append_records_with_exceptions_traces_error() {
+		// Arrange
+		var traceId = Fixture.CreateTraceId();
+
+		var stream = Fixture.GetStreamName();
+		var records = Fixture.CreateTestEvents(1).Select(e => new AppendRecord(stream, e));
+		var checks = new ConsistencyCheck[] {
+			new ConsistencyCheck.StreamStateCheck(stream, StreamState.StreamExists)
+		};
+
+		// Act
+		var appendTask = async () => await Fixture.Streams.AppendRecordsAsync(records, checks);
+		var rex = await appendTask.ShouldThrowAsync<AppendConsistencyViolationException>();
+
+		// Assert
+		var appendActivities = Fixture.GetActivities(TracingConstants.Operations.MultiAppend, traceId);
+
+		appendActivities.ShouldNotBeEmpty();
+		appendActivities.Count.ShouldBe(1);
+
+		var activity = appendActivities.First();
+		activity.Status.ShouldBe(ActivityStatusCode.Error);
+		activity.Events.ShouldHaveSingleItem();
+
+		var activityEvent = activity.Events.First();
+		activityEvent.Name.ShouldBe(TelemetryTags.Exception.EventName);
+		activityEvent.Tags.Any(tag => tag.Key == TelemetryTags.Exception.Message).ShouldBeTrue();
+		activityEvent.Tags.Any(tag => tag.Key == TelemetryTags.Exception.Stacktrace).ShouldBeTrue();
+		activityEvent.Tags.Any(tag => tag.Key == TelemetryTags.Exception.Type && (string?)tag.Value == rex.GetType().FullName).ShouldBeTrue();
+	}
+}

--- a/test/KurrentDB.Client.Tests/Streams/AppendRecords/AppendRecordsTests.cs
+++ b/test/KurrentDB.Client.Tests/Streams/AppendRecords/AppendRecordsTests.cs
@@ -1,0 +1,171 @@
+namespace KurrentDB.Client.Tests.Streams.AppendRecords;
+
+[Trait("Category", "Target:Streams")]
+[Trait("Category", "Operation:AppendRecords")]
+public class AppendRecordsTests(ITestOutputHelper output, KurrentDBPermanentFixture fixture) : KurrentDBPermanentTests<KurrentDBPermanentFixture>(output, fixture) {
+	[MinimumVersion.Fact(26, 1)]
+	public async Task append_records_to_single_stream() {
+		// Arrange
+		var stream = Fixture.GetStreamName();
+
+		var events = Fixture.CreateTestEvents(3);
+		var records = events.Select(e => new AppendRecord(stream, e));
+
+		// Act
+		var result = await Fixture.Streams.AppendRecordsAsync(records);
+
+		// Assert
+		result.Position.ShouldBePositive();
+		result.Responses.ShouldNotBeEmpty();
+		result.Responses!.Count().ShouldBe(1);
+		result.Responses!.First().Stream.ShouldBe(stream);
+		result.Responses!.First().StreamRevision.ShouldBePositive();
+
+		var readEvents = await Fixture.Streams
+			.ReadStreamAsync(Direction.Forwards, stream, StreamPosition.Start, 10)
+			.ToArrayAsync();
+
+		readEvents.Length.ShouldBe(3);
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task append_records_to_multiple_streams() {
+		// Arrange
+		var stream1 = Fixture.GetStreamName();
+		var stream2 = Fixture.GetStreamName();
+
+		var expectedMetadata = new Dictionary<string, string> {
+			["Name"] = Fixture.Faker.Person.FullName
+		};
+
+		var records = new[] {
+			new AppendRecord(stream1, Fixture.CreateTestEvent(metadata: expectedMetadata.Encode())),
+			new AppendRecord(stream1, Fixture.CreateTestEvent(metadata: expectedMetadata.Encode())),
+			new AppendRecord(stream1, Fixture.CreateTestEvent(metadata: expectedMetadata.Encode())),
+			new AppendRecord(stream2, Fixture.CreateTestEvent(metadata: expectedMetadata.Encode())),
+			new AppendRecord(stream2, Fixture.CreateTestEvent(metadata: expectedMetadata.Encode())),
+		};
+
+		// Act
+		var result = await Fixture.Streams.AppendRecordsAsync(records);
+
+		// Assert
+		result.Position.ShouldBePositive();
+		result.Responses.ShouldNotBeEmpty();
+		result.Responses!.Count().ShouldBe(2);
+
+		var stream1Events = await Fixture.Streams
+			.ReadStreamAsync(Direction.Forwards, stream1, StreamPosition.Start, 10)
+			.ToArrayAsync();
+
+		var stream2Events = await Fixture.Streams
+			.ReadStreamAsync(Direction.Forwards, stream2, StreamPosition.Start, 10)
+			.ToArrayAsync();
+
+		stream1Events.Length.ShouldBe(3);
+		stream2Events.Length.ShouldBe(2);
+
+		var metadata = stream1Events.First().Decode();
+		metadata.ShouldNotBeNull();
+		metadata[Constants.Metadata.SchemaName].ShouldBe("test-event-type");
+		metadata[Constants.Metadata.SchemaFormat].ShouldBe(nameof(SchemaDataFormat.Json));
+		metadata["Name"].ShouldBe(expectedMetadata["Name"]);
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task interleaved_tracks_revisions() {
+		// Arrange
+		var stream1 = Fixture.GetStreamName();
+		var stream2 = Fixture.GetStreamName();
+
+		var records = new[] {
+			new AppendRecord(stream1, Fixture.CreateTestEvent()),
+			new AppendRecord(stream2, Fixture.CreateTestEvent()),
+			new AppendRecord(stream1, Fixture.CreateTestEvent()),
+			new AppendRecord(stream2, Fixture.CreateTestEvent()),
+			new AppendRecord(stream1, Fixture.CreateTestEvent()),
+		};
+
+		// Act
+		var result = await Fixture.Streams.AppendRecordsAsync(records);
+
+		// Assert
+		result.Position.ShouldBePositive();
+		result.Responses!.Count().ShouldBe(2);
+
+		var revStream1 = result.Responses!.First(r => r.Stream == stream1);
+		var revStream2 = result.Responses!.First(r => r.Stream == stream2);
+
+		revStream1.StreamRevision.ShouldBe(2);
+		revStream2.StreamRevision.ShouldBe(1);
+
+		var stream1Events = await Fixture.Streams
+			.ReadStreamAsync(Direction.Forwards, stream1, StreamPosition.Start, 10)
+			.ToArrayAsync();
+
+		var stream2Events = await Fixture.Streams
+			.ReadStreamAsync(Direction.Forwards, stream2, StreamPosition.Start, 10)
+			.ToArrayAsync();
+
+		stream1Events.Length.ShouldBe(3);
+		stream2Events.Length.ShouldBe(2);
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task fails_with_invalid_metadata_format() {
+		// Arrange
+		var stream = Fixture.GetStreamName();
+
+		var invalidMetadata = "invalid"u8.ToArray();
+		var records = Fixture.CreateTestEvents(1, metadata: invalidMetadata).Select(e => new AppendRecord(stream, e));
+
+		// Act & Assert
+		var exception = await Fixture.Streams
+			.AppendRecordsAsync(records).AsTask()
+			.ShouldThrowAsync<ArgumentException>();
+
+		exception.Message.ShouldContain("Failed to decode event metadata");
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task extension_with_stream_and_events() {
+		// Arrange
+		var stream = Fixture.GetStreamName();
+		var events = Fixture.CreateTestEvents(3);
+
+		// Act
+		var result = await Fixture.Streams.AppendRecordsAsync(stream, events);
+
+		// Assert
+		result.Position.ShouldBePositive();
+		result.Responses.ShouldNotBeEmpty();
+		result.Responses!.First().Stream.ShouldBe(stream);
+
+		var readEvents = await Fixture.Streams
+			.ReadStreamAsync(Direction.Forwards, stream, StreamPosition.Start, 10)
+			.ToArrayAsync();
+
+		readEvents.Length.ShouldBe(3);
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task extension_with_expected_state() {
+		// Arrange
+		var stream = Fixture.GetStreamName();
+
+		// First write
+		await Fixture.Streams.AppendRecordsAsync(stream, StreamState.NoStream, Fixture.CreateTestEvents(2));
+
+		// Second write with expected state
+		var result = await Fixture.Streams.AppendRecordsAsync(stream, StreamState.StreamRevision(1), Fixture.CreateTestEvents(1));
+
+		// Assert
+		result.Position.ShouldBePositive();
+
+		var readEvents = await Fixture.Streams
+			.ReadStreamAsync(Direction.Forwards, stream, StreamPosition.Start, 10)
+			.ToArrayAsync();
+
+		readEvents.Length.ShouldBe(3);
+	}
+}

--- a/test/KurrentDB.Client.Tests/Streams/AppendRecords/CheckOnly/WhenExpectingExists.cs
+++ b/test/KurrentDB.Client.Tests/Streams/AppendRecords/CheckOnly/WhenExpectingExists.cs
@@ -1,0 +1,88 @@
+using static KurrentDB.Client.ConsistencyCheck;
+
+namespace KurrentDB.Client.Tests.Streams.AppendRecords.CheckOnly;
+
+[Trait("Category", "Target:Streams")]
+[Trait("Category", "Operation:AppendRecords")]
+public class WhenExpectingExists(ITestOutputHelper output, KurrentDBPermanentFixture fixture) : KurrentDBPermanentTests<KurrentDBPermanentFixture>(output, fixture) {
+	[MinimumVersion.Fact(26, 1)]
+	public async Task succeeds_when_stream_has_revision() {
+		var checkStream = Fixture.GetStreamName();
+		var writeStream = Fixture.GetStreamName();
+		await Fixture.Streams.AppendRecordsAsync(checkStream, Fixture.CreateTestEvents(3));
+
+		var result = await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(writeStream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(checkStream, StreamState.StreamExists)
+			]
+		);
+
+		result.Responses!.Count().ShouldBe(1);
+		result.Responses!.First().Stream.ShouldBe(writeStream);
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task fails_when_stream_not_found() {
+		var checkStream = Fixture.GetStreamName();
+		var writeStream = Fixture.GetStreamName();
+
+		var act = async () => await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(writeStream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(checkStream, StreamState.StreamExists)
+			]
+		);
+
+		var rex = await act.ShouldThrowAsync<AppendConsistencyViolationException>();
+		rex.Violations.Count.ShouldBe(1);
+		rex.Violations[0].Stream.ShouldBe(checkStream);
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task fails_when_stream_is_deleted() {
+		var checkStream = Fixture.GetStreamName();
+		var writeStream = Fixture.GetStreamName();
+		await Fixture.Streams.AppendToStreamAsync(checkStream, StreamState.NoStream, Fixture.CreateTestEvents());
+		await Fixture.Streams.DeleteAsync(checkStream, StreamState.StreamExists);
+
+		var act = async () => await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(writeStream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(checkStream, StreamState.StreamExists)
+			]
+		);
+
+		var rex = await act.ShouldThrowAsync<AppendConsistencyViolationException>();
+		rex.Violations.Count.ShouldBe(1);
+		rex.Violations[0].Stream.ShouldBe(checkStream);
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task fails_when_stream_is_tombstoned() {
+		var checkStream = Fixture.GetStreamName();
+		var writeStream = Fixture.GetStreamName();
+
+		await Fixture.Streams.AppendToStreamAsync(checkStream, StreamState.NoStream, Fixture.CreateTestEvents());
+		await Fixture.Streams.TombstoneAsync(checkStream, StreamState.StreamExists);
+
+		var act = async () => await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(writeStream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(checkStream, StreamState.StreamExists)
+			]
+		);
+
+		var rex = await act.ShouldThrowAsync<AppendConsistencyViolationException>();
+		rex.Violations.Count.ShouldBe(1);
+		rex.Violations[0].Stream.ShouldBe(checkStream);
+	}
+}

--- a/test/KurrentDB.Client.Tests/Streams/AppendRecords/CheckOnly/WhenExpectingNoStream.cs
+++ b/test/KurrentDB.Client.Tests/Streams/AppendRecords/CheckOnly/WhenExpectingNoStream.cs
@@ -1,0 +1,85 @@
+using static KurrentDB.Client.ConsistencyCheck;
+
+namespace KurrentDB.Client.Tests.Streams.AppendRecords.CheckOnly;
+
+[Trait("Category", "Target:Streams")]
+[Trait("Category", "Operation:AppendRecords")]
+public class WhenExpectingNoStream(ITestOutputHelper output, KurrentDBPermanentFixture fixture) : KurrentDBPermanentTests<KurrentDBPermanentFixture>(output, fixture) {
+	[MinimumVersion.Fact(26, 1)]
+	public async Task succeeds_when_stream_not_found() {
+		var checkStream = Fixture.GetStreamName();
+		var writeStream = Fixture.GetStreamName();
+
+		var result = await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(writeStream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(checkStream, StreamState.NoStream)
+			]
+		);
+
+		result.Responses!.Count().ShouldBe(1);
+		result.Responses!.First().Stream.ShouldBe(writeStream);
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task succeeds_when_stream_is_deleted() {
+		var checkStream = Fixture.GetStreamName();
+		var writeStream = Fixture.GetStreamName();
+		await Fixture.Streams.AppendToStreamAsync(checkStream, StreamState.NoStream, Fixture.CreateTestEvents());
+		await Fixture.Streams.DeleteAsync(checkStream, StreamState.StreamExists);
+
+		var result = await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(writeStream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(checkStream, StreamState.NoStream)
+			]
+		);
+
+		result.Responses!.Count().ShouldBe(1);
+		result.Responses!.First().Stream.ShouldBe(writeStream);
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task succeeds_when_stream_is_tombstoned() {
+		var checkStream = Fixture.GetStreamName();
+		var writeStream = Fixture.GetStreamName();
+		await Fixture.Streams.AppendToStreamAsync(checkStream, StreamState.NoStream, Fixture.CreateTestEvents());
+		await Fixture.Streams.TombstoneAsync(checkStream, StreamState.StreamExists);
+
+		var result = await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(writeStream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(checkStream, StreamState.NoStream)
+			]
+		);
+
+		result.Responses!.Count().ShouldBe(1);
+		result.Responses!.First().Stream.ShouldBe(writeStream);
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task fails_when_stream_has_revision() {
+		var checkStream = Fixture.GetStreamName();
+		var writeStream = Fixture.GetStreamName();
+		await Fixture.Streams.AppendRecordsAsync(checkStream, Fixture.CreateTestEvents(3));
+
+		var act = async () => await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(writeStream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(checkStream, StreamState.NoStream)
+			]
+		);
+
+		var rex = await act.ShouldThrowAsync<AppendConsistencyViolationException>();
+		rex.Violations.Count.ShouldBe(1);
+		rex.Violations[0].Stream.ShouldBe(checkStream);
+	}
+}

--- a/test/KurrentDB.Client.Tests/Streams/AppendRecords/CheckOnly/WhenExpectingRevision.cs
+++ b/test/KurrentDB.Client.Tests/Streams/AppendRecords/CheckOnly/WhenExpectingRevision.cs
@@ -1,0 +1,110 @@
+using static KurrentDB.Client.ConsistencyCheck;
+
+namespace KurrentDB.Client.Tests.Streams.AppendRecords.CheckOnly;
+
+[Trait("Category", "Target:Streams")]
+[Trait("Category", "Operation:AppendRecords")]
+public class WhenExpectingRevision(ITestOutputHelper output, KurrentDBPermanentFixture fixture) : KurrentDBPermanentTests<KurrentDBPermanentFixture>(output, fixture) {
+	const ulong ExpectedRevision = 10;
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task succeeds_when_stream_has_revision() {
+		var checkStream = Fixture.GetStreamName();
+		var writeStream = Fixture.GetStreamName();
+		await Fixture.Streams.AppendRecordsAsync(checkStream, Fixture.CreateTestEvents(11));
+
+		var result = await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(writeStream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(checkStream, StreamState.StreamRevision(ExpectedRevision))
+			]
+		);
+
+		result.Responses!.Count().ShouldBe(1);
+		result.Responses!.First().Stream.ShouldBe(writeStream);
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task fails_when_stream_not_found() {
+		var checkStream = Fixture.GetStreamName();
+		var writeStream = Fixture.GetStreamName();
+
+		var act = async () => await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(writeStream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(checkStream, StreamState.StreamRevision(ExpectedRevision))
+			]
+		);
+
+		var rex = await act.ShouldThrowAsync<AppendConsistencyViolationException>();
+		rex.Violations.Count.ShouldBe(1);
+		rex.Violations[0].Stream.ShouldBe(checkStream);
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task fails_when_stream_has_wrong_revision() {
+		var checkStream = Fixture.GetStreamName();
+		var writeStream = Fixture.GetStreamName();
+		await Fixture.Streams.AppendRecordsAsync(checkStream, Fixture.CreateTestEvents(5));
+
+		var act = async () => await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(writeStream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(checkStream, StreamState.StreamRevision(ExpectedRevision))
+			]
+		);
+
+		var rex = await act.ShouldThrowAsync<AppendConsistencyViolationException>();
+		rex.Violations.Count.ShouldBe(1);
+		rex.Violations[0].Stream.ShouldBe(checkStream);
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task fails_when_stream_is_deleted() {
+		var checkStream = Fixture.GetStreamName();
+		var writeStream = Fixture.GetStreamName();
+		await Fixture.Streams.AppendToStreamAsync(checkStream, StreamState.NoStream, Fixture.CreateTestEvents(3));
+		await Fixture.Streams.DeleteAsync(checkStream, StreamState.StreamExists);
+
+		var act = async () => await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(writeStream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(checkStream, StreamState.StreamRevision(ExpectedRevision))
+			]
+		);
+
+		var rex = await act.ShouldThrowAsync<AppendConsistencyViolationException>();
+		rex.Violations.Count.ShouldBe(1);
+		rex.Violations[0].Stream.ShouldBe(checkStream);
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task fails_when_stream_is_tombstoned() {
+		var checkStream = Fixture.GetStreamName();
+		var writeStream = Fixture.GetStreamName();
+
+		await Fixture.Streams.AppendToStreamAsync(checkStream, StreamState.NoStream, Fixture.CreateTestEvents());
+		await Fixture.Streams.TombstoneAsync(checkStream, StreamState.StreamExists);
+
+		var act = async () => await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(writeStream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(checkStream, StreamState.StreamRevision(ExpectedRevision))
+			]
+		);
+
+		var rex = await act.ShouldThrowAsync<AppendConsistencyViolationException>();
+		rex.Violations.Count.ShouldBe(1);
+		rex.Violations[0].Stream.ShouldBe(checkStream);
+	}
+}

--- a/test/KurrentDB.Client.Tests/Streams/AppendRecords/CheckOnly/WhenMultipleChecks.cs
+++ b/test/KurrentDB.Client.Tests/Streams/AppendRecords/CheckOnly/WhenMultipleChecks.cs
@@ -1,0 +1,226 @@
+using static KurrentDB.Client.ConsistencyCheck;
+
+namespace KurrentDB.Client.Tests.Streams.AppendRecords.CheckOnly;
+
+[Trait("Category", "Target:Streams")]
+[Trait("Category", "Operation:AppendRecords")]
+public class WhenMultipleChecks(ITestOutputHelper output, KurrentDBPermanentFixture fixture) : KurrentDBPermanentTests<KurrentDBPermanentFixture>(output, fixture) {
+	[MinimumVersion.Fact(26, 1)]
+	public async Task succeeds_when_all_checks_pass() {
+		var writeStream = Fixture.GetStreamName();
+		var checkStreamA = Fixture.GetStreamName();
+		var checkStreamB = Fixture.GetStreamName();
+
+		await Fixture.Streams.AppendRecordsAsync(checkStreamA, Fixture.CreateTestEvents(3));
+		await Fixture.Streams.AppendRecordsAsync(checkStreamB, Fixture.CreateTestEvents(5));
+
+		var result = await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(writeStream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(checkStreamA, StreamState.StreamRevision(2)),
+				new StreamStateCheck(checkStreamB, StreamState.StreamRevision(4))
+			]
+		);
+
+		result.Responses!.Count().ShouldBe(1);
+		result.Responses!.First().Stream.ShouldBe(writeStream);
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task succeeds_when_all_mixed_check_types_pass() {
+		var writeStream = Fixture.GetStreamName();
+		var revisionStream = Fixture.GetStreamName();
+		var existsStream = Fixture.GetStreamName();
+		var noStream = Fixture.GetStreamName();
+
+		await Fixture.Streams.AppendRecordsAsync(revisionStream, Fixture.CreateTestEvents(3));
+		await Fixture.Streams.AppendRecordsAsync(existsStream, Fixture.CreateTestEvents(1));
+
+		var result = await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(writeStream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(revisionStream, StreamState.StreamRevision(2)),
+				new StreamStateCheck(existsStream, StreamState.StreamExists),
+				new StreamStateCheck(noStream, StreamState.NoStream)
+			]
+		);
+
+		result.Responses!.Count().ShouldBe(1);
+		result.Responses!.First().Stream.ShouldBe(writeStream);
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task fails_when_one_of_multiple_checks_fails() {
+		var writeStream = Fixture.GetStreamName();
+		var checkStreamA = Fixture.GetStreamName();
+		var checkStreamB = Fixture.GetStreamName();
+
+		await Fixture.Streams.AppendRecordsAsync(checkStreamA, Fixture.CreateTestEvents(3));
+		// checkStreamB not seeded — will fail the revision check
+
+		var act = async () => await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(writeStream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(checkStreamA, StreamState.StreamRevision(2)),
+				new StreamStateCheck(checkStreamB, StreamState.StreamRevision(5))
+			]
+		);
+
+		var rex = await act.ShouldThrowAsync<AppendConsistencyViolationException>();
+		rex.Violations.Count.ShouldBe(1);
+		rex.Violations[0].CheckIndex.ShouldBe(1);
+		rex.Violations[0].Stream.ShouldBe(checkStreamB);
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task fails_when_all_checks_fail() {
+		var writeStream = Fixture.GetStreamName();
+		var checkStreamA = Fixture.GetStreamName();
+		var checkStreamB = Fixture.GetStreamName();
+
+		// Neither stream is seeded — both will fail
+
+		var act = async () => await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(writeStream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(checkStreamA, StreamState.StreamRevision(3)),
+				new StreamStateCheck(checkStreamB, StreamState.StreamExists)
+			]
+		);
+
+		var rex = await act.ShouldThrowAsync<AppendConsistencyViolationException>();
+		rex.Violations.Count.ShouldBe(2);
+
+		var violationA = rex.Violations.First(v => v.Stream == checkStreamA);
+		var violationB = rex.Violations.First(v => v.Stream == checkStreamB);
+
+		violationA.CheckIndex.ShouldBe(0);
+		violationB.CheckIndex.ShouldBe(1);
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task fails_when_first_check_fails_and_second_passes() {
+		var writeStream = Fixture.GetStreamName();
+		var checkStreamA = Fixture.GetStreamName();
+		var checkStreamB = Fixture.GetStreamName();
+
+		// checkStreamA not seeded — will fail the revision check
+		await Fixture.Streams.AppendRecordsAsync(checkStreamB, Fixture.CreateTestEvents(6));
+
+		var act = async () => await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(writeStream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(checkStreamA, StreamState.StreamRevision(3)),
+				new StreamStateCheck(checkStreamB, StreamState.StreamRevision(5))
+			]
+		);
+
+		var rex = await act.ShouldThrowAsync<AppendConsistencyViolationException>();
+		rex.Violations.Count.ShouldBe(1);
+		rex.Violations[0].CheckIndex.ShouldBe(0);
+		rex.Violations[0].Stream.ShouldBe(checkStreamA);
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task fails_when_two_of_three_checks_fail() {
+		var writeStream = Fixture.GetStreamName();
+		var checkStreamA = Fixture.GetStreamName();
+		var checkStreamB = Fixture.GetStreamName();
+		var checkStreamC = Fixture.GetStreamName();
+
+		await Fixture.Streams.AppendRecordsAsync(checkStreamA, Fixture.CreateTestEvents(3));
+		// checkStreamB not seeded — will fail
+		await Fixture.Streams.AppendRecordsAsync(checkStreamC, Fixture.CreateTestEvents(2));
+
+		var act = async () => await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(writeStream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(checkStreamA, StreamState.StreamRevision(2)),
+				new StreamStateCheck(checkStreamB, StreamState.StreamExists),
+				new StreamStateCheck(checkStreamC, StreamState.StreamRevision(10))
+			]
+		);
+
+		var rex = await act.ShouldThrowAsync<AppendConsistencyViolationException>();
+		rex.Violations.Count.ShouldBe(2);
+
+		var violationB = rex.Violations.First(v => v.Stream == checkStreamB);
+		var violationC = rex.Violations.First(v => v.Stream == checkStreamC);
+
+		violationB.CheckIndex.ShouldBe(1);
+		violationC.CheckIndex.ShouldBe(2);
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task fails_with_mixed_violation_states() {
+		var writeStream = Fixture.GetStreamName();
+		var deletedStream = Fixture.GetStreamName();
+		var tombstonedStream = Fixture.GetStreamName();
+		var missingStream = Fixture.GetStreamName();
+
+		await Fixture.Streams.AppendToStreamAsync(deletedStream, StreamState.NoStream, Fixture.CreateTestEvents(3));
+		await Fixture.Streams.DeleteAsync(deletedStream, StreamState.StreamExists);
+
+		await Fixture.Streams.AppendToStreamAsync(tombstonedStream, StreamState.NoStream, Fixture.CreateTestEvents());
+		await Fixture.Streams.TombstoneAsync(tombstonedStream, StreamState.StreamExists);
+		// missingStream not seeded
+
+		var act = async () => await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(writeStream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(deletedStream, StreamState.StreamExists),
+				new StreamStateCheck(tombstonedStream, StreamState.StreamExists),
+				new StreamStateCheck(missingStream, StreamState.StreamRevision(10))
+			]
+		);
+
+		var rex = await act.ShouldThrowAsync<AppendConsistencyViolationException>();
+		rex.Violations.Count.ShouldBe(3);
+
+		var deletedViolation = rex.Violations.First(v => v.Stream == deletedStream);
+		var tombstonedViolation = rex.Violations.First(v => v.Stream == tombstonedStream);
+		var missingViolation = rex.Violations.First(v => v.Stream == missingStream);
+
+		deletedViolation.CheckIndex.ShouldBe(0);
+		tombstonedViolation.CheckIndex.ShouldBe(1);
+		missingViolation.CheckIndex.ShouldBe(2);
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task fails_when_check_on_write_target_and_separate_check_fails() {
+		var checkStream = Fixture.GetStreamName();
+		var writeStream = Fixture.GetStreamName();
+
+		// checkStream not seeded — will fail
+		await Fixture.Streams.AppendRecordsAsync(writeStream, Fixture.CreateTestEvents(4));
+
+		var act = async () => await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(writeStream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(checkStream, StreamState.StreamRevision(5)),
+				new StreamStateCheck(writeStream, StreamState.StreamRevision(3))
+			]
+		);
+
+		var rex = await act.ShouldThrowAsync<AppendConsistencyViolationException>();
+		rex.Violations.Count.ShouldBe(1);
+		rex.Violations[0].CheckIndex.ShouldBe(0);
+		rex.Violations[0].Stream.ShouldBe(checkStream);
+	}
+}

--- a/test/KurrentDB.Client.Tests/Streams/AppendRecords/WriteOnly/WhenExpectingAny.cs
+++ b/test/KurrentDB.Client.Tests/Streams/AppendRecords/WriteOnly/WhenExpectingAny.cs
@@ -1,0 +1,65 @@
+namespace KurrentDB.Client.Tests.Streams.AppendRecords.WriteOnly;
+
+[Trait("Category", "Target:Streams")]
+[Trait("Category", "Operation:AppendRecords")]
+public class WhenExpectingAny(ITestOutputHelper output, KurrentDBPermanentFixture fixture) : KurrentDBPermanentTests<KurrentDBPermanentFixture>(output, fixture) {
+	[MinimumVersion.Fact(26, 1)]
+	public async Task succeeds_when_stream_has_revision() {
+		var stream = Fixture.GetStreamName();
+		await Fixture.Streams.AppendRecordsAsync(stream, Fixture.CreateTestEvents(3));
+
+		var result = await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(stream, Fixture.CreateTestEvent())
+			]
+		);
+
+		result.Responses!.Count().ShouldBe(1);
+		result.Responses!.First().Stream.ShouldBe(stream);
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task succeeds_when_stream_not_found() {
+		var stream = Fixture.GetStreamName();
+
+		var result = await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(stream, Fixture.CreateTestEvent())
+			]
+		);
+
+		result.Responses!.Count().ShouldBe(1);
+		result.Responses!.First().Stream.ShouldBe(stream);
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task succeeds_when_stream_is_deleted() {
+		var stream = Fixture.GetStreamName();
+		await Fixture.Streams.AppendToStreamAsync(stream, StreamState.NoStream, Fixture.CreateTestEvents());
+		await Fixture.Streams.DeleteAsync(stream, StreamState.StreamExists);
+
+		var result = await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(stream, Fixture.CreateTestEvent())
+			]
+		);
+
+		result.Responses!.Count().ShouldBe(1);
+		result.Responses!.First().Stream.ShouldBe(stream);
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task fails_when_stream_is_tombstoned() {
+		var stream = Fixture.GetStreamName();
+		await Fixture.Streams.AppendToStreamAsync(stream, StreamState.NoStream, Fixture.CreateTestEvents());
+		await Fixture.Streams.TombstoneAsync(stream, StreamState.StreamExists);
+
+		var act = async () => await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(stream, Fixture.CreateTestEvent())
+			]
+		);
+
+		await act.ShouldThrowAsync<AppendConsistencyViolationException>();
+	}
+}

--- a/test/KurrentDB.Client.Tests/Streams/AppendRecords/WriteOnly/WhenExpectingExists.cs
+++ b/test/KurrentDB.Client.Tests/Streams/AppendRecords/WriteOnly/WhenExpectingExists.cs
@@ -1,0 +1,80 @@
+using static KurrentDB.Client.ConsistencyCheck;
+
+namespace KurrentDB.Client.Tests.Streams.AppendRecords.WriteOnly;
+
+[Trait("Category", "Target:Streams")]
+[Trait("Category", "Operation:AppendRecords")]
+public class WhenExpectingExists(ITestOutputHelper output, KurrentDBPermanentFixture fixture) : KurrentDBPermanentTests<KurrentDBPermanentFixture>(output, fixture) {
+	[MinimumVersion.Fact(26, 1)]
+	public async Task succeeds_when_stream_has_revision() {
+		var stream = Fixture.GetStreamName();
+		await Fixture.Streams.AppendRecordsAsync(stream, Fixture.CreateTestEvents(3));
+
+		var result = await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(stream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(stream, StreamState.StreamExists)
+			]
+		);
+
+		result.Responses!.Count().ShouldBe(1);
+		result.Responses!.First().Stream.ShouldBe(stream);
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task fails_when_stream_not_found() {
+		var stream = Fixture.GetStreamName();
+
+		var act = async () => await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(stream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(stream, StreamState.StreamExists)
+			]
+		);
+
+		var rex = await act.ShouldThrowAsync<AppendConsistencyViolationException>();
+		rex.Violations.Count.ShouldBe(1);
+		rex.Violations[0].Stream.ShouldBe(stream);
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task fails_when_stream_is_deleted() {
+		var stream = Fixture.GetStreamName();
+		await Fixture.Streams.AppendToStreamAsync(stream, StreamState.NoStream, Fixture.CreateTestEvents());
+		await Fixture.Streams.DeleteAsync(stream, StreamState.StreamExists);
+
+		var act = async () => await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(stream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(stream, StreamState.StreamExists)
+			]
+		);
+
+		await act.ShouldThrowAsync<AppendConsistencyViolationException>();
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task fails_when_stream_is_tombstoned() {
+		var stream = Fixture.GetStreamName();
+
+		await Fixture.Streams.AppendToStreamAsync(stream, StreamState.NoStream, Fixture.CreateTestEvents());
+		await Fixture.Streams.TombstoneAsync(stream, StreamState.StreamExists);
+
+		var act = async () => await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(stream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(stream, StreamState.StreamExists)
+			]
+		);
+
+		await act.ShouldThrowAsync<AppendConsistencyViolationException>();
+	}
+}

--- a/test/KurrentDB.Client.Tests/Streams/AppendRecords/WriteOnly/WhenExpectingNoStream.cs
+++ b/test/KurrentDB.Client.Tests/Streams/AppendRecords/WriteOnly/WhenExpectingNoStream.cs
@@ -1,0 +1,81 @@
+using static KurrentDB.Client.ConsistencyCheck;
+
+namespace KurrentDB.Client.Tests.Streams.AppendRecords.WriteOnly;
+
+[Trait("Category", "Target:Streams")]
+[Trait("Category", "Operation:AppendRecords")]
+public class WhenExpectingNoStream(ITestOutputHelper output, KurrentDBPermanentFixture fixture) : KurrentDBPermanentTests<KurrentDBPermanentFixture>(output, fixture) {
+	[MinimumVersion.Fact(26, 1)]
+	public async Task succeeds_when_stream_not_found() {
+		var stream = Fixture.GetStreamName();
+
+		var result = await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(stream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(stream, StreamState.NoStream)
+			]
+		);
+
+		result.Responses!.Count().ShouldBe(1);
+		result.Responses!.First().Stream.ShouldBe(stream);
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task succeeds_when_stream_is_deleted() {
+		var stream = Fixture.GetStreamName();
+		await Fixture.Streams.AppendToStreamAsync(stream, StreamState.NoStream, Fixture.CreateTestEvents());
+		await Fixture.Streams.DeleteAsync(stream, StreamState.StreamExists);
+
+		var result = await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(stream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(stream, StreamState.NoStream)
+			]
+		);
+
+		result.Responses!.Count().ShouldBe(1);
+		result.Responses!.First().Stream.ShouldBe(stream);
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task fails_when_stream_has_revision() {
+		var stream = Fixture.GetStreamName();
+		await Fixture.Streams.AppendRecordsAsync(stream, Fixture.CreateTestEvents(3));
+
+		var act = async () => await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(stream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(stream, StreamState.NoStream)
+			]
+		);
+
+		var rex = await act.ShouldThrowAsync<AppendConsistencyViolationException>();
+		rex.Violations.Count.ShouldBe(1);
+		rex.Violations[0].Stream.ShouldBe(stream);
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task fails_when_stream_is_tombstoned() {
+		var stream = Fixture.GetStreamName();
+
+		await Fixture.Streams.AppendToStreamAsync(stream, StreamState.NoStream, Fixture.CreateTestEvents());
+		await Fixture.Streams.TombstoneAsync(stream, StreamState.StreamExists);
+
+		var act = async () => await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(stream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(stream, StreamState.NoStream)
+			]
+		);
+
+		await act.ShouldThrowAsync<AppendConsistencyViolationException>();
+	}
+}

--- a/test/KurrentDB.Client.Tests/Streams/AppendRecords/WriteOnly/WhenExpectingRevision.cs
+++ b/test/KurrentDB.Client.Tests/Streams/AppendRecords/WriteOnly/WhenExpectingRevision.cs
@@ -1,0 +1,101 @@
+using static KurrentDB.Client.ConsistencyCheck;
+
+namespace KurrentDB.Client.Tests.Streams.AppendRecords.WriteOnly;
+
+[Trait("Category", "Target:Streams")]
+[Trait("Category", "Operation:AppendRecords")]
+public class WhenExpectingRevision(ITestOutputHelper output, KurrentDBPermanentFixture fixture) : KurrentDBPermanentTests<KurrentDBPermanentFixture>(output, fixture) {
+	const ulong ExpectedRevision = 10;
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task succeeds_when_stream_has_revision() {
+		var stream = Fixture.GetStreamName();
+		await Fixture.Streams.AppendRecordsAsync(stream, Fixture.CreateTestEvents(11));
+
+		var result = await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(stream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(stream, StreamState.StreamRevision(ExpectedRevision))
+			]
+		);
+
+		result.Responses!.Count().ShouldBe(1);
+		result.Responses!.First().Stream.ShouldBe(stream);
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task fails_when_stream_not_found() {
+		var stream = Fixture.GetStreamName();
+
+		var act = async () => await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(stream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(stream, StreamState.StreamRevision(ExpectedRevision))
+			]
+		);
+
+		var rex = await act.ShouldThrowAsync<AppendConsistencyViolationException>();
+		rex.Violations.Count.ShouldBe(1);
+		rex.Violations[0].Stream.ShouldBe(stream);
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task fails_when_stream_has_wrong_revision() {
+		var stream = Fixture.GetStreamName();
+		await Fixture.Streams.AppendRecordsAsync(stream, Fixture.CreateTestEvents(5));
+
+		var act = async () => await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(stream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(stream, StreamState.StreamRevision(ExpectedRevision))
+			]
+		);
+
+		var rex = await act.ShouldThrowAsync<AppendConsistencyViolationException>();
+		rex.Violations.Count.ShouldBe(1);
+		rex.Violations[0].Stream.ShouldBe(stream);
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task fails_when_stream_is_deleted() {
+		var stream = Fixture.GetStreamName();
+		await Fixture.Streams.AppendToStreamAsync(stream, StreamState.NoStream, Fixture.CreateTestEvents(3));
+		await Fixture.Streams.DeleteAsync(stream, StreamState.StreamExists);
+
+		var act = async () => await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(stream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(stream, StreamState.StreamRevision(ExpectedRevision))
+			]
+		);
+
+		await act.ShouldThrowAsync<AppendConsistencyViolationException>();
+	}
+
+	[MinimumVersion.Fact(26, 1)]
+	public async Task fails_when_stream_is_tombstoned() {
+		var stream = Fixture.GetStreamName();
+
+		await Fixture.Streams.AppendToStreamAsync(stream, StreamState.NoStream, Fixture.CreateTestEvents());
+		await Fixture.Streams.TombstoneAsync(stream, StreamState.StreamExists);
+
+		var act = async () => await Fixture.Streams.AppendRecordsAsync(
+			records: [
+				new AppendRecord(stream, Fixture.CreateTestEvent())
+			],
+			checks: [
+				new StreamStateCheck(stream, StreamState.StreamRevision(ExpectedRevision))
+			]
+		);
+
+		await act.ShouldThrowAsync<AppendConsistencyViolationException>();
+	}
+}


### PR DESCRIPTION
Adds the `AppendRecords` operation, which allows appending events to one or more streams in a single atomic transaction similar to `MultiStreamAppend`, but with two key differences:

- Interleaved ordering: Records from different streams can be mixed freely, and their exact order is preserved in the global log.
- Decoupled consistency checks: You can validate the state of any stream before the transaction commits, even streams you are not writing to. This makes it possible to enforce business rules that span multiple streams in a single round-trip.