### PR TITLE
Upgrade packages for CVE-2026-40894

### DIFF
--- a/src/KurrentDB.Client/KurrentDB.Client.csproj
+++ b/src/KurrentDB.Client/KurrentDB.Client.csproj
@@ -11,8 +11,8 @@
 		<PackageReference Include="Google.Protobuf" Version="3.32.1"/>
 		<PackageReference Include="Grpc.Net.Client" Version="2.67.0"/>
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0"/>
-		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.0"/>
-		<PackageReference Include="OpenTelemetry.Api" Version="1.12.0"/>
+		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.0"/>
+		<PackageReference Include="OpenTelemetry.Api" Version="1.15.3"/>
 
 		<PackageReference Include="Grpc.StatusProto" Version="2.71.0" />
 		<PackageReference Include="Google.Api.CommonProtos" Version="2.16.0" GeneratePathProperty="true" />


### PR DESCRIPTION
https://github.com/advisories/GHSA-g94r-2vxg-569j

(the DiagnosticSource is needed too)