### PR TITLE
fix: prevent NRE on transport level gRPC errors

### DIFF
--- a/src/KurrentDB.Client/Core/Exceptions/AccessDeniedException.cs
+++ b/src/KurrentDB.Client/Core/Exceptions/AccessDeniedException.cs
@@ -19,7 +19,8 @@ namespace KurrentDB.Client {
 
 		}
 
-		public static AccessDeniedException FromRpcException(RpcException ex) => FromRpcStatus(ex.GetRpcStatus()!);
+		public static AccessDeniedException FromRpcException(RpcException ex) =>
+			FromRpcStatus(ex.GetRpcStatus() ?? throw ex);
 
 		public static AccessDeniedException FromRpcStatus(Google.Rpc.Status ex) {
 			return new(ex.Message, ex.ToRpcException());

--- a/src/KurrentDB.Client/Core/Exceptions/AppendTransactionMaxSizeExceededException.cs
+++ b/src/KurrentDB.Client/Core/Exceptions/AppendTransactionMaxSizeExceededException.cs
@@ -21,7 +21,8 @@ public class AppendTransactionMaxSizeExceededException(int size, int maxSize, Ex
 	/// </summary>
 	public int MaxSize { get; } = maxSize;
 
-	public static AppendTransactionMaxSizeExceededException FromRpcException(RpcException ex) => FromRpcStatus(ex.GetRpcStatus()!);
+	public static AppendTransactionMaxSizeExceededException FromRpcException(RpcException ex) =>
+		FromRpcStatus(ex.GetRpcStatus() ?? throw ex);
 
 	public static AppendTransactionMaxSizeExceededException FromRpcStatus(Google.Rpc.Status ex) {
 		var details = ex.GetDetail<AppendTransactionSizeExceededErrorDetails>();

--- a/src/KurrentDB.Client/Core/Exceptions/NotLeaderException.cs
+++ b/src/KurrentDB.Client/Core/Exceptions/NotLeaderException.cs
@@ -24,7 +24,8 @@ namespace KurrentDB.Client {
 			LeaderEndpoint = new DnsEndPoint(host, port);
 		}
 
-		public static NotLeaderException FromRpcException(RpcException ex) => FromRpcStatus(ex.GetRpcStatus()!);
+		public static NotLeaderException FromRpcException(RpcException ex) =>
+			FromRpcStatus(ex.GetRpcStatus() ?? throw ex);
 
 		public static NotLeaderException FromRpcStatus(Google.Rpc.Status ex) {
 			var details = ex.GetDetail<NotLeaderNodeErrorDetails>();

--- a/src/KurrentDB.Client/Core/Exceptions/StreamTombstonedException.cs
+++ b/src/KurrentDB.Client/Core/Exceptions/StreamTombstonedException.cs
@@ -19,7 +19,8 @@ public class StreamTombstonedException : Exception {
 		Stream = stream;
 	}
 
-	public static StreamTombstonedException FromRpcException(RpcException ex) => FromRpcStatus(ex.GetRpcStatus()!);
+	public static StreamTombstonedException FromRpcException(RpcException ex) =>
+		FromRpcStatus(ex.GetRpcStatus() ?? throw ex);
 
 	public static StreamTombstonedException FromRpcStatus(Google.Rpc.Status ex) {
 		var details = ex.GetDetail<StreamTombstonedErrorDetails>();

--- a/src/KurrentDB.Client/Core/Exceptions/WrongExpectedVersionException.cs
+++ b/src/KurrentDB.Client/Core/Exceptions/WrongExpectedVersionException.cs
@@ -47,7 +47,8 @@ namespace KurrentDB.Client {
 			ActualVersion = actualStreamState.ToInt64();
 		}
 
-		public static WrongExpectedVersionException FromRpcException(RpcException ex) => FromRpcStatus(ex.GetRpcStatus()!);
+		public static WrongExpectedVersionException FromRpcException(RpcException ex) =>
+			FromRpcStatus(ex.GetRpcStatus() ?? throw ex);
 
 		public static WrongExpectedVersionException FromRpcStatus(Google.Rpc.Status ex) {
 			var details = ex.GetDetail<StreamRevisionConflictErrorDetails>();

--- a/src/KurrentDB.Client/Streams/KurrentDBClient.MultiAppend.cs
+++ b/src/KurrentDB.Client/Streams/KurrentDBClient.MultiAppend.cs
@@ -79,8 +79,7 @@ public partial class KurrentDBClient {
 
 				return new MultiStreamAppendResponse(response.Position, responses);
 			} catch (RpcException ex) {
-				var status = ex.GetRpcStatus()!;
-				throw status.GetDetail<ErrorInfo>() switch {
+				throw ex.GetRpcStatus()?.GetDetail<ErrorInfo>() switch {
 					{ Reason: "STREAM_REVISION_CONFLICT" }         => WrongExpectedVersionException.FromRpcException(ex),
 					{ Reason: "STREAM_TOMBSTONED" }                => StreamTombstonedException.FromRpcException(ex),
 					{ Reason: "APPEND_RECORD_SIZE_EXCEEDED" }      => AppendRecordSizeExceededException.FromRpcException(ex),

--- a/src/KurrentDB.Client/Streams/MaximumAppendSizeExceededException.cs
+++ b/src/KurrentDB.Client/Streams/MaximumAppendSizeExceededException.cs
@@ -43,7 +43,8 @@ namespace KurrentDB.Client {
 			MaxSize  = maxSize;
 		}
 
-		public static AppendRecordSizeExceededException FromRpcException(RpcException ex) => FromRpcStatus(ex.GetRpcStatus()!);
+		public static AppendRecordSizeExceededException FromRpcException(RpcException ex) =>
+			FromRpcStatus(ex.GetRpcStatus() ?? throw ex);
 
 		public static AppendRecordSizeExceededException FromRpcStatus(Google.Rpc.Status ex) {
 			var details = ex.GetDetail<AppendRecordSizeExceededErrorDetails>();


### PR DESCRIPTION
## Summary

`GetRpcStatus()` can return null for transport-level gRPC errors (connection drops, timeouts), but the code assumed it never would. This caused a `NullReferenceException` that masked the actual error. Now the original `RpcException` is surfaced instead.
