### PR TITLE
[DEV-1655] feat: support V2 projection engine on create

### DIFF
--- a/src/KurrentDB.Client/Core/proto/kurrentdb/protocol/v1/projectionmanagement.proto
+++ b/src/KurrentDB.Client/Core/proto/kurrentdb/protocol/v1/projectionmanagement.proto
@@ -32,6 +32,7 @@ message CreateReq {
 			Continuous continuous = 3;
 		}
 		string query = 4;
+		int32 engine_version = 5; // 0 or 1 = v1 (default), 2 = v2
 
 		message Transient {
 			string name = 1;

--- a/src/KurrentDB.Client/ProjectionManagement/KurrentDBProjectionManagementClient.Create.cs
+++ b/src/KurrentDB.Client/ProjectionManagement/KurrentDBProjectionManagementClient.Create.cs
@@ -7,15 +7,15 @@ namespace KurrentDB.Client {
 		/// <summary>
 		/// Creates a one-time projection.
 		/// </summary>
-		/// <param name="query"></param>
-		/// <param name="deadline"></param>
-		/// <param name="userCredentials"></param>
+		/// <param name="query">The JavaScript source of the projection.</param>
+		/// <param name="deadline">The maximum time to wait for the operation to complete.</param>
+		/// <param name="userCredentials">The <see cref="UserCredentials"/> to use for the operation.</param>
 		/// <param name="engineVersion">
 		/// The projection engine version to use. The engine version is pinned at create time and cannot be changed later.
 		/// Defaults to <see cref="ProjectionEngineVersion.V1"/>.
 		/// </param>
-		/// <param name="cancellationToken"></param>
-		/// <returns></returns>
+		/// <param name="cancellationToken">The token used to cancel the operation.</param>
+		/// <returns>A <see cref="Task"/> that completes when the projection has been created.</returns>
 		public async Task CreateOneTimeAsync(string query, TimeSpan? deadline = null,
 			UserCredentials? userCredentials = null,
 			ProjectionEngineVersion engineVersion = ProjectionEngineVersion.V1,
@@ -35,18 +35,18 @@ namespace KurrentDB.Client {
 		/// <summary>
 		/// Creates a continuous projection.
 		/// </summary>
-		/// <param name="name"></param>
-		/// <param name="query"></param>
-		/// <param name="trackEmittedStreams"></param>
-		/// <param name="deadline"></param>
-		/// <param name="userCredentials"></param>
+		/// <param name="name">The name of the projection.</param>
+		/// <param name="query">The JavaScript source of the projection.</param>
+		/// <param name="trackEmittedStreams">Whether the streams emitted by this projection should be tracked.</param>
+		/// <param name="deadline">The maximum time to wait for the operation to complete.</param>
+		/// <param name="userCredentials">The <see cref="UserCredentials"/> to use for the operation.</param>
 		/// <param name="engineVersion">
 		/// The projection engine version to use. The engine version is pinned at create time and cannot be changed later.
 		/// Defaults to <see cref="ProjectionEngineVersion.V1"/>. <see cref="ProjectionEngineVersion.V2"/> does not support
 		/// <paramref name="trackEmittedStreams"/>.
 		/// </param>
-		/// <param name="cancellationToken"></param>
-		/// <returns></returns>
+		/// <param name="cancellationToken">The token used to cancel the operation.</param>
+		/// <returns>A <see cref="Task"/> that completes when the projection has been created.</returns>
 		public async Task CreateContinuousAsync(string name, string query, bool trackEmittedStreams = false,
 			TimeSpan? deadline = null, UserCredentials? userCredentials = null,
 			ProjectionEngineVersion engineVersion = ProjectionEngineVersion.V1,
@@ -69,16 +69,16 @@ namespace KurrentDB.Client {
 		/// <summary>
 		/// Creates a transient projection.
 		/// </summary>
-		/// <param name="name"></param>
-		/// <param name="query"></param>
-		/// <param name="deadline"></param>
-		/// <param name="userCredentials"></param>
+		/// <param name="name">The name of the projection.</param>
+		/// <param name="query">The JavaScript source of the projection.</param>
+		/// <param name="deadline">The maximum time to wait for the operation to complete.</param>
+		/// <param name="userCredentials">The <see cref="UserCredentials"/> to use for the operation.</param>
 		/// <param name="engineVersion">
 		/// The projection engine version to use. The engine version is pinned at create time and cannot be changed later.
 		/// Defaults to <see cref="ProjectionEngineVersion.V1"/>.
 		/// </param>
-		/// <param name="cancellationToken"></param>
-		/// <returns></returns>
+		/// <param name="cancellationToken">The token used to cancel the operation.</param>
+		/// <returns>A <see cref="Task"/> that completes when the projection has been created.</returns>
 		public async Task CreateTransientAsync(string name, string query, TimeSpan? deadline = null,
 			UserCredentials? userCredentials = null,
 			ProjectionEngineVersion engineVersion = ProjectionEngineVersion.V1,

--- a/src/KurrentDB.Client/ProjectionManagement/KurrentDBProjectionManagementClient.Create.cs
+++ b/src/KurrentDB.Client/ProjectionManagement/KurrentDBProjectionManagementClient.Create.cs
@@ -10,15 +10,16 @@ namespace KurrentDB.Client {
 		/// <param name="query"></param>
 		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
-		/// <param name="cancellationToken"></param>
 		/// <param name="engineVersion">
 		/// The projection engine version to use. The engine version is pinned at create time and cannot be changed later.
 		/// Defaults to <see cref="ProjectionEngineVersion.V1"/>.
 		/// </param>
+		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
 		public async Task CreateOneTimeAsync(string query, TimeSpan? deadline = null,
-			UserCredentials? userCredentials = null, CancellationToken cancellationToken = default,
-			ProjectionEngineVersion engineVersion = ProjectionEngineVersion.V1) {
+			UserCredentials? userCredentials = null,
+			ProjectionEngineVersion engineVersion = ProjectionEngineVersion.V1,
+			CancellationToken cancellationToken = default) {
 			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
 			using var call = new ProjectionsClient(
 				channelInfo.CallInvoker).CreateAsync(new CreateReq {
@@ -39,17 +40,17 @@ namespace KurrentDB.Client {
 		/// <param name="trackEmittedStreams"></param>
 		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
-		/// <param name="cancellationToken"></param>
 		/// <param name="engineVersion">
 		/// The projection engine version to use. The engine version is pinned at create time and cannot be changed later.
 		/// Defaults to <see cref="ProjectionEngineVersion.V1"/>. <see cref="ProjectionEngineVersion.V2"/> does not support
 		/// <paramref name="trackEmittedStreams"/>.
 		/// </param>
+		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
 		public async Task CreateContinuousAsync(string name, string query, bool trackEmittedStreams = false,
 			TimeSpan? deadline = null, UserCredentials? userCredentials = null,
-			CancellationToken cancellationToken = default,
-			ProjectionEngineVersion engineVersion = ProjectionEngineVersion.V1) {
+			ProjectionEngineVersion engineVersion = ProjectionEngineVersion.V1,
+			CancellationToken cancellationToken = default) {
 			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
 			using var call = new ProjectionsClient(
 				channelInfo.CallInvoker).CreateAsync(new CreateReq {
@@ -72,15 +73,16 @@ namespace KurrentDB.Client {
 		/// <param name="query"></param>
 		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
-		/// <param name="cancellationToken"></param>
 		/// <param name="engineVersion">
 		/// The projection engine version to use. The engine version is pinned at create time and cannot be changed later.
 		/// Defaults to <see cref="ProjectionEngineVersion.V1"/>.
 		/// </param>
+		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
 		public async Task CreateTransientAsync(string name, string query, TimeSpan? deadline = null,
-			UserCredentials? userCredentials = null, CancellationToken cancellationToken = default,
-			ProjectionEngineVersion engineVersion = ProjectionEngineVersion.V1) {
+			UserCredentials? userCredentials = null,
+			ProjectionEngineVersion engineVersion = ProjectionEngineVersion.V1,
+			CancellationToken cancellationToken = default) {
 			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
 			using var call = new ProjectionsClient(
 				channelInfo.CallInvoker).CreateAsync(new CreateReq {

--- a/src/KurrentDB.Client/ProjectionManagement/KurrentDBProjectionManagementClient.Create.cs
+++ b/src/KurrentDB.Client/ProjectionManagement/KurrentDBProjectionManagementClient.Create.cs
@@ -51,6 +51,11 @@ namespace KurrentDB.Client {
 			TimeSpan? deadline = null, UserCredentials? userCredentials = null,
 			ProjectionEngineVersion engineVersion = ProjectionEngineVersion.V1,
 			CancellationToken cancellationToken = default) {
+			if (engineVersion == ProjectionEngineVersion.V2 && trackEmittedStreams)
+				throw new ArgumentException(
+					$"{nameof(trackEmittedStreams)} is not supported when {nameof(engineVersion)} is {nameof(ProjectionEngineVersion.V2)}.",
+					nameof(trackEmittedStreams));
+
 			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
 			using var call = new ProjectionsClient(
 				channelInfo.CallInvoker).CreateAsync(new CreateReq {

--- a/src/KurrentDB.Client/ProjectionManagement/KurrentDBProjectionManagementClient.Create.cs
+++ b/src/KurrentDB.Client/ProjectionManagement/KurrentDBProjectionManagementClient.Create.cs
@@ -11,15 +11,21 @@ namespace KurrentDB.Client {
 		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
 		/// <param name="cancellationToken"></param>
+		/// <param name="engineVersion">
+		/// The projection engine version to use. The engine version is pinned at create time and cannot be changed later.
+		/// Defaults to <see cref="ProjectionEngineVersion.V1"/>.
+		/// </param>
 		/// <returns></returns>
 		public async Task CreateOneTimeAsync(string query, TimeSpan? deadline = null,
-			UserCredentials? userCredentials = null, CancellationToken cancellationToken = default) {
+			UserCredentials? userCredentials = null, CancellationToken cancellationToken = default,
+			ProjectionEngineVersion engineVersion = ProjectionEngineVersion.V1) {
 			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
 			using var call = new ProjectionsClient(
 				channelInfo.CallInvoker).CreateAsync(new CreateReq {
 				Options = new CreateReq.Types.Options {
-					OneTime = new Empty(),
-					Query = query
+					OneTime       = new Empty(),
+					Query         = query,
+					EngineVersion = (int)engineVersion
 				}
 			}, KurrentDBCallOptions.CreateNonStreaming(Settings, deadline, userCredentials, cancellationToken));
 			await call.ResponseAsync.ConfigureAwait(false);
@@ -34,19 +40,26 @@ namespace KurrentDB.Client {
 		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
 		/// <param name="cancellationToken"></param>
+		/// <param name="engineVersion">
+		/// The projection engine version to use. The engine version is pinned at create time and cannot be changed later.
+		/// Defaults to <see cref="ProjectionEngineVersion.V1"/>. <see cref="ProjectionEngineVersion.V2"/> does not support
+		/// <paramref name="trackEmittedStreams"/>.
+		/// </param>
 		/// <returns></returns>
 		public async Task CreateContinuousAsync(string name, string query, bool trackEmittedStreams = false,
 			TimeSpan? deadline = null, UserCredentials? userCredentials = null,
-			CancellationToken cancellationToken = default) {
+			CancellationToken cancellationToken = default,
+			ProjectionEngineVersion engineVersion = ProjectionEngineVersion.V1) {
 			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
 			using var call = new ProjectionsClient(
 				channelInfo.CallInvoker).CreateAsync(new CreateReq {
 				Options = new CreateReq.Types.Options {
 					Continuous = new CreateReq.Types.Options.Types.Continuous {
-						Name = name,
+						Name                = name,
 						TrackEmittedStreams = trackEmittedStreams
 					},
-					Query = query
+					Query         = query,
+					EngineVersion = (int)engineVersion
 				}
 			}, KurrentDBCallOptions.CreateNonStreaming(Settings, deadline, userCredentials, cancellationToken));
 			await call.ResponseAsync.ConfigureAwait(false);
@@ -60,9 +73,14 @@ namespace KurrentDB.Client {
 		/// <param name="deadline"></param>
 		/// <param name="userCredentials"></param>
 		/// <param name="cancellationToken"></param>
+		/// <param name="engineVersion">
+		/// The projection engine version to use. The engine version is pinned at create time and cannot be changed later.
+		/// Defaults to <see cref="ProjectionEngineVersion.V1"/>.
+		/// </param>
 		/// <returns></returns>
 		public async Task CreateTransientAsync(string name, string query, TimeSpan? deadline = null,
-			UserCredentials? userCredentials = null, CancellationToken cancellationToken = default) {
+			UserCredentials? userCredentials = null, CancellationToken cancellationToken = default,
+			ProjectionEngineVersion engineVersion = ProjectionEngineVersion.V1) {
 			var channelInfo = await GetChannelInfo(cancellationToken).ConfigureAwait(false);
 			using var call = new ProjectionsClient(
 				channelInfo.CallInvoker).CreateAsync(new CreateReq {
@@ -70,7 +88,8 @@ namespace KurrentDB.Client {
 					Transient = new CreateReq.Types.Options.Types.Transient {
 						Name = name
 					},
-					Query = query
+					Query         = query,
+					EngineVersion = (int)engineVersion
 				}
 			}, KurrentDBCallOptions.CreateNonStreaming(Settings, deadline, userCredentials, cancellationToken));
 			await call.ResponseAsync.ConfigureAwait(false);

--- a/src/KurrentDB.Client/ProjectionManagement/ProjectionEngineVersion.cs
+++ b/src/KurrentDB.Client/ProjectionManagement/ProjectionEngineVersion.cs
@@ -7,7 +7,13 @@ namespace KurrentDB.Client {
 	/// </remarks>
 	public enum ProjectionEngineVersion {
 		/// <summary>
-		/// The original projection engine. This is the default.
+		/// No engine version specified. The server treats this the same as <see cref="V1"/>.
+		/// This is the default value of the enum.
+		/// </summary>
+		Unspecified = 0,
+
+		/// <summary>
+		/// The original projection engine. Selected by default when no engine version is specified.
 		/// </summary>
 		V1 = 1,
 

--- a/src/KurrentDB.Client/ProjectionManagement/ProjectionEngineVersion.cs
+++ b/src/KurrentDB.Client/ProjectionManagement/ProjectionEngineVersion.cs
@@ -1,0 +1,22 @@
+namespace KurrentDB.Client {
+	/// <summary>
+	/// The projection engine version used to execute a projection.
+	/// </summary>
+	/// <remarks>
+	/// The engine version is pinned at projection create time and cannot be changed later.
+	/// </remarks>
+	public enum ProjectionEngineVersion {
+		/// <summary>
+		/// The original projection engine. This is the default.
+		/// </summary>
+		V1 = 1,
+
+		/// <summary>
+		/// The next-generation projection engine that processes partitions in parallel.
+		/// V2 is opt-in and does not support <c>trackEmittedStreams</c>, bi-state projections,
+		/// or live <c>outputState</c> result streams. See the KurrentDB documentation for the full list of
+		/// limitations before choosing V2.
+		/// </summary>
+		V2 = 2
+	}
+}

--- a/test/KurrentDB.Client.Tests/ProjectionManagement/ProjectionManagementTests.cs
+++ b/test/KurrentDB.Client.Tests/ProjectionManagement/ProjectionManagementTests.cs
@@ -46,6 +46,18 @@ public class ProjectionManagementTests(ITestOutputHelper output, ProjectionManag
 		);
 	}
 
+	[Fact]
+	public async Task continuous_v2_engine() {
+		var name = Fixture.GetProjectionName();
+
+		await Fixture.DBProjections.CreateContinuousAsync(
+			name,
+			"fromAll().when({$init: function (state, ev) {return {};}});",
+			userCredentials: TestCredentials.Root,
+			engineVersion: ProjectionEngineVersion.V2
+		);
+	}
+
 	static readonly string[] Names = ["$streams", "$stream_by_category", "$by_category", "$by_event_type", "$by_correlation_id"];
 
 	public class CustomFixture : KurrentDBTemporaryFixture {

--- a/test/KurrentDB.Client.Tests/ProjectionManagement/ProjectionManagementTests.cs
+++ b/test/KurrentDB.Client.Tests/ProjectionManagement/ProjectionManagementTests.cs
@@ -59,7 +59,7 @@ public class ProjectionManagementTests(ITestOutputHelper output, ProjectionManag
 	}
 
 	[Fact]
-	public async Task continuous_v2_engine_with_track_emitted_streams_throws() {
+	public async Task continuous_v2_engine_throws_when_track_emitted_streams_enabled() {
 		var ex = await Assert.ThrowsAsync<ArgumentException>(
 			() => Fixture.DBProjections.CreateContinuousAsync(
 				Fixture.GetProjectionName(),

--- a/test/KurrentDB.Client.Tests/ProjectionManagement/ProjectionManagementTests.cs
+++ b/test/KurrentDB.Client.Tests/ProjectionManagement/ProjectionManagementTests.cs
@@ -58,6 +58,21 @@ public class ProjectionManagementTests(ITestOutputHelper output, ProjectionManag
 		);
 	}
 
+	[Fact]
+	public async Task continuous_v2_engine_with_track_emitted_streams_throws() {
+		var ex = await Assert.ThrowsAsync<ArgumentException>(
+			() => Fixture.DBProjections.CreateContinuousAsync(
+				Fixture.GetProjectionName(),
+				"fromAll().when({$init: function (state, ev) {return {};}});",
+				trackEmittedStreams: true,
+				userCredentials: TestCredentials.Root,
+				engineVersion: ProjectionEngineVersion.V2
+			)
+		);
+
+		Assert.Equal("trackEmittedStreams", ex.ParamName);
+	}
+
 	static readonly string[] Names = ["$streams", "$stream_by_category", "$by_category", "$by_event_type", "$by_correlation_id"];
 
 	public class CustomFixture : KurrentDBTemporaryFixture {


### PR DESCRIPTION
## Summary

Adds an opt-in `engineVersion` parameter to the projection create APIs, letting you target the new V2 projection engine in KurrentDB. Behavior is unchanged unless you explicitly opt in — existing code keeps using V1.

## What's new

- New `ProjectionEngineVersion` enum: `V1` (default) and `V2`.
- New optional `engineVersion` parameter on:
  - `KurrentDBProjectionManagementClient.CreateOneTimeAsync`
  - `KurrentDBProjectionManagementClient.CreateContinuousAsync`
  - `KurrentDBProjectionManagementClient.CreateTransientAsync`
- The engine version is pinned at create time and cannot be changed later, matching the server contract.

## Usage

```csharp
await client.CreateContinuousAsync(
    name: "by-category",
    query: "...",
    engineVersion: ProjectionEngineVersion.V2);
```

## Compatibility

- Fully backwards compatible. The default is `ProjectionEngineVersion.V1`, so existing calls behave exactly as before.
- Requires a KurrentDB server version that supports the V2 engine when `V2` is selected.

## V2 limitations

When opting into V2, note that the engine does **not** support:

- `trackEmittedStreams`
- bi-state projections
- live `outputState` result streams

Refer to the KurrentDB documentation for the complete list of V2 limitations before adopting it for production projections.

Linear: [DEV-1655](https://linear.app/kurrent/issue/DEV-1655)